### PR TITLE
refactor: quality ratchet 2 — health tool tests, CLI decomposition, navigate contracts

### DIFF
--- a/cli.go
+++ b/cli.go
@@ -265,6 +265,36 @@ sources:
 	return cmd
 }
 
+// sourceStatus holds per-source metadata for status reporting.
+type sourceStatus struct {
+	ID          string `json:"id"`
+	Type        string `json:"type"`
+	Status      string `json:"status"`
+	PageCount   int    `json:"pageCount"`
+	LastFetched string `json:"lastFetched,omitempty"`
+	Error       string `json:"error,omitempty"`
+}
+
+// statusData holds all data needed to render the status output.
+// Separates data collection from formatting to reduce cyclomatic complexity.
+type statusData struct {
+	PageCount          int
+	BlockCount         int
+	EmbeddingCount     int
+	EmbeddingModel     string
+	EmbeddingAvailable bool
+	Sources            []sourceStatus
+	IndexPath          string
+}
+
+// embeddingCoverage computes the percentage of blocks with embeddings.
+func (d statusData) embeddingCoverage() float64 {
+	if d.BlockCount > 0 {
+		return float64(d.EmbeddingCount) / float64(d.BlockCount) * 100
+	}
+	return 0
+}
+
 // newStatusCmd creates the `dewey status` subcommand.
 // Reports index health: page count, block count, source info.
 // Supports --json flag for structured output.
@@ -277,7 +307,6 @@ func newStatusCmd() *cobra.Command {
 		Long:         "Show Dewey index health: page count, block count, source info, and index path.",
 		SilenceUsage: true,
 		RunE: func(cmd *cobra.Command, args []string) error {
-			// Find .dewey/ directory.
 			cwd, err := os.Getwd()
 			if err != nil {
 				return fmt.Errorf("get working directory: %w", err)
@@ -288,135 +317,146 @@ func newStatusCmd() *cobra.Command {
 				return fmt.Errorf("not initialized. Run 'dewey init' first")
 			}
 
-			dbPath := filepath.Join(deweyDir, "graph.db")
-			var pageCount, blockCount, embeddingCount int
-			var embeddingModel string
-			embeddingAvailable := false
-
-			// Read embedding model from config.yaml if it exists.
-			configPath := filepath.Join(deweyDir, "config.yaml")
-			if configData, err := os.ReadFile(configPath); err == nil {
-				// Simple YAML parsing for model name — avoid adding a YAML dependency
-				// just for status display. The config is already parsed elsewhere.
-				for _, line := range strings.Split(string(configData), "\n") {
-					line = strings.TrimSpace(line)
-					if strings.HasPrefix(line, "model:") {
-						embeddingModel = strings.TrimSpace(strings.TrimPrefix(line, "model:"))
-					}
-				}
+			data, err := queryStoreStatus(deweyDir)
+			if err != nil {
+				return err
 			}
 
-			// Load per-source status from store.
-			type sourceStatus struct {
-				ID          string `json:"id"`
-				Type        string `json:"type"`
-				Status      string `json:"status"`
-				PageCount   int    `json:"pageCount"`
-				LastFetched string `json:"lastFetched,omitempty"`
-				Error       string `json:"error,omitempty"`
-			}
-			var sources []sourceStatus
-
-			// Open store if database exists.
-			if _, err := os.Stat(dbPath); err == nil {
-				s, err := store.New(dbPath)
-				if err != nil {
-					return fmt.Errorf("open store: %w", err)
-				}
-				defer func() { _ = s.Close() }()
-
-				pages, err := s.ListPages()
-				if err != nil {
-					return fmt.Errorf("list pages: %w", err)
-				}
-				pageCount = len(pages)
-
-				bc, err := s.CountBlocks()
-				if err == nil {
-					blockCount = bc
-				}
-
-				ec, err := s.CountEmbeddings()
-				if err == nil {
-					embeddingCount = ec
-				}
-
-				storedSources, _ := s.ListSources()
-				for _, src := range storedSources {
-					ss := sourceStatus{
-						ID:     src.ID,
-						Type:   src.Type,
-						Status: src.Status,
-						Error:  src.ErrorMessage,
-					}
-					pc, _ := s.CountPagesBySource(src.ID)
-					ss.PageCount = pc
-					if src.LastFetchedAt > 0 {
-						elapsed := time.Since(time.UnixMilli(src.LastFetchedAt))
-						ss.LastFetched = formatDuration(elapsed)
-					}
-					sources = append(sources, ss)
-				}
-			}
-
-			// Compute embedding coverage.
-			var coverage float64
-			if blockCount > 0 {
-				coverage = float64(embeddingCount) / float64(blockCount) * 100
-			}
-
+			w := cmd.OutOrStdout()
 			if jsonOutput {
-				status := map[string]any{
-					"path":               deweyDir,
-					"pages":              pageCount,
-					"blocks":             blockCount,
-					"embeddings":         embeddingCount,
-					"embeddingModel":     embeddingModel,
-					"embeddingAvailable": embeddingAvailable,
-					"embeddingCoverage":  coverage,
-					"sources":            sources,
-				}
-				data, err := json.MarshalIndent(status, "", "  ")
-				if err != nil {
-					return fmt.Errorf("marshal JSON: %w", err)
-				}
-				_, _ = fmt.Fprintln(cmd.OutOrStdout(), string(data))
-			} else {
-				_, _ = fmt.Fprintln(cmd.OutOrStdout(), "Dewey Index Status")
-				_, _ = fmt.Fprintf(cmd.OutOrStdout(), "  Path:       %s\n", deweyDir)
-				_, _ = fmt.Fprintf(cmd.OutOrStdout(), "  Pages:      %d\n", pageCount)
-				_, _ = fmt.Fprintf(cmd.OutOrStdout(), "  Blocks:     %d\n", blockCount)
-				_, _ = fmt.Fprintf(cmd.OutOrStdout(), "  Embeddings: %d\n", embeddingCount)
-				if embeddingModel != "" {
-					_, _ = fmt.Fprintf(cmd.OutOrStdout(), "  Model:      %s\n", embeddingModel)
-				}
-				_, _ = fmt.Fprintf(cmd.OutOrStdout(), "  Coverage:   %.1f%%\n", coverage)
-
-				if len(sources) > 0 {
-					_, _ = fmt.Fprintln(cmd.OutOrStdout(), "\nSources")
-					for _, src := range sources {
-						lastFetched := "never"
-						if src.LastFetched != "" {
-							lastFetched = src.LastFetched + " ago"
-						}
-						if src.Error != "" {
-							_, _ = fmt.Fprintf(cmd.OutOrStdout(), "  %-15s %-8s %3d pages  %s  error: %s\n",
-								src.ID, src.Status, src.PageCount, lastFetched, src.Error)
-						} else {
-							_, _ = fmt.Fprintf(cmd.OutOrStdout(), "  %-15s %-8s %3d pages  %s\n",
-								src.ID, src.Status, src.PageCount, lastFetched)
-						}
-					}
-				}
+				return formatStatusJSON(data, w)
 			}
-
-			return nil
+			return formatStatusText(data, w)
 		},
 	}
 
 	cmd.Flags().BoolVar(&jsonOutput, "json", false, "Output as JSON")
 
 	return cmd
+}
+
+// readEmbeddingModel extracts the embedding model name from config.yaml
+// using simple line parsing to avoid a YAML dependency for status display.
+func readEmbeddingModel(deweyDir string) string {
+	configPath := filepath.Join(deweyDir, "config.yaml")
+	configData, err := os.ReadFile(configPath)
+	if err != nil {
+		return ""
+	}
+	for _, line := range strings.Split(string(configData), "\n") {
+		line = strings.TrimSpace(line)
+		if strings.HasPrefix(line, "model:") {
+			return strings.TrimSpace(strings.TrimPrefix(line, "model:"))
+		}
+	}
+	return ""
+}
+
+// queryStoreStatus opens the store at deweyDir, queries all counts and source
+// records, and returns a populated statusData. The store is closed before
+// returning. Returns a zero-value statusData (with IndexPath set) if the
+// database does not yet exist.
+func queryStoreStatus(deweyDir string) (statusData, error) {
+	data := statusData{
+		IndexPath:      deweyDir,
+		EmbeddingModel: readEmbeddingModel(deweyDir),
+	}
+
+	dbPath := filepath.Join(deweyDir, "graph.db")
+	if _, err := os.Stat(dbPath); err != nil {
+		// Database does not exist yet — return zero counts.
+		return data, nil
+	}
+
+	s, err := store.New(dbPath)
+	if err != nil {
+		return data, fmt.Errorf("open store: %w", err)
+	}
+	defer func() { _ = s.Close() }()
+
+	pages, err := s.ListPages()
+	if err != nil {
+		return data, fmt.Errorf("list pages: %w", err)
+	}
+	data.PageCount = len(pages)
+
+	if bc, err := s.CountBlocks(); err == nil {
+		data.BlockCount = bc
+	}
+	if ec, err := s.CountEmbeddings(); err == nil {
+		data.EmbeddingCount = ec
+	}
+
+	storedSources, _ := s.ListSources()
+	for _, src := range storedSources {
+		ss := sourceStatus{
+			ID:     src.ID,
+			Type:   src.Type,
+			Status: src.Status,
+			Error:  src.ErrorMessage,
+		}
+		pc, _ := s.CountPagesBySource(src.ID)
+		ss.PageCount = pc
+		if src.LastFetchedAt > 0 {
+			elapsed := time.Since(time.UnixMilli(src.LastFetchedAt))
+			ss.LastFetched = formatDuration(elapsed)
+		}
+		data.Sources = append(data.Sources, ss)
+	}
+
+	return data, nil
+}
+
+// formatStatusText writes human-readable status output to w.
+func formatStatusText(data statusData, w io.Writer) error {
+	_, _ = fmt.Fprintln(w, "Dewey Index Status")
+	_, _ = fmt.Fprintf(w, "  Path:       %s\n", data.IndexPath)
+	_, _ = fmt.Fprintf(w, "  Pages:      %d\n", data.PageCount)
+	_, _ = fmt.Fprintf(w, "  Blocks:     %d\n", data.BlockCount)
+	_, _ = fmt.Fprintf(w, "  Embeddings: %d\n", data.EmbeddingCount)
+	if data.EmbeddingModel != "" {
+		_, _ = fmt.Fprintf(w, "  Model:      %s\n", data.EmbeddingModel)
+	}
+	_, _ = fmt.Fprintf(w, "  Coverage:   %.1f%%\n", data.embeddingCoverage())
+
+	if len(data.Sources) > 0 {
+		_, _ = fmt.Fprintln(w, "\nSources")
+		for _, src := range data.Sources {
+			lastFetched := "never"
+			if src.LastFetched != "" {
+				lastFetched = src.LastFetched + " ago"
+			}
+			if src.Error != "" {
+				_, _ = fmt.Fprintf(w, "  %-15s %-8s %3d pages  %s  error: %s\n",
+					src.ID, src.Status, src.PageCount, lastFetched, src.Error)
+			} else {
+				_, _ = fmt.Fprintf(w, "  %-15s %-8s %3d pages  %s\n",
+					src.ID, src.Status, src.PageCount, lastFetched)
+			}
+		}
+	}
+
+	return nil
+}
+
+// formatStatusJSON writes JSON-formatted status output to w.
+func formatStatusJSON(data statusData, w io.Writer) error {
+	status := map[string]any{
+		"path":               data.IndexPath,
+		"pages":              data.PageCount,
+		"blocks":             data.BlockCount,
+		"embeddings":         data.EmbeddingCount,
+		"embeddingModel":     data.EmbeddingModel,
+		"embeddingAvailable": data.EmbeddingAvailable,
+		"embeddingCoverage":  data.embeddingCoverage(),
+		"sources":            data.Sources,
+	}
+	out, err := json.MarshalIndent(status, "", "  ")
+	if err != nil {
+		return fmt.Errorf("marshal JSON: %w", err)
+	}
+	_, _ = fmt.Fprintln(w, string(out))
+	return nil
 }
 
 // --- Helpers ---
@@ -560,78 +600,9 @@ Fetches content from all configured sources and indexes it.`,
 			mgr := source.NewManager(configs, cwd, cacheDir)
 			result, allDocs := mgr.FetchAll(sourceName, force, lastFetchedTimes)
 
-			// Index fetched documents into store.
-			totalIndexed := 0
-			for sourceID, docs := range allDocs {
-				for _, doc := range docs {
-					// Upsert page from document.
-					existing, _ := s.GetPage(doc.Title)
-					if existing != nil {
-						existing.ContentHash = doc.ContentHash
-						existing.SourceID = sourceID
-						existing.SourceDocID = doc.ID
-						if err := s.UpdatePage(existing); err != nil {
-							logger.Warn("failed to update page", "page", doc.Title, "err", err)
-							continue
-						}
-					} else {
-						page := &store.Page{
-							Name:         doc.Title,
-							OriginalName: doc.Title,
-							SourceID:     sourceID,
-							SourceDocID:  doc.ID,
-							ContentHash:  doc.ContentHash,
-							CreatedAt:    doc.FetchedAt.UnixMilli(),
-							UpdatedAt:    doc.FetchedAt.UnixMilli(),
-						}
-						if doc.Properties != nil {
-							propsJSON, _ := json.Marshal(doc.Properties)
-							page.Properties = string(propsJSON)
-						}
-						if err := s.InsertPage(page); err != nil {
-							logger.Warn("failed to insert page", "page", doc.Title, "err", err)
-							continue
-						}
-					}
-					totalIndexed++
-				}
+			totalIndexed := indexDocuments(s, allDocs, configs)
+			reportSourceErrors(s, result)
 
-				// Update source record in store.
-				existingSrc, _ := s.GetSource(sourceID)
-				if existingSrc == nil {
-					// Find config for this source.
-					var srcType, srcName string
-					for _, cfg := range configs {
-						if cfg.ID == sourceID {
-							srcType = cfg.Type
-							srcName = cfg.Name
-							break
-						}
-					}
-					_ = s.InsertSource(&store.SourceRecord{
-						ID:            sourceID,
-						Type:          srcType,
-						Name:          srcName,
-						Status:        "active",
-						LastFetchedAt: time.Now().UnixMilli(),
-					})
-				} else {
-					_ = s.UpdateLastFetched(sourceID, time.Now().UnixMilli())
-					_ = s.UpdateSourceStatus(sourceID, "active", "")
-				}
-			}
-
-			// Report errors for failed sources.
-			for _, summary := range result.Summaries {
-				if summary.Error != "" {
-					existingSrc, _ := s.GetSource(summary.SourceID)
-					if existingSrc != nil {
-						_ = s.UpdateSourceStatus(summary.SourceID, "error", summary.Error)
-					}
-				}
-			}
-
-			// Print summary.
 			logger.Info("index complete",
 				"documents", totalIndexed,
 				"errors", result.TotalErrs,
@@ -646,6 +617,82 @@ Fetches content from all configured sources and indexes it.`,
 	cmd.Flags().BoolVar(&force, "force", false, "Force full re-index, ignoring refresh intervals")
 
 	return cmd
+}
+
+// indexDocuments upserts fetched documents into the persistent store and updates
+// source records. Returns the total number of documents successfully indexed.
+func indexDocuments(s *store.Store, allDocs map[string][]source.Document, configs []source.SourceConfig) int {
+	totalIndexed := 0
+	for sourceID, docs := range allDocs {
+		for _, doc := range docs {
+			existing, _ := s.GetPage(doc.Title)
+			if existing != nil {
+				existing.ContentHash = doc.ContentHash
+				existing.SourceID = sourceID
+				existing.SourceDocID = doc.ID
+				if err := s.UpdatePage(existing); err != nil {
+					logger.Warn("failed to update page", "page", doc.Title, "err", err)
+					continue
+				}
+			} else {
+				page := &store.Page{
+					Name:         doc.Title,
+					OriginalName: doc.Title,
+					SourceID:     sourceID,
+					SourceDocID:  doc.ID,
+					ContentHash:  doc.ContentHash,
+					CreatedAt:    doc.FetchedAt.UnixMilli(),
+					UpdatedAt:    doc.FetchedAt.UnixMilli(),
+				}
+				if doc.Properties != nil {
+					propsJSON, _ := json.Marshal(doc.Properties)
+					page.Properties = string(propsJSON)
+				}
+				if err := s.InsertPage(page); err != nil {
+					logger.Warn("failed to insert page", "page", doc.Title, "err", err)
+					continue
+				}
+			}
+			totalIndexed++
+		}
+
+		// Update source record in store.
+		existingSrc, _ := s.GetSource(sourceID)
+		if existingSrc == nil {
+			var srcType, srcName string
+			for _, cfg := range configs {
+				if cfg.ID == sourceID {
+					srcType = cfg.Type
+					srcName = cfg.Name
+					break
+				}
+			}
+			_ = s.InsertSource(&store.SourceRecord{
+				ID:            sourceID,
+				Type:          srcType,
+				Name:          srcName,
+				Status:        "active",
+				LastFetchedAt: time.Now().UnixMilli(),
+			})
+		} else {
+			_ = s.UpdateLastFetched(sourceID, time.Now().UnixMilli())
+			_ = s.UpdateSourceStatus(sourceID, "active", "")
+		}
+	}
+	return totalIndexed
+}
+
+// reportSourceErrors updates source status for any sources that failed
+// during the fetch phase.
+func reportSourceErrors(s *store.Store, result *source.FetchResult) {
+	for _, summary := range result.Summaries {
+		if summary.Error != "" {
+			existingSrc, _ := s.GetSource(summary.SourceID)
+			if existingSrc != nil {
+				_ = s.UpdateSourceStatus(summary.SourceID, "error", summary.Error)
+			}
+		}
+	}
 }
 
 // --- Source command (T051) ---

--- a/openspec/changes/archive/2026-03-27-gaze-quality-ratchet-2/.openspec.yaml
+++ b/openspec/changes/archive/2026-03-27-gaze-quality-ratchet-2/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: unbound-force
+created: 2026-03-27

--- a/openspec/changes/archive/2026-03-27-gaze-quality-ratchet-2/design.md
+++ b/openspec/changes/archive/2026-03-27-gaze-quality-ratchet-2/design.md
@@ -1,0 +1,82 @@
+## Context
+
+The first quality ratchet (PR #5) decomposed `handleEvent`, `newServer`, and `IncrementalIndex`, reducing CRAPload from 15 to 13. However, extracting `registerHealthTool` from `newServer` created a new worst-offender at CRAP 67.5 (complexity 8, only 2.4% coverage). The GazeCRAPload sits at 34 — exactly at the CI gate boundary — leaving no headroom.
+
+This second ratchet targets the next tier of offenders: the health tool test gap, two CLI commands with complexity >19, the highest-complexity function in the project (`Similar` at 22), and Q3 navigate functions with adequate line coverage but weak contract assertions.
+
+Per the proposal's constitution alignment: N/A for Autonomous Collaboration, PASS for Composability First, Observable Quality, and Testability.
+
+## Goals / Non-Goals
+
+### Goals
+- Reduce CRAPload from 13 to <=10 by adding tests for `registerHealthTool` and decomposing `newIndexCmd` and `newStatusCmd`
+- Reduce GazeCRAPload from 34 to <=30 by decomposing `Similar` and strengthening navigate contract assertions
+- Create headroom below the CI gates (CRAPload <=15, GazeCRAPload <=34) so future development doesn't immediately break CI
+
+### Non-Goals
+- Changing external MCP tool behavior or API contracts
+- Refactoring the health tool's internal structure (only adding test coverage)
+- Addressing functions below the top 5 recommendations (e.g., `RenamePage`, `AppendBlockInPage`, `DiskSource.Diff`)
+- Achieving 100% contract coverage — focus on the worst Q3 functions only
+
+## Decisions
+
+### 1. Testing `registerHealthTool` via MCP server interface
+
+The health tool is registered as a closure on the MCP server, making it impossible to call directly in tests. The test strategy is to create a server with `newServer(mockBackend, false, opts...)`, then invoke the health tool through the server's tool-call interface using `mcp.CallTool`. This matches how existing `TestNewServer_*` tests work in `server_test.go`.
+
+Test configurations:
+- Nil store + nil embedder (minimal config)
+- Non-nil store with pages, blocks, embeddings, and sources
+- Non-nil embedder with model available
+- Non-nil embedder with model unavailable
+- Backend ping error
+
+**Rationale**: Testing through the MCP interface is the only option since the health handler is a closure. This approach also validates the full registration path, catching any issues with the `mcp.AddTool` call itself.
+
+### 2. Decomposition pattern for `newIndexCmd` (cli.go:513, complexity 19)
+
+Extract three private functions:
+- `loadSourceConfigs(deweyDir string) ([]source.Config, error)` — loads and validates sources.yaml
+- `indexDocuments(s *store.Store, allDocs map[string][]source.Document) (int, error)` — loops over fetched documents, upserts pages and blocks
+- `generateEmbeddings(s *store.Store, e embed.Embedder) error` — handles the embedding pass logic
+
+The outer `RunE` becomes an orchestrator: open store → load configs → create manager → fetch → index → embed → report.
+
+**Rationale**: The 80-line `RunE` closure has three distinct phases already separated by comments. Each phase is independently testable. The store and config loading can be tested with in-memory SQLite and temp dirs; the embedding pass is already tested elsewhere.
+
+### 3. Decomposition pattern for `(*Semantic).Similar` (tools/semantic.go:88, complexity 22)
+
+Extract three private methods:
+- `validateSimilarInput(input types.SimilarInput) *mcp.CallToolResult` — validates input fields and embedder/store availability; returns error result or nil
+- `resolveQueryVector(ctx context.Context, input types.SimilarInput, modelID string) ([]float32, *mcp.CallToolResult)` — resolves the query embedding by UUID or page name; returns vector or error result
+- `filterSimilarResults(results []store.SimilarityResult, excludeUUID, excludePage string, limit int) []types.SemanticSearchResult` — filters self-references and builds the response objects
+
+The outer `Similar` method becomes: validate → resolve vector → search → filter → format.
+
+**Rationale**: The function has complexity 22 (highest in the project) driven by multiple early-return error paths and the UUID-vs-page branching for vector resolution. Extracting validation and vector resolution removes the two largest sources of branching. The result filtering is a pure function with no error paths.
+
+### 4. Navigate contract assertion strategy
+
+The existing navigate tests in `tools/navigate_test.go` call `GetPage`/`GetBlock`/`ListPages` and check for non-error return. Strengthen by asserting:
+- `GetPage`: block tree depth, outgoing link names, backlink count, property extraction from enriched blocks, truncation behavior with `MaxBlocks`
+- `GetBlock`: ancestor chain, children present, sibling blocks when requested
+- `ListPages`: page count, sort order, namespace filtering results
+
+**Rationale**: These functions have 84-100% line coverage but only 25% contract coverage. The gap is entirely in assertion weakness — the mock backend provides rich data that the tests currently ignore.
+
+### 5. Decomposition pattern for `newStatusCmd` (cli.go:271, complexity 21)
+
+Extract two private functions:
+- `queryStoreStatus(dbPath string) (statusData, error)` — opens the store, queries counts and sources, closes the store, returns a `statusData` struct
+- `formatStatusOutput(data statusData, jsonOutput bool) error` — formats and prints the status in text or JSON mode
+
+The outer `RunE` becomes: find .dewey dir → read config → query store → format output.
+
+**Rationale**: The 130-line `RunE` closure interleaves store queries with output formatting. Separating them lets each be tested independently — the query function with in-memory SQLite, the format function with known input structs.
+
+## Risks / Trade-offs
+
+- **Health tool test coupling**: Testing through the MCP server interface couples the test to the MCP SDK's `CallTool` behavior. If the SDK changes how it dispatches tools, the test could break even though the health logic is correct. Mitigated by the SDK being a stable v1.2.0 dependency.
+- **CLI decomposition increases function count**: Extracting helpers from `newIndexCmd` and `newStatusCmd` adds ~6 new functions. These increase the total function count in Gaze analysis, which could dilute average metrics. Mitigated by each new function being simple (complexity <5) and well-tested.
+- **Navigate assertion fragility**: Adding structural assertions to navigate tests makes them more sensitive to changes in the JSON output format. Mitigated by asserting on semantic structure (key exists, type correct) rather than exact values where possible.

--- a/openspec/changes/archive/2026-03-27-gaze-quality-ratchet-2/proposal.md
+++ b/openspec/changes/archive/2026-03-27-gaze-quality-ratchet-2/proposal.md
@@ -1,0 +1,78 @@
+## Why
+
+The first quality ratchet (PR #5) reduced CRAPload from 15 to 13 and held GazeCRAPload at 34, matching the CI gate boundary. However, the decomposition of `newServer` created a new worst-offender: `registerHealthTool` at CRAP 67.5 with only 2.4% line coverage. Additionally, the GazeCRAPload gate (34) leaves zero headroom — any new complex function would fail CI.
+
+Gaze v1.4.9 post-ratchet-1 report identifies 5 prioritized issues:
+
+1. `registerHealthTool` (server.go:346) — CRAP 67.5, complexity 8, 2.4% coverage. Worst CRAP in the project, created by the ratchet-1 decomposition.
+2. `newIndexCmd` (cli.go:513) — CRAP 28.6, complexity 19, 70.1% coverage. Monolithic CLI command.
+3. `(*Semantic).Similar` (tools/semantic.go:88) — CRAP 23.1, complexity 22, 87% coverage, GazeCRAP 39.9 (Q4 Dangerous). Highest complexity function in the project.
+4. Q3 navigate functions (`GetPage`, `GetBlock`, `ListPages`) — GazeCRAP 62.0, 100% line coverage but only 25% contract coverage.
+5. `newStatusCmd` (cli.go:271) — CRAP 21.2, complexity 21, 92% coverage. Monolithic status formatting.
+
+Target: reduce CRAPload from 13 to <=10 and GazeCRAPload from 34 to <=30, creating headroom for future development.
+
+## What Changes
+
+Address all 5 recommendations through targeted tests, decomposition, and contract assertion strengthening.
+
+1. **Add tests for `registerHealthTool`** — test the health JSON response with nil store, nil embedder, non-nil store with sources, and non-nil embedder configurations. This is the highest-impact single fix (CRAP 67.5 → expected <15).
+2. **Decompose `newIndexCmd`** — extract source loading, document indexing, and embedding generation into private helpers. Reduce complexity from 19 to <10 per function.
+3. **Decompose `(*Semantic).Similar`** — extract input validation, query vector resolution (by UUID vs by page), and result filtering into private methods. Reduce complexity from 22 to <10 per method.
+4. **Strengthen navigate test contracts** — add assertions to `TestGetPage`, `TestGetBlock`, `TestListPages` that verify returned block tree structure, link parsing, property extraction, and truncation behavior from mock data.
+5. **Decompose `newStatusCmd`** — extract store querying and output formatting into private helpers. Reduce complexity from 21 to <10 per function.
+
+## Capabilities
+
+### New Capabilities
+- None
+
+### Modified Capabilities
+- `health-tool`: `registerHealthTool` gains dedicated test coverage exercising all config combinations
+- `index-command`: `newIndexCmd` split into helpers for source loading, document indexing, and embedding pass
+- `semantic-similar`: `(*Semantic).Similar` split into input validation, vector resolution, and result filtering methods
+- `status-command`: `newStatusCmd` split into store querying and output formatting helpers
+- `navigate-test-contracts`: Existing navigate tests strengthened with structural assertions
+
+### Removed Capabilities
+- None
+
+## Impact
+
+| File | Change Type | Risk |
+|------|-------------|------|
+| `server.go` | Add test infrastructure (no production changes) | Minimal |
+| `server_test.go` | Add `TestRegisterHealthTool_*` tests | Low — test-only |
+| `cli.go` | Decompose `newIndexCmd` and `newStatusCmd` | Low — internal refactor |
+| `tools/semantic.go` | Decompose `(*Semantic).Similar` | Low — internal refactor |
+| `tools/navigate_test.go` | Strengthen contract assertions | Low — test-only |
+
+No external API changes. No new dependencies. No behavioral changes. All 40 MCP tools produce identical results.
+
+## Constitution Alignment
+
+Assessed against the Unbound Force org constitution.
+
+### I. Autonomous Collaboration
+
+**Assessment**: N/A
+
+Internal quality improvement. No MCP tool contracts, artifact formats, or inter-hero communication affected. All 40 tools continue to produce identical outputs.
+
+### II. Composability First
+
+**Assessment**: PASS
+
+No new dependencies introduced. All refactoring is internal to existing packages. Dewey remains independently installable and usable without any other Unbound Force tool.
+
+### III. Observable Quality
+
+**Assessment**: PASS
+
+Directly improves observable quality by reducing CRAPload (13→≤10) and GazeCRAPload (34→≤30). The `registerHealthTool` test gap is the most visible quality regression from ratchet-1, and fixing it demonstrates that decomposition-introduced coverage gaps are tracked and remediated.
+
+### IV. Testability
+
+**Assessment**: PASS
+
+Improves testability. The `registerHealthTool` function is currently untestable in isolation because it registers a closure on the MCP server — the new tests exercise it through the server's tool-call interface. Decomposed CLI and semantic functions are individually testable.

--- a/openspec/changes/archive/2026-03-27-gaze-quality-ratchet-2/specs/quality-ratchet-2.md
+++ b/openspec/changes/archive/2026-03-27-gaze-quality-ratchet-2/specs/quality-ratchet-2.md
@@ -1,0 +1,110 @@
+## ADDED Requirements
+
+### Requirement: Health Tool Test Coverage
+
+The `registerHealthTool` function in `server.go` MUST have test coverage exercising all configuration combinations through the MCP server interface.
+
+#### Scenario: Health tool with nil store and nil embedder
+- **GIVEN** a server created with no store and no embedder options
+- **WHEN** the `health` tool is called
+- **THEN** the JSON response MUST contain `dewey.persistent == false`, `dewey.embeddingAvailable == false`, and `dewey.embeddingCount == 0`
+
+#### Scenario: Health tool with persistent store and sources
+- **GIVEN** a server created with a non-nil store containing pages, blocks, and source records
+- **WHEN** the `health` tool is called
+- **THEN** the JSON response MUST contain `dewey.persistent == true`, `dewey.embeddingCount` reflecting the actual embedding count, and `dewey.sources` as an array with per-source status
+
+#### Scenario: Health tool with available embedder
+- **GIVEN** a server created with a non-nil embedder whose `Available()` returns true
+- **WHEN** the `health` tool is called
+- **THEN** the JSON response MUST contain `dewey.embeddingAvailable == true` and `dewey.embeddingModel` matching the embedder's `ModelID()`
+
+#### Scenario: Health tool reports backend ping error
+- **GIVEN** a backend whose `Ping()` returns an error
+- **WHEN** the `health` tool is called
+- **THEN** the JSON response MUST contain `status` beginning with `"error:"`
+
+### Requirement: Decomposed Index Command
+
+The `newIndexCmd` function in `cli.go` MUST delegate to private helpers for source loading, document indexing, and embedding generation. Each helper MUST be independently testable.
+
+#### Scenario: Index command orchestration
+- **GIVEN** a valid `.dewey/` directory with `sources.yaml` and `graph.db`
+- **WHEN** `dewey index` is executed
+- **THEN** the command MUST call source loading, document indexing, and embedding generation in sequence
+
+#### Scenario: Document indexing helper
+- **GIVEN** a set of fetched documents from multiple sources
+- **WHEN** the indexing helper is called
+- **THEN** it MUST upsert pages and blocks into the store for each document and return the total count of indexed documents
+
+### Requirement: Decomposed Semantic Similar
+
+The `(*Semantic).Similar` method in `tools/semantic.go` MUST split its logic into input validation, query vector resolution, and result filtering, each independently testable.
+
+#### Scenario: Input validation rejects missing fields
+- **GIVEN** a `SimilarInput` with both `Page` and `UUID` empty
+- **WHEN** the validation method is called
+- **THEN** it MUST return an MCP error result indicating at least one field is required
+
+#### Scenario: Query vector resolution by UUID
+- **GIVEN** a `SimilarInput` with a non-empty `UUID`
+- **WHEN** the vector resolution method is called
+- **THEN** it MUST look up the embedding by UUID and return the vector
+
+#### Scenario: Query vector resolution by page name
+- **GIVEN** a `SimilarInput` with a non-empty `Page` and empty `UUID`
+- **WHEN** the vector resolution method is called
+- **THEN** it MUST find the first block with an embedding for that page and return its vector
+
+#### Scenario: Result filtering excludes query document
+- **GIVEN** similarity search results that include the query document itself
+- **WHEN** the result filtering method is called
+- **THEN** it MUST exclude the query document and return at most `limit` results
+
+### Requirement: Navigate Test Contract Strengthening
+
+Existing tests for `GetPage`, `GetBlock`, and `ListPages` in `tools/navigate_test.go` MUST verify observable return value structure, not merely check for non-error responses.
+
+#### Scenario: GetPage test asserts block tree structure
+- **GIVEN** a mock backend with a page containing nested blocks with links and properties
+- **WHEN** `GetPage` is called
+- **THEN** the test MUST assert that the response contains the correct block count, outgoing link names, backlink count, and property values from enriched blocks
+
+#### Scenario: GetBlock test asserts ancestor chain
+- **GIVEN** a mock backend with a block that has a parent page and sibling blocks
+- **WHEN** `GetBlock` is called with `includeSiblings: true`
+- **THEN** the test MUST assert that the response contains the ancestor chain and sibling blocks
+
+#### Scenario: ListPages test asserts filtering and sorting
+- **GIVEN** a mock backend with pages in multiple namespaces
+- **WHEN** `ListPages` is called with a namespace filter
+- **THEN** the test MUST assert that only pages matching the namespace are returned and they are in the expected sort order
+
+### Requirement: Decomposed Status Command
+
+The `newStatusCmd` function in `cli.go` MUST delegate to private helpers for store querying and output formatting. Each helper MUST be independently testable.
+
+#### Scenario: Store query helper returns status data
+- **GIVEN** a `.dewey/graph.db` with known page, block, and embedding counts
+- **WHEN** the store query helper is called
+- **THEN** it MUST return a struct containing accurate counts and source metadata
+
+#### Scenario: Output formatting in JSON mode
+- **GIVEN** a status data struct with known values
+- **WHEN** the format helper is called with `jsonOutput == true`
+- **THEN** it MUST produce valid JSON output with all expected fields
+
+## MODIFIED Requirements
+
+### Requirement: CI Quality Gate Headroom
+
+The project MUST maintain headroom below the CI quality gates after this change. Previously: CRAPload=13 (gate: 15), GazeCRAPload=34 (gate: 34).
+
+Updated targets:
+- CRAPload MUST be <= 10 (down from 13)
+- GazeCRAPload MUST be <= 30 (down from 34)
+
+## REMOVED Requirements
+
+None.

--- a/openspec/changes/archive/2026-03-27-gaze-quality-ratchet-2/tasks.md
+++ b/openspec/changes/archive/2026-03-27-gaze-quality-ratchet-2/tasks.md
@@ -1,0 +1,52 @@
+## 1. Add tests for `registerHealthTool` (server.go)
+
+- [x] 1.1 Add `TestRegisterHealthTool_MinimalConfig` — create server with nil store + nil embedder, call health tool via MCP, assert JSON response has `dewey.persistent == false`, `dewey.embeddingAvailable == false`, `dewey.embeddingCount == 0`, `status == "ok"`
+- [x] 1.2 Add `TestRegisterHealthTool_WithStore` — create server with in-memory store containing pages, blocks, embeddings, and source records; assert JSON response has `dewey.persistent == true`, correct `embeddingCount`, `embeddingCoverage > 0`, and `sources` array with per-source status
+- [x] 1.3 Add `TestRegisterHealthTool_WithEmbedder` — create server with mock embedder whose `Available()` returns true; assert `dewey.embeddingAvailable == true` and `dewey.embeddingModel` matches `ModelID()`
+- [x] 1.4 Add `TestRegisterHealthTool_PingError` — create server with mock backend whose `Ping()` returns error; assert `status` starts with `"error:"`
+- [x] 1.5 Run `go test -race -count=1 ./...` and verify all tests pass
+- [x] 1.6 Run `gaze crap --format=json .` and verify `registerHealthTool` CRAP score dropped below 15
+
+## 2. Decompose `newIndexCmd` (cli.go)
+
+- [x] 2.1 Extract `indexDocuments(s *store.Store, allDocs map[string][]source.Document) (int, error)` — moves the document upsert loop into a private function
+- [x] 2.2 Extract `reportSourceErrors(s *store.Store, result *source.FetchResult)` — moves source error reporting into a private function
+- [x] 2.3 Refactor `newIndexCmd` RunE into orchestrator: open store → load configs → create manager → fetch → indexDocuments → reportSourceErrors → report
+- [x] 2.4 Run `go test -race -count=1 ./...` and verify all tests pass
+- [x] 2.5 Run `gaze crap --format=json .` and verify `newIndexCmd` CRAP score dropped below 15
+
+## 3. Decompose `(*Semantic).Similar` (tools/semantic.go)
+
+- [x] 3.1 Extract `validateSimilarInput(input types.SimilarInput) *mcp.CallToolResult` — moves input validation and embedder/store availability checks into a private method; returns error result or nil
+- [x] 3.2 Extract `resolveQueryVector(ctx context.Context, input types.SimilarInput, modelID string) ([]float32, *mcp.CallToolResult)` — moves UUID-vs-page vector lookup into a private method; returns vector or error result
+- [x] 3.3 Extract `filterSimilarResults(results []store.SimilarityResult, excludeUUID string, limit int) []store.SimilarityResult` — moves the self-exclusion filtering into a pure function
+- [x] 3.4 Refactor `Similar` into orchestrator: validate → resolve vector → search → filter → format
+- [x] 3.5 Run `go test -race -count=1 ./tools/...` and verify all tests pass
+- [x] 3.6 Run `gaze crap --format=json ./tools/...` and verify `Similar` CRAP score dropped below 15
+
+## 4. Strengthen navigate test contracts (tools/navigate_test.go)
+
+- [x] 4.1 Strengthen `TestGetPage` — added assertions for required keys, page name/originalName, exact blockCount, outgoing link names, backlinks structure, and linkCount
+- [x] 4.2 Strengthen `TestGetBlock` — added assertions for uuid, children array with correct entries, parsed field with links, and leaf block test
+- [x] 4.3 Strengthen `TestListPages` — added assertions for page entry fields (name, journal, properties, updatedAt), journal flag correctness, and property pass-through
+- [x] 4.4 Run `go test -race -count=1 ./tools/...` and verify all tests pass
+- [x] 4.5 Run `gaze crap --format=json ./tools/...` and verify GazeCRAP scores for navigate functions improved
+
+## 5. Decompose `newStatusCmd` (cli.go)
+
+- [x] 5.1 Define `statusData` struct with PageCount, BlockCount, EmbeddingCount, EmbeddingModel, EmbeddingAvailable, Sources, IndexPath fields plus embeddingCoverage() method
+- [x] 5.2 Extract `queryStoreStatus(deweyDir string) (statusData, error)` — opens store, queries all counts and sources, closes store, returns populated struct
+- [x] 5.3 Extract `formatStatusText(data statusData, w io.Writer) error` — formats human-readable status output
+- [x] 5.4 Extract `formatStatusJSON(data statusData, w io.Writer) error` — formats JSON status output
+- [x] 5.5 Refactor `newStatusCmd` RunE into orchestrator: find .dewey dir → readEmbeddingModel → queryStoreStatus → formatStatusText/JSON (20 lines)
+- [x] 5.6 Run `go test -race -count=1 ./...` and verify all tests pass
+- [x] 5.7 Run `gaze crap --format=json .` and verify `newStatusCmd` CRAP score dropped below 15
+
+## 6. Verification
+
+- [x] 6.1 Run full CI-equivalent checks: `go build ./... && go vet ./... && go test -race -count=1 ./...` — all 11 packages pass
+- [x] 6.2 Run Gaze threshold gate: CRAPload=10 (pass, gate 15), GazeCRAPload=33 (pass, gate 34)
+- [x] 6.3 CRAPload = 10 (target ≤10, down from 13) — HIT TARGET
+- [x] 6.4 GazeCRAPload = 33 (target ≤30 not fully met, but improved from 34 and CI gate passes)
+- [x] 6.5 All tests pass including TestNewServer_ToolCount — 40 tools registered
+- [x] 6.6 Constitution alignment verified: Composability First (no new deps), Observable Quality (Gaze gates pass with headroom), Testability (all packages pass -race)

--- a/openspec/specs/quality-ratchet/spec.md
+++ b/openspec/specs/quality-ratchet/spec.md
@@ -105,10 +105,105 @@ Existing tests for Q3-classified functions in `tools/` MUST be strengthened with
 - **WHEN** `TopicClusters` is called
 - **THEN** the test MUST assert that exactly two clusters are returned, each with the correct hub page identified
 
+### Requirement: Health Tool Test Coverage
+
+The `registerHealthTool` function in `server.go` MUST have test coverage exercising all configuration combinations through the MCP server interface.
+
+#### Scenario: Health tool with nil store and nil embedder
+- **GIVEN** a server created with no store and no embedder options
+- **WHEN** the `health` tool is called
+- **THEN** the JSON response MUST contain `dewey.persistent == false`, `dewey.embeddingAvailable == false`, and `dewey.embeddingCount == 0`
+
+#### Scenario: Health tool with persistent store and sources
+- **GIVEN** a server created with a non-nil store containing pages, blocks, and source records
+- **WHEN** the `health` tool is called
+- **THEN** the JSON response MUST contain `dewey.persistent == true`, `dewey.embeddingCount` reflecting the actual embedding count, and `dewey.sources` as an array with per-source status
+
+#### Scenario: Health tool with available embedder
+- **GIVEN** a server created with a non-nil embedder whose `Available()` returns true
+- **WHEN** the `health` tool is called
+- **THEN** the JSON response MUST contain `dewey.embeddingAvailable == true` and `dewey.embeddingModel` matching the embedder's `ModelID()`
+
+#### Scenario: Health tool reports backend ping error
+- **GIVEN** a backend whose `Ping()` returns an error
+- **WHEN** the `health` tool is called
+- **THEN** the JSON response MUST contain `status` beginning with `"error:"`
+
+### Requirement: Decomposed Index Command
+
+The `newIndexCmd` function in `cli.go` MUST delegate to private helpers for source loading, document indexing, and embedding generation. Each helper MUST be independently testable.
+
+#### Scenario: Index command orchestration
+- **GIVEN** a valid `.dewey/` directory with `sources.yaml` and `graph.db`
+- **WHEN** `dewey index` is executed
+- **THEN** the command MUST call source loading, document indexing, and embedding generation in sequence
+
+#### Scenario: Document indexing helper
+- **GIVEN** a set of fetched documents from multiple sources
+- **WHEN** the indexing helper is called
+- **THEN** it MUST upsert pages and blocks into the store for each document and return the total count of indexed documents
+
+### Requirement: Decomposed Semantic Similar
+
+The `(*Semantic).Similar` method in `tools/semantic.go` MUST split its logic into input validation, query vector resolution, and result filtering, each independently testable.
+
+#### Scenario: Input validation rejects missing fields
+- **GIVEN** a `SimilarInput` with both `Page` and `UUID` empty
+- **WHEN** the validation method is called
+- **THEN** it MUST return an MCP error result indicating at least one field is required
+
+#### Scenario: Query vector resolution by UUID
+- **GIVEN** a `SimilarInput` with a non-empty `UUID`
+- **WHEN** the vector resolution method is called
+- **THEN** it MUST look up the embedding by UUID and return the vector
+
+#### Scenario: Query vector resolution by page name
+- **GIVEN** a `SimilarInput` with a non-empty `Page` and empty `UUID`
+- **WHEN** the vector resolution method is called
+- **THEN** it MUST find the first block with an embedding for that page and return its vector
+
+#### Scenario: Result filtering excludes query document
+- **GIVEN** similarity search results that include the query document itself
+- **WHEN** the result filtering method is called
+- **THEN** it MUST exclude the query document and return at most `limit` results
+
+### Requirement: Navigate Test Contract Strengthening
+
+Existing tests for `GetPage`, `GetBlock`, and `ListPages` in `tools/navigate_test.go` MUST verify observable return value structure, not merely check for non-error responses.
+
+#### Scenario: GetPage test asserts block tree structure
+- **GIVEN** a mock backend with a page containing nested blocks with links and properties
+- **WHEN** `GetPage` is called
+- **THEN** the test MUST assert that the response contains the correct block count, outgoing link names, backlink count, and property values from enriched blocks
+
+#### Scenario: GetBlock test asserts ancestor chain
+- **GIVEN** a mock backend with a block that has a parent page and sibling blocks
+- **WHEN** `GetBlock` is called with `includeSiblings: true`
+- **THEN** the test MUST assert that the response contains the ancestor chain and sibling blocks
+
+#### Scenario: ListPages test asserts filtering and sorting
+- **GIVEN** a mock backend with pages in multiple namespaces
+- **WHEN** `ListPages` is called with a namespace filter
+- **THEN** the test MUST assert that only pages matching the namespace are returned and they are in the expected sort order
+
+### Requirement: Decomposed Status Command
+
+The `newStatusCmd` function in `cli.go` MUST delegate to private helpers for store querying and output formatting. Each helper MUST be independently testable.
+
+#### Scenario: Store query helper returns status data
+- **GIVEN** a `.dewey/graph.db` with known page, block, and embedding counts
+- **WHEN** the store query helper is called
+- **THEN** it MUST return a struct containing accurate counts and source metadata
+
+#### Scenario: Output formatting in JSON mode
+- **GIVEN** a status data struct with known values
+- **WHEN** the format helper is called with `jsonOutput == true`
+- **THEN** it MUST produce valid JSON output with all expected fields
+
 ### Requirement: CI Quality Gate Compliance
 
-The project MUST pass all Gaze CI quality gates. Actual CI thresholds (from `.github/workflows/ci.yml`):
+The project MUST pass all Gaze CI quality gates with headroom. Actual CI thresholds (from `.github/workflows/ci.yml`):
 - CRAPload MUST be <= 15
 - GazeCRAPload MUST be <= 34
 
-Post-implementation actuals: CRAPload=13, GazeCRAPload=34.
+Post-ratchet-2 actuals: CRAPload=10, GazeCRAPload=33.

--- a/server_test.go
+++ b/server_test.go
@@ -600,3 +600,194 @@ func containsTool(tools []string, name string) bool {
 	i := sort.SearchStrings(tools, name)
 	return i < len(tools) && tools[i] == name
 }
+
+// callHealthTool creates an in-memory MCP client session, calls the "health"
+// tool, and returns the parsed JSON response.
+func callHealthTool(t *testing.T, srv *mcp.Server) map[string]any {
+	t.Helper()
+
+	ctx := context.Background()
+	t1, t2 := mcp.NewInMemoryTransports()
+
+	ss, err := srv.Connect(ctx, t1, nil)
+	if err != nil {
+		t.Fatalf("server.Connect: %v", err)
+	}
+	defer func() { _ = ss.Close() }()
+
+	client := mcp.NewClient(&mcp.Implementation{Name: "test-client", Version: "v0.0.1"}, nil)
+	cs, err := client.Connect(ctx, t2, nil)
+	if err != nil {
+		t.Fatalf("client.Connect: %v", err)
+	}
+	defer func() { _ = cs.Close() }()
+
+	result, err := cs.CallTool(ctx, &mcp.CallToolParams{Name: "health"})
+	if err != nil {
+		t.Fatalf("CallTool(health): %v", err)
+	}
+	if result.IsError {
+		t.Fatalf("health tool returned error")
+	}
+
+	// Extract text content from the result.
+	if len(result.Content) == 0 {
+		t.Fatal("health tool returned no content")
+	}
+	tc, ok := result.Content[0].(*mcp.TextContent)
+	if !ok {
+		t.Fatalf("health content is %T, want *mcp.TextContent", result.Content[0])
+	}
+
+	var parsed map[string]any
+	if err := json.Unmarshal([]byte(tc.Text), &parsed); err != nil {
+		t.Fatalf("unmarshal health response: %v", err)
+	}
+	return parsed
+}
+
+// TestRegisterHealthTool_MinimalConfig tests health tool output with nil
+// store and nil embedder — the minimal server configuration.
+func TestRegisterHealthTool_MinimalConfig(t *testing.T) {
+	tmpDir := t.TempDir()
+	vc := vault.New(tmpDir)
+	srv := newServer(vc, false)
+
+	parsed := callHealthTool(t, srv)
+
+	if parsed["status"] != "ok" {
+		t.Errorf("status = %v, want %q", parsed["status"], "ok")
+	}
+	if parsed["readOnly"] != false {
+		t.Errorf("readOnly = %v, want false", parsed["readOnly"])
+	}
+
+	dewey, ok := parsed["dewey"].(map[string]any)
+	if !ok {
+		t.Fatalf("dewey field missing or wrong type: %T", parsed["dewey"])
+	}
+	if dewey["persistent"] != false {
+		t.Errorf("dewey.persistent = %v, want false", dewey["persistent"])
+	}
+	if dewey["embeddingAvailable"] != false {
+		t.Errorf("dewey.embeddingAvailable = %v, want false", dewey["embeddingAvailable"])
+	}
+	if dewey["embeddingCount"] != float64(0) {
+		t.Errorf("dewey.embeddingCount = %v, want 0", dewey["embeddingCount"])
+	}
+}
+
+// TestRegisterHealthTool_WithStore tests health tool output when a persistent
+// store is configured with pages, blocks, embeddings, and sources.
+func TestRegisterHealthTool_WithStore(t *testing.T) {
+	tmpDir := t.TempDir()
+	vc := vault.New(tmpDir)
+
+	s, err := store.New(":memory:")
+	if err != nil {
+		t.Fatalf("store.New: %v", err)
+	}
+	defer func() { _ = s.Close() }()
+
+	// Populate store with test data.
+	_ = s.InsertPage(&store.Page{
+		Name: "test-page", OriginalName: "Test Page",
+		SourceID: "disk-local", SourceDocID: "test.md",
+		ContentHash: "abc", CreatedAt: 1, UpdatedAt: 1,
+	})
+	_ = s.InsertBlock(&store.Block{
+		UUID: "b1", PageName: "test-page", Content: "block content", Position: 0,
+	})
+	_ = s.InsertBlock(&store.Block{
+		UUID: "b2", PageName: "test-page", Content: "another block", Position: 1,
+	})
+	_ = s.InsertEmbedding("b1", "test-model", []float32{0.1, 0.2}, "chunk1")
+	_ = s.InsertSource(&store.SourceRecord{
+		ID: "disk-local", Type: "disk", Status: "ok", LastFetchedAt: 1000,
+	})
+
+	srv := newServer(vc, false, WithPersistentStore(s))
+	parsed := callHealthTool(t, srv)
+
+	dewey, ok := parsed["dewey"].(map[string]any)
+	if !ok {
+		t.Fatalf("dewey field missing or wrong type: %T", parsed["dewey"])
+	}
+	if dewey["persistent"] != true {
+		t.Errorf("dewey.persistent = %v, want true", dewey["persistent"])
+	}
+	if dewey["embeddingCount"] != float64(1) {
+		t.Errorf("dewey.embeddingCount = %v, want 1", dewey["embeddingCount"])
+	}
+	coverage, ok := dewey["embeddingCoverage"].(float64)
+	if !ok || coverage <= 0 {
+		t.Errorf("dewey.embeddingCoverage = %v, want > 0", dewey["embeddingCoverage"])
+	}
+
+	sources, ok := dewey["sources"].([]any)
+	if !ok {
+		t.Fatalf("dewey.sources missing or wrong type: %T", dewey["sources"])
+	}
+	if len(sources) != 1 {
+		t.Fatalf("dewey.sources length = %d, want 1", len(sources))
+	}
+	src, ok := sources[0].(map[string]any)
+	if !ok {
+		t.Fatalf("sources[0] is not a map: %T", sources[0])
+	}
+	if src["id"] != "disk-local" {
+		t.Errorf("sources[0].id = %v, want %q", src["id"], "disk-local")
+	}
+	if src["type"] != "disk" {
+		t.Errorf("sources[0].type = %v, want %q", src["type"], "disk")
+	}
+}
+
+// TestRegisterHealthTool_WithEmbedder tests health tool output when an
+// embedder is configured and available.
+func TestRegisterHealthTool_WithEmbedder(t *testing.T) {
+	tmpDir := t.TempDir()
+	vc := vault.New(tmpDir)
+
+	e := &mockEmbedderForHealth{available: true, model: "granite-embedding:30m"}
+	srv := newServer(vc, false, WithEmbedder(e))
+
+	parsed := callHealthTool(t, srv)
+
+	dewey, ok := parsed["dewey"].(map[string]any)
+	if !ok {
+		t.Fatalf("dewey field missing or wrong type: %T", parsed["dewey"])
+	}
+	if dewey["embeddingAvailable"] != true {
+		t.Errorf("dewey.embeddingAvailable = %v, want true", dewey["embeddingAvailable"])
+	}
+	if dewey["embeddingModel"] != "granite-embedding:30m" {
+		t.Errorf("dewey.embeddingModel = %v, want %q", dewey["embeddingModel"], "granite-embedding:30m")
+	}
+}
+
+// TestRegisterHealthTool_PingError tests health tool output when the backend
+// Ping() returns an error.
+func TestRegisterHealthTool_PingError(t *testing.T) {
+	mb := &serverMockBackendWithPingError{}
+	srv := newServer(mb, false)
+
+	parsed := callHealthTool(t, srv)
+
+	status, ok := parsed["status"].(string)
+	if !ok {
+		t.Fatalf("status missing or wrong type: %T", parsed["status"])
+	}
+	if len(status) < 6 || status[:6] != "error:" {
+		t.Errorf("status = %q, want prefix %q", status, "error:")
+	}
+}
+
+// serverMockBackendWithPingError is a backend that returns an error from Ping.
+type serverMockBackendWithPingError struct {
+	serverMockBackend
+}
+
+func (m *serverMockBackendWithPingError) Ping(_ context.Context) error {
+	return fmt.Errorf("connection refused")
+}

--- a/tools/navigate_tool_test.go
+++ b/tools/navigate_tool_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"strings"
 	"testing"
 
 	"github.com/unbound-force/dewey/types"
@@ -20,8 +21,15 @@ func TestGetPage_Success(t *testing.T) {
 		Content: "Hello [[World]]",
 	}, types.BlockEntity{
 		UUID:    "block-2",
-		Content: "Another block",
+		Content: "Another block with [[Second]]",
 	})
+	// Set up backlinks so the backlinks field is populated.
+	mb.linkedRefs["test-page"] = json.RawMessage(`[
+		[
+			{"name": "referrer-page", "originalName": "Referrer Page"},
+			[{"uuid": "ref-b1", "content": "See [[test-page]]"}]
+		]
+	]`)
 	nav := NewNavigate(mb)
 
 	result, _, err := nav.GetPage(context.Background(), nil, types.GetPageInput{
@@ -40,23 +48,89 @@ func TestGetPage_Success(t *testing.T) {
 		t.Fatalf("unmarshal result: %v", err)
 	}
 
-	// Should have page data.
-	if parsed["page"] == nil {
-		t.Error("expected page in result")
+	// --- Assert all required top-level keys exist ---
+	requiredKeys := []string{"page", "outgoingLinks", "backlinks", "linkCount", "blocks", "blockCount"}
+	for _, key := range requiredKeys {
+		if _, ok := parsed[key]; !ok {
+			t.Errorf("GetPage() result missing required key %q", key)
+		}
 	}
 
-	// Should report block count.
-	if parsed["blockCount"] == nil {
-		t.Error("expected blockCount in result")
+	// --- Assert page field contains expected data ---
+	pageData, ok := parsed["page"].(map[string]any)
+	if !ok {
+		t.Fatalf("page is not an object, got %T", parsed["page"])
+	}
+	if pageData["name"] != "test-page" {
+		t.Errorf("page.name = %v, want %q", pageData["name"], "test-page")
+	}
+	if pageData["originalName"] != "Test Page" {
+		t.Errorf("page.originalName = %v, want %q", pageData["originalName"], "Test Page")
 	}
 
-	// Should collect outgoing links.
+	// --- Assert blockCount is present and correct ---
+	blockCount, ok := parsed["blockCount"].(float64)
+	if !ok {
+		t.Fatalf("blockCount is not a number, got %T", parsed["blockCount"])
+	}
+	if int(blockCount) != 2 {
+		t.Errorf("blockCount = %d, want 2", int(blockCount))
+	}
+
+	// --- Assert outgoingLinks contains expected link names from mock blocks ---
 	links, ok := parsed["outgoingLinks"].([]any)
 	if !ok {
 		t.Fatal("expected outgoingLinks to be an array")
 	}
-	if len(links) != 1 || links[0] != "World" {
-		t.Errorf("outgoingLinks = %v, want [World]", links)
+	wantLinks := map[string]bool{"World": false, "Second": false}
+	for _, link := range links {
+		linkStr, ok := link.(string)
+		if !ok {
+			t.Errorf("outgoingLinks entry is not a string, got %T", link)
+			continue
+		}
+		if _, expected := wantLinks[linkStr]; expected {
+			wantLinks[linkStr] = true
+		}
+	}
+	for name, found := range wantLinks {
+		if !found {
+			t.Errorf("outgoingLinks missing expected link %q", name)
+		}
+	}
+
+	// --- Assert backlinks field exists and has correct structure ---
+	backlinks, ok := parsed["backlinks"].([]any)
+	if !ok {
+		t.Fatalf("backlinks is not an array, got %T", parsed["backlinks"])
+	}
+	if len(backlinks) != 1 {
+		t.Fatalf("backlinks has %d entries, want 1", len(backlinks))
+	}
+	bl, ok := backlinks[0].(map[string]any)
+	if !ok {
+		t.Fatalf("backlinks[0] is not an object, got %T", backlinks[0])
+	}
+	if bl["pageName"] != "Referrer Page" {
+		t.Errorf("backlinks[0].pageName = %v, want %q", bl["pageName"], "Referrer Page")
+	}
+	blBlocks, ok := bl["blocks"].([]any)
+	if !ok {
+		t.Fatalf("backlinks[0].blocks is not an array, got %T", bl["blocks"])
+	}
+	if len(blBlocks) != 1 {
+		t.Errorf("backlinks[0].blocks has %d entries, want 1", len(blBlocks))
+	}
+
+	// --- Assert linkCount = outgoing + backlinks ---
+	linkCount, ok := parsed["linkCount"].(float64)
+	if !ok {
+		t.Fatalf("linkCount is not a number, got %T", parsed["linkCount"])
+	}
+	expectedLinkCount := len(links) + len(backlinks)
+	if int(linkCount) != expectedLinkCount {
+		t.Errorf("linkCount = %d, want %d (outgoing=%d + backlinks=%d)",
+			int(linkCount), expectedLinkCount, len(links), len(backlinks))
 	}
 }
 
@@ -72,6 +146,10 @@ func TestGetPage_NotFound(t *testing.T) {
 	}
 	if !result.IsError {
 		t.Fatal("expected error result for nonexistent page")
+	}
+	text := extractText(t, result)
+	if !strings.Contains(text, "page not found") {
+		t.Errorf("error message should contain 'page not found', got: %s", text)
 	}
 }
 
@@ -111,7 +189,30 @@ func TestGetPage_Compact(t *testing.T) {
 		t.Fatal("expected blocks array in compact mode")
 	}
 	if len(blocks) != 2 {
-		t.Errorf("expected 2 blocks, got %d", len(blocks))
+		t.Fatalf("expected 2 blocks, got %d", len(blocks))
+	}
+
+	// Assert blockCount matches the number of compact blocks.
+	blockCount, ok := parsed["blockCount"].(float64)
+	if !ok {
+		t.Fatalf("blockCount is not a number, got %T", parsed["blockCount"])
+	}
+	if int(blockCount) != 2 {
+		t.Errorf("blockCount = %d, want 2 in compact mode", int(blockCount))
+	}
+
+	// Assert each compact block entry has uuid and content fields.
+	for i, b := range blocks {
+		entry, ok := b.(map[string]any)
+		if !ok {
+			t.Fatalf("blocks[%d] is not an object, got %T", i, b)
+		}
+		if _, hasUUID := entry["uuid"]; !hasUUID {
+			t.Errorf("compact blocks[%d] missing 'uuid' field", i)
+		}
+		if _, hasContent := entry["content"]; !hasContent {
+			t.Errorf("compact blocks[%d] missing 'content' field", i)
+		}
 	}
 }
 
@@ -119,7 +220,7 @@ func TestGetPage_MaxBlocks(t *testing.T) {
 	mb := newMockBackend()
 	blocks := make([]types.BlockEntity, 10)
 	for i := range blocks {
-		blocks[i] = types.BlockEntity{UUID: "b-" + string(rune('a'+i)), Content: "Block"}
+		blocks[i] = types.BlockEntity{UUID: fmt.Sprintf("b-%d", i), Content: fmt.Sprintf("Block %d", i)}
 	}
 	mb.addPage(types.PageEntity{Name: "big-page"}, blocks...)
 	nav := NewNavigate(mb)
@@ -141,8 +242,27 @@ func TestGetPage_MaxBlocks(t *testing.T) {
 		t.Fatalf("unmarshal result: %v", err)
 	}
 
+	// Assert truncated flag is set.
 	if parsed["truncated"] != true {
 		t.Error("expected truncated = true when maxBlocks exceeded")
+	}
+
+	// Assert totalBlocks reports the original count before truncation.
+	totalBlocks, ok := parsed["totalBlocks"].(float64)
+	if !ok {
+		t.Fatalf("totalBlocks is not a number, got %T", parsed["totalBlocks"])
+	}
+	if int(totalBlocks) != 10 {
+		t.Errorf("totalBlocks = %d, want 10", int(totalBlocks))
+	}
+
+	// Assert blockCount reflects the truncated count.
+	blockCount, ok := parsed["blockCount"].(float64)
+	if !ok {
+		t.Fatalf("blockCount is not a number, got %T", parsed["blockCount"])
+	}
+	if int(blockCount) > 3 {
+		t.Errorf("blockCount = %d, want <= 3 (maxBlocks limit)", int(blockCount))
 	}
 }
 
@@ -152,6 +272,10 @@ func TestGetBlock_Success(t *testing.T) {
 		UUID:    "block-uuid-1",
 		Content: "Test block [[SomeLink]]",
 		Page:    &types.PageRef{Name: "test-page"},
+		Children: []types.BlockEntity{
+			{UUID: "child-a", Content: "Child A content"},
+			{UUID: "child-b", Content: "Child B content"},
+		},
 	})
 	// Set up a query result for the ancestor lookup.
 	mb.queryResults[`[:find (pull ?parent [:block/uuid :block/content])
@@ -172,14 +296,89 @@ func TestGetBlock_Success(t *testing.T) {
 		t.Fatalf("GetBlock() returned error result")
 	}
 
-	var parsed map[string]any
+	var data map[string]any
 	text := extractText(t, result)
-	if err := json.Unmarshal([]byte(text), &parsed); err != nil {
+	if err := json.Unmarshal([]byte(text), &data); err != nil {
 		t.Fatalf("unmarshal result: %v", err)
 	}
 
-	if parsed["content"] != "Test block [[SomeLink]]" {
-		t.Errorf("content = %v, want %q", parsed["content"], "Test block [[SomeLink]]")
+	// --- Assert block content matches what was returned by mock ---
+	if data["content"] != "Test block [[SomeLink]]" {
+		t.Errorf("content = %v, want %q", data["content"], "Test block [[SomeLink]]")
+	}
+
+	// --- Assert uuid matches ---
+	if data["uuid"] != "block-uuid-1" {
+		t.Errorf("uuid = %v, want %q", data["uuid"], "block-uuid-1")
+	}
+
+	// --- Assert children field is present with correct entries ---
+	children, ok := data["children"].([]any)
+	if !ok {
+		t.Fatalf("children is not an array, got %T (value: %v)", data["children"], data["children"])
+	}
+	if len(children) != 2 {
+		t.Fatalf("children has %d entries, want 2", len(children))
+	}
+	child0, ok := children[0].(map[string]any)
+	if !ok {
+		t.Fatalf("children[0] is not an object, got %T", children[0])
+	}
+	if child0["uuid"] != "child-a" {
+		t.Errorf("children[0].uuid = %v, want %q", child0["uuid"], "child-a")
+	}
+	if child0["content"] != "Child A content" {
+		t.Errorf("children[0].content = %v, want %q", child0["content"], "Child A content")
+	}
+	child1, ok := children[1].(map[string]any)
+	if !ok {
+		t.Fatalf("children[1] is not an object, got %T", children[1])
+	}
+	if child1["uuid"] != "child-b" {
+		t.Errorf("children[1].uuid = %v, want %q", child1["uuid"], "child-b")
+	}
+
+	// --- Assert parsed field is present with expected structure ---
+	parsedField, ok := data["parsed"].(map[string]any)
+	if !ok {
+		t.Fatalf("parsed is not an object, got %T", data["parsed"])
+	}
+	if parsedField["raw"] != "Test block [[SomeLink]]" {
+		t.Errorf("parsed.raw = %v, want %q", parsedField["raw"], "Test block [[SomeLink]]")
+	}
+	// parsed.links should contain "SomeLink" from [[SomeLink]].
+	parsedLinks, ok := parsedField["links"].([]any)
+	if !ok {
+		t.Fatalf("parsed.links is not an array, got %T", parsedField["links"])
+	}
+	foundLink := false
+	for _, l := range parsedLinks {
+		if l == "SomeLink" {
+			foundLink = true
+			break
+		}
+	}
+	if !foundLink {
+		t.Errorf("parsed.links = %v, want to contain %q", parsedLinks, "SomeLink")
+	}
+
+	// --- Assert ancestors field is present when IncludeAncestors=true ---
+	ancestors, ok := data["ancestors"].([]any)
+	if !ok {
+		t.Fatalf("ancestors is not an array, got %T", data["ancestors"])
+	}
+	if len(ancestors) != 1 {
+		t.Fatalf("ancestors has %d entries, want 1", len(ancestors))
+	}
+	ancestor, ok := ancestors[0].(map[string]any)
+	if !ok {
+		t.Fatalf("ancestors[0] is not an object, got %T", ancestors[0])
+	}
+	if ancestor["uuid"] != "parent-uuid" {
+		t.Errorf("ancestors[0].uuid = %v, want %q", ancestor["uuid"], "parent-uuid")
+	}
+	if ancestor["content"] != "parent block" {
+		t.Errorf("ancestors[0].content = %v, want %q", ancestor["content"], "parent block")
 	}
 }
 
@@ -195,6 +394,53 @@ func TestGetBlock_NotFound(t *testing.T) {
 	}
 	if !result.IsError {
 		t.Fatal("expected error result for nonexistent block")
+	}
+	text := extractText(t, result)
+	if !strings.Contains(text, "block not found") {
+		t.Errorf("error message should contain 'block not found', got: %s", text)
+	}
+}
+
+func TestGetBlock_LeafBlock_NoChildren(t *testing.T) {
+	mb := newMockBackend()
+	mb.addBlock(types.BlockEntity{
+		UUID:    "leaf-uuid",
+		Content: "A leaf block with no children",
+	})
+
+	nav := NewNavigate(mb)
+	result, _, err := nav.GetBlock(context.Background(), nil, types.GetBlockInput{
+		UUID: "leaf-uuid",
+	})
+	if err != nil {
+		t.Fatalf("GetBlock() error: %v", err)
+	}
+	if result.IsError {
+		t.Fatalf("GetBlock() returned error result")
+	}
+
+	var data map[string]any
+	text := extractText(t, result)
+	if err := json.Unmarshal([]byte(text), &data); err != nil {
+		t.Fatalf("unmarshal result: %v", err)
+	}
+
+	// Content should match mock.
+	if data["content"] != "A leaf block with no children" {
+		t.Errorf("content = %v, want %q", data["content"], "A leaf block with no children")
+	}
+
+	// Children should be absent or null for a leaf block (omitempty in JSON tags).
+	if children, exists := data["children"]; exists && children != nil {
+		childArr, ok := children.([]any)
+		if ok && len(childArr) > 0 {
+			t.Errorf("leaf block should have no children, got %d", len(childArr))
+		}
+	}
+
+	// parsed field should still be present even for leaf blocks.
+	if _, ok := data["parsed"].(map[string]any); !ok {
+		t.Errorf("parsed field missing or not an object, got %T", data["parsed"])
 	}
 }
 
@@ -363,9 +609,22 @@ func TestTraverse_NoPath(t *testing.T) {
 
 func TestListPages_DefaultParams(t *testing.T) {
 	mb := newMockBackend()
-	mb.addPage(types.PageEntity{Name: "alpha", OriginalName: "Alpha"})
-	mb.addPage(types.PageEntity{Name: "beta", OriginalName: "Beta"})
-	mb.addPage(types.PageEntity{Name: "gamma", OriginalName: "Gamma"})
+	mb.addPage(types.PageEntity{
+		Name:         "alpha",
+		OriginalName: "Alpha",
+		Properties:   map[string]any{"status": "active"},
+		UpdatedAt:    1700000000,
+	})
+	mb.addPage(types.PageEntity{
+		Name:         "beta",
+		OriginalName: "Beta",
+		Journal:      true,
+		UpdatedAt:    1700000100,
+	})
+	mb.addPage(types.PageEntity{
+		Name:         "gamma",
+		OriginalName: "Gamma",
+	})
 	nav := NewNavigate(mb)
 
 	result, _, err := nav.ListPages(context.Background(), nil, types.ListPagesInput{})
@@ -382,18 +641,63 @@ func TestListPages_DefaultParams(t *testing.T) {
 		t.Fatalf("unmarshal result: %v", err)
 	}
 
-	// Should return all 3 pages sorted by name.
+	// --- Assert pages count matches expected ---
 	if len(parsed) != 3 {
 		t.Fatalf("expected 3 pages, got %d", len(parsed))
 	}
-	if parsed[0]["name"] != "Alpha" {
-		t.Errorf("first page name = %v, want %q", parsed[0]["name"], "Alpha")
+
+	// --- Assert each page entry has required fields with correct types ---
+	for i, page := range parsed {
+		// name field must be present and be a string.
+		nameVal, ok := page["name"]
+		if !ok {
+			t.Errorf("pages[%d] missing 'name' field", i)
+		} else if _, isStr := nameVal.(string); !isStr {
+			t.Errorf("pages[%d].name is not a string, got %T", i, nameVal)
+		}
+
+		// journal field must be present (boolean).
+		if _, ok := page["journal"]; !ok {
+			t.Errorf("pages[%d] missing 'journal' field", i)
+		}
+
+		// properties field must be present (may be null).
+		if _, ok := page["properties"]; !ok {
+			t.Errorf("pages[%d] missing 'properties' field", i)
+		}
 	}
-	if parsed[1]["name"] != "Beta" {
-		t.Errorf("second page name = %v, want %q", parsed[1]["name"], "Beta")
+
+	// --- Assert pages are sorted by name (default sort) ---
+	wantOrder := []string{"Alpha", "Beta", "Gamma"}
+	for i, wantName := range wantOrder {
+		if parsed[i]["name"] != wantName {
+			t.Errorf("pages[%d].name = %v, want %q (sorted by name)", i, parsed[i]["name"], wantName)
+		}
 	}
-	if parsed[2]["name"] != "Gamma" {
-		t.Errorf("third page name = %v, want %q", parsed[2]["name"], "Gamma")
+
+	// --- Assert journal field values ---
+	if parsed[0]["journal"] != false {
+		t.Errorf("pages[0] (Alpha) journal = %v, want false", parsed[0]["journal"])
+	}
+	if parsed[1]["journal"] != true {
+		t.Errorf("pages[1] (Beta) journal = %v, want true", parsed[1]["journal"])
+	}
+
+	// --- Assert properties are passed through ---
+	props, ok := parsed[0]["properties"].(map[string]any)
+	if !ok {
+		t.Fatalf("pages[0].properties is not an object, got %T", parsed[0]["properties"])
+	}
+	if props["status"] != "active" {
+		t.Errorf("pages[0].properties.status = %v, want %q", props["status"], "active")
+	}
+
+	// --- Assert updatedAt is present only when > 0 ---
+	if _, ok := parsed[0]["updatedAt"]; !ok {
+		t.Error("pages[0] (Alpha) should have 'updatedAt' since UpdatedAt > 0")
+	}
+	if _, ok := parsed[2]["updatedAt"]; ok {
+		t.Error("pages[2] (Gamma) should not have 'updatedAt' since UpdatedAt is 0")
 	}
 }
 
@@ -563,6 +867,10 @@ func TestListPages_GetAllPagesError(t *testing.T) {
 	}
 	if !result.IsError {
 		t.Fatal("expected error result when GetAllPages fails")
+	}
+	text := extractText(t, result)
+	if !strings.Contains(text, "failed to list pages") {
+		t.Errorf("error message should contain 'failed to list pages', got: %s", text)
 	}
 }
 

--- a/tools/semantic.go
+++ b/tools/semantic.go
@@ -86,16 +86,8 @@ func (s *Semantic) SemanticSearch(ctx context.Context, req *mcp.CallToolRequest,
 // is provided, the embedder is unavailable, no embeddings exist in the
 // index, or the referenced page/block has no embedding.
 func (s *Semantic) Similar(ctx context.Context, req *mcp.CallToolRequest, input types.SimilarInput) (*mcp.CallToolResult, any, error) {
-	// Validate: at least one of page or uuid must be provided.
-	if input.Page == "" && input.UUID == "" {
-		return errorResult("At least one of 'page' or 'uuid' must be provided."), nil, nil
-	}
-
-	if s.embedder == nil || !s.embedder.Available() {
-		return errorResult("Semantic search unavailable: embedding model not loaded. Ensure Ollama is running with the configured model."), nil, nil
-	}
-	if s.store == nil {
-		return errorResult("Semantic search unavailable: no persistent store configured."), nil, nil
+	if errResult := s.validateSimilarInput(input); errResult != nil {
+		return errResult, nil, nil
 	}
 
 	limit := input.Limit
@@ -105,57 +97,84 @@ func (s *Semantic) Similar(ctx context.Context, req *mcp.CallToolRequest, input 
 
 	modelID := s.embedder.ModelID()
 
-	// Check if any embeddings exist at all.
-	count, err := s.store.CountEmbeddings()
-	if err != nil {
-		return errorResult(fmt.Sprintf("Failed to check embeddings: %v", err)), nil, nil
-	}
-	if count == 0 {
-		return errorResult("No embeddings in index. Run `dewey index` to generate embeddings."), nil, nil
+	queryVec, errResult := s.resolveQueryVector(ctx, input, modelID)
+	if errResult != nil {
+		return errResult, nil, nil
 	}
 
-	var queryVec []float32
-
-	if input.UUID != "" {
-		// Look up embedding by block UUID.
-		emb, err := s.store.GetEmbedding(input.UUID, modelID)
-		if err != nil {
-			return errorResult(fmt.Sprintf("Failed to look up embedding: %v", err)), nil, nil
-		}
-		if emb == nil {
-			return errorResult(fmt.Sprintf("No embedding found for %s. Run `dewey index` to generate embeddings.", input.UUID)), nil, nil
-		}
-		queryVec = emb.Vector
-	} else {
-		// Look up by page name — find the first block's embedding.
-		blocks, err := s.store.GetBlocksByPage(input.Page)
-		if err != nil || len(blocks) == 0 {
-			return errorResult(fmt.Sprintf("Page/block not found: %s", input.Page)), nil, nil
-		}
-
-		// Find the first block that has an embedding.
-		for _, block := range blocks {
-			emb, err := s.store.GetEmbedding(block.UUID, modelID)
-			if err == nil && emb != nil {
-				queryVec = emb.Vector
-				break
-			}
-		}
-		if queryVec == nil {
-			return errorResult(fmt.Sprintf("No embedding found for %s. Run `dewey index` to generate embeddings.", input.Page)), nil, nil
-		}
-	}
-
-	// Search for similar blocks.
 	results, err := s.store.SearchSimilar(modelID, queryVec, limit+1, 0.0)
 	if err != nil {
 		return errorResult(fmt.Sprintf("Search failed: %v", err)), nil, nil
 	}
 
-	// Filter out the query document itself from results.
+	filtered := filterSimilarResults(results, input.UUID, limit)
+	output := toSemanticResults(filtered)
+
+	res, err := jsonTextResult(output)
+	return res, nil, err
+}
+
+// validateSimilarInput checks that the input has at least one identifier
+// and that the embedder and store are available. Returns an error result
+// or nil if validation passes.
+func (s *Semantic) validateSimilarInput(input types.SimilarInput) *mcp.CallToolResult {
+	if input.Page == "" && input.UUID == "" {
+		return errorResult("At least one of 'page' or 'uuid' must be provided.")
+	}
+	if s.embedder == nil || !s.embedder.Available() {
+		return errorResult("Semantic search unavailable: embedding model not loaded. Ensure Ollama is running with the configured model.")
+	}
+	if s.store == nil {
+		return errorResult("Semantic search unavailable: no persistent store configured.")
+	}
+	return nil
+}
+
+// resolveQueryVector looks up the embedding vector for the given input,
+// either by block UUID or by finding the first embedded block for a page.
+// Returns the vector or an error result.
+func (s *Semantic) resolveQueryVector(_ context.Context, input types.SimilarInput, modelID string) ([]float32, *mcp.CallToolResult) {
+	// Check if any embeddings exist at all.
+	count, err := s.store.CountEmbeddings()
+	if err != nil {
+		return nil, errorResult(fmt.Sprintf("Failed to check embeddings: %v", err))
+	}
+	if count == 0 {
+		return nil, errorResult("No embeddings in index. Run `dewey index` to generate embeddings.")
+	}
+
+	if input.UUID != "" {
+		emb, err := s.store.GetEmbedding(input.UUID, modelID)
+		if err != nil {
+			return nil, errorResult(fmt.Sprintf("Failed to look up embedding: %v", err))
+		}
+		if emb == nil {
+			return nil, errorResult(fmt.Sprintf("No embedding found for %s. Run `dewey index` to generate embeddings.", input.UUID))
+		}
+		return emb.Vector, nil
+	}
+
+	// Look up by page name — find the first block's embedding.
+	blocks, err := s.store.GetBlocksByPage(input.Page)
+	if err != nil || len(blocks) == 0 {
+		return nil, errorResult(fmt.Sprintf("Page/block not found: %s", input.Page))
+	}
+
+	for _, block := range blocks {
+		emb, err := s.store.GetEmbedding(block.UUID, modelID)
+		if err == nil && emb != nil {
+			return emb.Vector, nil
+		}
+	}
+	return nil, errorResult(fmt.Sprintf("No embedding found for %s. Run `dewey index` to generate embeddings.", input.Page))
+}
+
+// filterSimilarResults removes the query document from results and enforces
+// the limit. This is a pure function with no side effects.
+func filterSimilarResults(results []store.SimilarityResult, excludeUUID string, limit int) []store.SimilarityResult {
 	filtered := make([]store.SimilarityResult, 0, len(results))
 	for _, r := range results {
-		if r.BlockUUID == input.UUID {
+		if r.BlockUUID == excludeUUID {
 			continue
 		}
 		filtered = append(filtered, r)
@@ -163,11 +182,7 @@ func (s *Semantic) Similar(ctx context.Context, req *mcp.CallToolRequest, input 
 	if len(filtered) > limit {
 		filtered = filtered[:limit]
 	}
-
-	output := toSemanticResults(filtered)
-
-	res, err := jsonTextResult(output)
-	return res, nil, err
+	return filtered
 }
 
 // SemanticSearchFiltered handles the dewey_semantic_search_filtered MCP


### PR DESCRIPTION
## Summary

- Add 4 health tool tests via MCP in-memory transport, covering nil/non-nil store, embedder, and ping error configurations
- Decompose `newIndexCmd` (extract `indexDocuments`, `reportSourceErrors`) and `newStatusCmd` (extract `statusData`, `queryStoreStatus`, `formatStatusText/JSON`) in cli.go
- Decompose `(*Semantic).Similar` into `validateSimilarInput`, `resolveQueryVector`, `filterSimilarResults` (complexity 22 → 8 per method)
- Strengthen navigate test contracts for `GetPage`, `GetBlock`, `ListPages` with structural assertions

## Motivation

Post-ratchet-1 Gaze report showed `registerHealthTool` at CRAP 67.5 (created by the ratchet-1 decomposition with only 2.4% coverage), GazeCRAPload at the CI gate boundary (34/34), and no headroom. This ratchet eliminates the health tool gap and reduces complexity in the next tier of offenders.

## Results

| Metric | Before | After | CI Gate |
|--------|--------|-------|---------|
| CRAPload | 13 | **10** | ≤15 |
| GazeCRAPload | 34 | **33** | ≤34 |
| Root coverage | 77.3% | **83.8%** | — |
| Q4 Dangerous | 4 | **3** | — |

## Verification

- `go build ./...` — PASS
- `go vet ./...` — PASS
- `go test -race -count=1 ./...` — 11 packages PASS
- `gaze crap --max-crapload=15 --max-gaze-crapload=34` — both PASS

No behavioral changes. All 40 MCP tools produce identical results.