### PR TITLE
refactor: quality ratchet 3 — RenamePage, source CLI, DiskSource decomposition

### DIFF
--- a/cli.go
+++ b/cli.go
@@ -755,92 +755,22 @@ Examples:
 			}
 
 			var newSource source.SourceConfig
+			var buildErr error
 
 			switch sourceType {
 			case "github":
-				if org == "" {
-					return fmt.Errorf("--org is required for github source")
-				}
-				if repos == "" {
-					return fmt.Errorf("--repos is required for github source")
-				}
-
-				repoList := strings.Split(repos, ",")
-				for i := range repoList {
-					repoList[i] = strings.TrimSpace(repoList[i])
-				}
-
-				contentTypes := []string{"issues", "pulls", "readme"}
-				if content != "" {
-					contentTypes = strings.Split(content, ",")
-					for i := range contentTypes {
-						contentTypes[i] = strings.TrimSpace(contentTypes[i])
-					}
-				}
-
-				if refresh == "" {
-					refresh = "daily"
-				}
-
-				sourceID := fmt.Sprintf("github-%s", org)
-				newSource = source.SourceConfig{
-					ID:              sourceID,
-					Type:            "github",
-					Name:            org,
-					RefreshInterval: refresh,
-					Config: map[string]any{
-						"org":     org,
-						"repos":   repoList,
-						"content": contentTypes,
-					},
-				}
-
+				newSource, buildErr = buildGitHubSource(org, repos, content, refresh)
 			case "web":
-				if webURL == "" {
-					return fmt.Errorf("--url is required for web source")
-				}
-
-				name := webName
-				if name == "" {
-					// Derive name from URL hostname.
-					name = strings.TrimPrefix(webURL, "https://")
-					name = strings.TrimPrefix(name, "http://")
-					if idx := strings.Index(name, "/"); idx > 0 {
-						name = name[:idx]
-					}
-				}
-
-				if refresh == "" {
-					refresh = "weekly"
-				}
-
-				sourceID := fmt.Sprintf("web-%s", name)
-				newSource = source.SourceConfig{
-					ID:              sourceID,
-					Type:            "web",
-					Name:            name,
-					RefreshInterval: refresh,
-					Config: map[string]any{
-						"urls":  []string{webURL},
-						"depth": depth,
-					},
-				}
-
+				newSource, buildErr = buildWebSource(webURL, webName, refresh, depth)
 			default:
 				return fmt.Errorf("unknown source type %q (use github or web)", sourceType)
 			}
-
-			// Check for duplicate source.
-			for _, src := range existing {
-				if src.ID == newSource.ID {
-					return fmt.Errorf("source %s already exists", newSource.ID)
-				}
+			if buildErr != nil {
+				return buildErr
 			}
 
-			// Append and save.
-			existing = append(existing, newSource)
-			if err := source.SaveSourcesConfig(sourcesPath, existing); err != nil {
-				return fmt.Errorf("save sources config: %w", err)
+			if err := saveSourceConfig(sourcesPath, existing, newSource); err != nil {
+				return err
 			}
 
 			logger.Info("added source",
@@ -866,4 +796,90 @@ Examples:
 	cmd.Flags().IntVar(&depth, "depth", 1, "Crawl depth")
 
 	return cmd
+}
+
+// buildGitHubSource validates inputs and creates a SourceConfig for a GitHub source.
+func buildGitHubSource(org, repos, content, refresh string) (source.SourceConfig, error) {
+	if org == "" {
+		return source.SourceConfig{}, fmt.Errorf("--org is required for github source")
+	}
+	if repos == "" {
+		return source.SourceConfig{}, fmt.Errorf("--repos is required for github source")
+	}
+
+	repoList := strings.Split(repos, ",")
+	for i := range repoList {
+		repoList[i] = strings.TrimSpace(repoList[i])
+	}
+
+	contentTypes := []string{"issues", "pulls", "readme"}
+	if content != "" {
+		contentTypes = strings.Split(content, ",")
+		for i := range contentTypes {
+			contentTypes[i] = strings.TrimSpace(contentTypes[i])
+		}
+	}
+
+	if refresh == "" {
+		refresh = "daily"
+	}
+
+	return source.SourceConfig{
+		ID:              fmt.Sprintf("github-%s", org),
+		Type:            "github",
+		Name:            org,
+		RefreshInterval: refresh,
+		Config: map[string]any{
+			"org":     org,
+			"repos":   repoList,
+			"content": contentTypes,
+		},
+	}, nil
+}
+
+// buildWebSource validates inputs and creates a SourceConfig for a web crawl source.
+func buildWebSource(webURL, webName, refresh string, depth int) (source.SourceConfig, error) {
+	if webURL == "" {
+		return source.SourceConfig{}, fmt.Errorf("--url is required for web source")
+	}
+
+	name := webName
+	if name == "" {
+		name = strings.TrimPrefix(webURL, "https://")
+		name = strings.TrimPrefix(name, "http://")
+		if idx := strings.Index(name, "/"); idx > 0 {
+			name = name[:idx]
+		}
+	}
+
+	if refresh == "" {
+		refresh = "weekly"
+	}
+
+	return source.SourceConfig{
+		ID:              fmt.Sprintf("web-%s", name),
+		Type:            "web",
+		Name:            name,
+		RefreshInterval: refresh,
+		Config: map[string]any{
+			"urls":  []string{webURL},
+			"depth": depth,
+		},
+	}, nil
+}
+
+// saveSourceConfig checks for duplicate source IDs, appends the new source,
+// and saves the updated config to the YAML file.
+func saveSourceConfig(sourcesPath string, existing []source.SourceConfig, newSource source.SourceConfig) error {
+	for _, src := range existing {
+		if src.ID == newSource.ID {
+			return fmt.Errorf("source %s already exists", newSource.ID)
+		}
+	}
+
+	existing = append(existing, newSource)
+	if err := source.SaveSourcesConfig(sourcesPath, existing); err != nil {
+		return fmt.Errorf("save sources config: %w", err)
+	}
+	return nil
 }

--- a/cli_test.go
+++ b/cli_test.go
@@ -14,6 +14,8 @@ import (
 	"time"
 
 	"github.com/unbound-force/dewey/client"
+	"github.com/unbound-force/dewey/source"
+	"github.com/unbound-force/dewey/store"
 	"github.com/unbound-force/dewey/types"
 )
 
@@ -1930,5 +1932,206 @@ func TestCheckGraphVersionControl_EmptyPath(t *testing.T) {
 
 	if strings.Contains(logBuf.String(), "not version controlled") {
 		t.Errorf("should not warn when path is empty, got:\n%s", logBuf.String())
+	}
+}
+
+// --- indexDocuments tests ---
+
+// TestIndexDocuments_InsertNew verifies that indexDocuments inserts a new page
+// into the store when no existing page matches the document title.
+func TestIndexDocuments_InsertNew(t *testing.T) {
+	s, err := store.New(":memory:")
+	if err != nil {
+		t.Fatalf("store.New: %v", err)
+	}
+	defer func() { _ = s.Close() }()
+
+	now := time.Now()
+	docs := map[string][]source.Document{
+		"test-src": {
+			{
+				ID:          "doc-001",
+				Title:       "My Test Page",
+				Content:     "some content",
+				ContentHash: "abc123",
+				FetchedAt:   now,
+			},
+		},
+	}
+
+	got := indexDocuments(s, docs, nil)
+	if got != 1 {
+		t.Fatalf("indexDocuments() = %d, want 1", got)
+	}
+
+	page, err := s.GetPage("My Test Page")
+	if err != nil {
+		t.Fatalf("GetPage: %v", err)
+	}
+	if page == nil {
+		t.Fatal("GetPage returned nil, want page")
+	}
+	if page.Name != "My Test Page" {
+		t.Errorf("page.Name = %q, want %q", page.Name, "My Test Page")
+	}
+	if page.ContentHash != "abc123" {
+		t.Errorf("page.ContentHash = %q, want %q", page.ContentHash, "abc123")
+	}
+	if page.SourceID != "test-src" {
+		t.Errorf("page.SourceID = %q, want %q", page.SourceID, "test-src")
+	}
+	if page.SourceDocID != "doc-001" {
+		t.Errorf("page.SourceDocID = %q, want %q", page.SourceDocID, "doc-001")
+	}
+}
+
+// TestIndexDocuments_UpdateExisting verifies that indexDocuments updates an
+// existing page's ContentHash when the document title matches.
+func TestIndexDocuments_UpdateExisting(t *testing.T) {
+	s, err := store.New(":memory:")
+	if err != nil {
+		t.Fatalf("store.New: %v", err)
+	}
+	defer func() { _ = s.Close() }()
+
+	// Pre-insert a page with the old content hash.
+	if err := s.InsertPage(&store.Page{
+		Name:         "Existing Page",
+		OriginalName: "Existing Page",
+		ContentHash:  "old-hash",
+		SourceID:     "old-src",
+		SourceDocID:  "old-doc",
+	}); err != nil {
+		t.Fatalf("InsertPage: %v", err)
+	}
+
+	docs := map[string][]source.Document{
+		"new-src": {
+			{
+				ID:          "new-doc",
+				Title:       "Existing Page",
+				Content:     "updated content",
+				ContentHash: "new-hash",
+				FetchedAt:   time.Now(),
+			},
+		},
+	}
+
+	got := indexDocuments(s, docs, nil)
+	if got != 1 {
+		t.Fatalf("indexDocuments() = %d, want 1", got)
+	}
+
+	page, err := s.GetPage("Existing Page")
+	if err != nil {
+		t.Fatalf("GetPage: %v", err)
+	}
+	if page == nil {
+		t.Fatal("GetPage returned nil, want page")
+	}
+	if page.ContentHash != "new-hash" {
+		t.Errorf("page.ContentHash = %q, want %q", page.ContentHash, "new-hash")
+	}
+	if page.SourceID != "new-src" {
+		t.Errorf("page.SourceID = %q, want %q (should be updated)", page.SourceID, "new-src")
+	}
+	if page.SourceDocID != "new-doc" {
+		t.Errorf("page.SourceDocID = %q, want %q (should be updated)", page.SourceDocID, "new-doc")
+	}
+}
+
+// TestIndexDocuments_SourceRecord verifies that indexDocuments creates a source
+// record in the store when a matching SourceConfig is provided.
+func TestIndexDocuments_SourceRecord(t *testing.T) {
+	s, err := store.New(":memory:")
+	if err != nil {
+		t.Fatalf("store.New: %v", err)
+	}
+	defer func() { _ = s.Close() }()
+
+	docs := map[string][]source.Document{
+		"test-src": {
+			{
+				ID:          "doc-1",
+				Title:       "Source Doc",
+				ContentHash: "hash1",
+				FetchedAt:   time.Now(),
+			},
+		},
+	}
+	configs := []source.SourceConfig{
+		{
+			ID:   "test-src",
+			Type: "github",
+			Name: "my-github",
+		},
+	}
+
+	indexDocuments(s, docs, configs)
+
+	src, err := s.GetSource("test-src")
+	if err != nil {
+		t.Fatalf("GetSource: %v", err)
+	}
+	if src == nil {
+		t.Fatal("GetSource returned nil, want source record")
+	}
+	if src.Type != "github" {
+		t.Errorf("src.Type = %q, want %q", src.Type, "github")
+	}
+	if src.Status != "active" {
+		t.Errorf("src.Status = %q, want %q", src.Status, "active")
+	}
+}
+
+// TestIndexDocuments_WithProperties verifies that indexDocuments serializes
+// document Properties to JSON and stores them on the page.
+func TestIndexDocuments_WithProperties(t *testing.T) {
+	s, err := store.New(":memory:")
+	if err != nil {
+		t.Fatalf("store.New: %v", err)
+	}
+	defer func() { _ = s.Close() }()
+
+	docs := map[string][]source.Document{
+		"prop-src": {
+			{
+				ID:          "doc-props",
+				Title:       "Props Page",
+				ContentHash: "hash-props",
+				FetchedAt:   time.Now(),
+				Properties: map[string]any{
+					"type":   "issue",
+					"status": "open",
+				},
+			},
+		},
+	}
+
+	got := indexDocuments(s, docs, nil)
+	if got != 1 {
+		t.Fatalf("indexDocuments() = %d, want 1", got)
+	}
+
+	page, err := s.GetPage("Props Page")
+	if err != nil {
+		t.Fatalf("GetPage: %v", err)
+	}
+	if page == nil {
+		t.Fatal("GetPage returned nil, want page")
+	}
+	if page.Properties == "" {
+		t.Fatal("page.Properties is empty, want JSON")
+	}
+
+	var props map[string]any
+	if err := json.Unmarshal([]byte(page.Properties), &props); err != nil {
+		t.Fatalf("unmarshal Properties: %v", err)
+	}
+	if props["type"] != "issue" {
+		t.Errorf("props[\"type\"] = %v, want %q", props["type"], "issue")
+	}
+	if props["status"] != "open" {
+		t.Errorf("props[\"status\"] = %v, want %q", props["status"], "open")
 	}
 }

--- a/openspec/changes/gaze-quality-ratchet-3/.openspec.yaml
+++ b/openspec/changes/gaze-quality-ratchet-3/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: unbound-force
+created: 2026-03-27

--- a/openspec/changes/gaze-quality-ratchet-3/design.md
+++ b/openspec/changes/gaze-quality-ratchet-3/design.md
@@ -1,0 +1,77 @@
+## Context
+
+Two quality ratchets have reduced CRAPload from 15 to 10 and GazeCRAPload from 34 to 33. The remaining top-5 functions are dominated by complexity rather than coverage gaps, requiring decomposition. One function (`indexDocuments`) was newly extracted in ratchet-2 and needs test coverage. One tool (`GetWhiteboard`) has the worst GazeCRAP in the project (85.7) due to assertion structure that Gaze's mapper can't trace.
+
+Per the proposal's constitution alignment: N/A for Autonomous Collaboration, PASS for Composability First, Observable Quality, and Testability.
+
+## Goals / Non-Goals
+
+### Goals
+- Reduce CRAPload from 10 to <=7 by decomposing `RenamePage`, `newSourceAddCmd`, and `DiskSource.Diff`
+- Reduce GazeCRAPload from 33 to <=28 by restructuring whiteboard test assertions and adding `indexDocuments` tests
+- Eliminate all Q4 Dangerous functions that are addressable in this iteration
+
+### Non-Goals
+- Changing external MCP tool behavior or API contracts
+- Refactoring functions below the top 5 (e.g., `PrependBlockInPage`, `crawl`, `parseDecisionBlock`)
+- Adding new test infrastructure or frameworks
+
+## Decisions
+
+### 1. Decomposition pattern for `RenamePage` (vault/vault.go:981, complexity 17)
+
+Extract four private methods:
+- `renameFile(oldPath, newAbsPath string) error` — creates target directory and renames the file
+- `reindexRenamed(newRelPath, newAbsPath string)` — reads the renamed file and re-indexes it (called within the existing lock)
+- `cleanupEmptyDirs(startDir, vaultAbs string)` — walks up from the old file's directory removing empty directories
+
+The validation (name length, null bytes, page existence, target conflict) and path computation remain in `RenamePage`. The link-update call (`updateLinksAcrossVaultLocked`) is already a separate method and stays as-is.
+
+**Rationale**: The complexity comes from four distinct phases: validation → file rename → link update → index rebuild → cleanup. Each phase is independently testable. The lock scope stays in `RenamePage` since all phases need the lock.
+
+### 2. Decomposition pattern for `newSourceAddCmd` (cli.go:714, complexity 19)
+
+Extract three private functions:
+- `buildGitHubSource(org, repos, content, refresh string) (source.SourceConfig, error)` — validates required fields, parses repo/content lists, returns populated config
+- `buildWebSource(webURL, webName, refresh string, depth int) (source.SourceConfig, error)` — validates URL, derives name, returns populated config
+- `saveSourceConfig(sourcesPath string, existing []source.SourceConfig, newSource source.SourceConfig) error` — checks for duplicates, appends, and saves
+
+The RunE becomes: get working dir → load existing → build config by type → save → log.
+
+**Rationale**: The complexity comes from the `switch sourceType` block with two branches of validation + config construction, plus the duplicate check and save. Extracting per-type builders eliminates the switch branching from the orchestrator.
+
+### 3. Test strategy for `indexDocuments` (cli.go:624, complexity 10)
+
+Add tests in `cli_test.go` covering:
+- Insert new page: verify `s.GetPage()` returns the inserted page with correct fields
+- Update existing page: insert a page first, call `indexDocuments` with same title but different hash, verify update
+- Source record creation: verify `s.GetSource()` returns the new source after indexing
+- Properties marshaling: provide a document with `Properties` map, verify the page's `Properties` field is valid JSON
+
+Test infrastructure: use in-memory SQLite (`store.New(":memory:")`), create `source.Document` structs with `time.Now()` for `FetchedAt`.
+
+**Rationale**: The function was extracted during ratchet-2 and has 61.3% coverage from the parent test. Dedicated unit tests will push coverage above 85% and bring CRAP below 15.
+
+### 4. Whiteboard assertion restructuring
+
+The current `TestGetWhiteboard` tests parse the JSON output string and assert on the parsed map. Gaze's contract mapper can't trace assertions through `json.Unmarshal` because the function return is `*mcp.CallToolResult` (an opaque struct with a `Content` field).
+
+The fix: keep the JSON parsing but add explicit assertions on the parsed map's fields using direct map key access with type assertions, ensuring each side effect (embedded pages, connections, element count) has a dedicated `t.Errorf` call that Gaze can map to the function's observable outputs.
+
+**Rationale**: The issue isn't assertion count — the test already has 15+ assertions. The issue is assertion structure. Gaze maps assertions to side effects by tracing the return value through the test. Assertions that go through helper functions or intermediate variables lose traceability. Direct `if parsed["embeddedPages"]` assertions are traceable.
+
+### 5. Decomposition pattern for `(*DiskSource).Diff` (source/disk.go:121, complexity 15)
+
+Extract two private functions matching the ratchet-1 pattern:
+- `walkDiskFiles(basePath string) (map[string]string, error)` — walks the directory, skips hidden dirs and non-.md files, returns relPath → hash map
+- `diffFileChanges(currentFiles, storedHashes map[string]string, fetcher func(string) (Document, error)) []Change` — compares hashes, fetches changed/new docs, returns categorized changes
+
+The outer `Diff` becomes: walk → diff → return.
+
+**Rationale**: This mirrors the `walkVault`/`diffPages` pattern from ratchet-1. The walk is pure I/O, the diff is pure comparison logic. Both are independently testable.
+
+## Risks / Trade-offs
+
+- **RenamePage lock scope**: All extracted methods run within the existing `c.mu.Lock()`. The methods themselves don't acquire locks, which is correct but means they can't be called from unlocked contexts. GoDoc must document this clearly.
+- **Whiteboard assertion restructuring may not fully satisfy Gaze**: The mapper's traceability depends on its SSA analysis quality. If restructured assertions still don't register, the GazeCRAP score won't improve. Mitigated by verifying with `gaze quality` after changes.
+- **indexDocuments test isolation**: The function calls `logger.Warn` for failures, which writes to stderr. Tests should redirect or accept this output. Not a blocker.

--- a/openspec/changes/gaze-quality-ratchet-3/proposal.md
+++ b/openspec/changes/gaze-quality-ratchet-3/proposal.md
@@ -1,0 +1,76 @@
+## Why
+
+The second quality ratchet (PR #6) reduced CRAPload from 13 to 10 and GazeCRAPload from 34 to 33, establishing headroom below the CI gates (15/34). However, 10 functions still exceed the CRAP threshold of 15, and 3 remain in the Q4 Dangerous quadrant. The worst CRAP scores are now dominated by complexity rather than coverage gaps, indicating the remaining work is decomposition-focused.
+
+Five prioritized issues from the post-ratchet-2 Gaze report:
+
+1. `(*Client).RenamePage` (vault/vault.go:981) — CRAP 22.6, complexity 17 (Q4 Dangerous). Despite 100% contract coverage, complexity alone drives the score above threshold.
+2. `newSourceAddCmd` (cli.go:714) — CRAP 21.6, complexity 19. Monolithic CLI command with interleaved validation, config construction, and YAML writing.
+3. `indexDocuments` (cli.go:624) — CRAP 15.8, complexity 10, 61.3% coverage. Extracted during ratchet-2 but lacks dedicated tests.
+4. `(*Whiteboard).GetWhiteboard` (tools/whiteboard.go:90) — GazeCRAP 85.7 (worst in project), 100% line coverage but only 20% contract coverage. Existing tests assert through JSON output, which Gaze's mapper can't trace.
+5. `(*DiskSource).Diff` (source/disk.go:121) — CRAP 15.7, complexity 15 (Q4 Dangerous), GazeCRAP 23.3.
+
+Target: reduce CRAPload from 10 to <=7 and GazeCRAPload from 33 to <=28.
+
+## What Changes
+
+1. **Decompose `RenamePage`** — Extract file-rename I/O, link-update traversal, index-rebuild, and empty-directory cleanup into separate private methods.
+2. **Decompose `newSourceAddCmd`** — Extract source config builders (`buildGitHubSource`, `buildWebSource`) and the save-with-dedup logic into private functions.
+3. **Add tests for `indexDocuments`** — Dedicated tests with in-memory store verifying page insert, page update, source record creation, and properties marshaling.
+4. **Restructure whiteboard test assertions** — Bypass JSON serialization and assert directly on the return map fields so Gaze's contract mapper can trace them.
+5. **Decompose `(*DiskSource).Diff`** — Extract `walkDiskFiles` (filesystem scan) and `diffFileChanges` (hash comparison) matching the `walkVault`/`diffPages` pattern from ratchet-1.
+
+## Capabilities
+
+### New Capabilities
+- None
+
+### Modified Capabilities
+- `vault-rename`: `RenamePage` split into file-rename, link-update, index-rebuild, and cleanup phases
+- `source-add-command`: `newSourceAddCmd` refactored with per-type config builders and save helper
+- `index-documents-coverage`: `indexDocuments` gains dedicated test coverage
+- `whiteboard-test-contracts`: Whiteboard test assertions restructured for Gaze mapper visibility
+- `disk-source-diff`: `DiskSource.Diff` split into walk and comparison phases
+
+### Removed Capabilities
+- None
+
+## Impact
+
+| File | Change Type | Risk |
+| ---- | ----------- | ---- |
+| `vault/vault.go` | Decompose `RenamePage` | Medium — touches rename logic with file I/O, requires careful phase extraction |
+| `cli.go` | Decompose `newSourceAddCmd` | Low — internal refactor, no API change |
+| `cli_test.go` | Add `indexDocuments` tests | Low — test-only |
+| `tools/whiteboard_test.go` | Restructure assertions | Low — test-only, no production changes |
+| `source/disk.go` | Decompose `Diff` | Low — internal refactor, well-established pattern |
+
+No external API changes. No new dependencies. No behavioral changes. All 40 MCP tools produce identical results.
+
+## Constitution Alignment
+
+Assessed against the Unbound Force org constitution.
+
+### I. Autonomous Collaboration
+
+**Assessment**: N/A
+
+Internal quality improvement. No MCP tool contracts or inter-hero communication affected.
+
+### II. Composability First
+
+**Assessment**: PASS
+
+No new dependencies. All refactoring is internal to existing packages. Dewey remains independently installable.
+
+### III. Observable Quality
+
+**Assessment**: PASS
+
+Directly improves observable quality by reducing CRAPload and GazeCRAPload, creating further headroom below CI gates.
+
+### IV. Testability
+
+**Assessment**: PASS
+
+Decomposed functions are individually testable. The `indexDocuments` test gap is explicitly addressed. Whiteboard assertion restructuring improves Gaze's ability to measure contract coverage.

--- a/openspec/changes/gaze-quality-ratchet-3/specs/quality-ratchet-3.md
+++ b/openspec/changes/gaze-quality-ratchet-3/specs/quality-ratchet-3.md
@@ -1,0 +1,115 @@
+## ADDED Requirements
+
+### Requirement: Decomposed RenamePage
+
+The `(*Client).RenamePage` method in `vault/vault.go` MUST decompose its file-rename, index-rebuild, and cleanup phases into private methods.
+
+#### Scenario: File rename phase handles directory creation
+- **GIVEN** a page being renamed to a path with non-existent parent directories
+- **WHEN** the rename file phase executes
+- **THEN** it MUST create the target directory and rename the file atomically
+
+#### Scenario: Reindex phase reads and indexes the renamed file
+- **GIVEN** a file has been successfully renamed
+- **WHEN** the reindex phase executes
+- **THEN** it MUST read the file content, index it under the new name, and rebuild backlinks
+
+#### Scenario: Cleanup phase removes empty directories
+- **GIVEN** a rename that leaves the old file's directory empty
+- **WHEN** the cleanup phase executes
+- **THEN** it MUST walk up from the old directory removing empty directories until it reaches the vault root or a non-empty directory
+
+#### Scenario: RenamePage produces identical results after decomposition
+- **GIVEN** a vault with known files and link structure
+- **WHEN** `RenamePage` is called before and after refactoring
+- **THEN** the resulting file structure, link updates, and index state MUST be identical
+
+### Requirement: Decomposed Source Add Command
+
+The `newSourceAddCmd` function in `cli.go` MUST extract per-type source config builders and save logic into private functions.
+
+#### Scenario: GitHub source builder validates required fields
+- **GIVEN** a call with `sourceType == "github"` and `--org` empty
+- **WHEN** the builder is called
+- **THEN** it MUST return an error indicating `--org is required`
+
+#### Scenario: Web source builder derives name from URL
+- **GIVEN** a call with `--url https://pkg.go.dev/std` and `--name` empty
+- **WHEN** the builder is called
+- **THEN** it MUST derive the name as `"pkg.go.dev"` from the URL hostname
+
+#### Scenario: Save helper rejects duplicate sources
+- **GIVEN** an existing sources list containing source ID `"github-org"`
+- **WHEN** the save helper is called with a new source having the same ID
+- **THEN** it MUST return an error indicating the source already exists
+
+### Requirement: indexDocuments Test Coverage
+
+The `indexDocuments` function in `cli.go` MUST have dedicated test coverage verifying page upsert and source record operations.
+
+#### Scenario: Insert new page from document
+- **GIVEN** an in-memory store with no existing pages
+- **WHEN** `indexDocuments` is called with one document
+- **THEN** the store MUST contain a page with the document's title, content hash, source ID, and source doc ID
+
+#### Scenario: Update existing page
+- **GIVEN** an in-memory store with an existing page
+- **WHEN** `indexDocuments` is called with a document having the same title but different content hash
+- **THEN** the page's content hash MUST be updated to the new value
+
+#### Scenario: Source record creation
+- **GIVEN** documents from a source not yet in the store
+- **WHEN** `indexDocuments` completes
+- **THEN** a source record MUST exist with the correct type and status
+
+#### Scenario: Properties marshaling
+- **GIVEN** a document with a non-nil Properties map
+- **WHEN** `indexDocuments` inserts the page
+- **THEN** the page's Properties field MUST contain valid JSON matching the original map
+
+### Requirement: Whiteboard Contract Assertion Restructuring
+
+Tests for `GetWhiteboard` in `tools/whiteboard_test.go` MUST structure assertions so that Gaze's contract mapper can trace them to observable side effects.
+
+#### Scenario: Assertions trace to embedded pages
+- **GIVEN** a mock backend with whiteboard blocks containing embedded page references
+- **WHEN** the test calls `GetWhiteboard` and parses the result
+- **THEN** the test MUST assert directly on the `embeddedPages` field of the parsed map with a dedicated `t.Errorf` call
+
+#### Scenario: Assertions trace to connections
+- **GIVEN** a mock backend with whiteboard blocks containing source/target connector properties
+- **WHEN** the test calls `GetWhiteboard` and parses the result
+- **THEN** the test MUST assert directly on the `connections` field with dedicated comparison assertions
+
+### Requirement: Decomposed DiskSource Diff
+
+The `(*DiskSource).Diff` method in `source/disk.go` MUST split its filesystem walk and hash comparison into private functions.
+
+#### Scenario: Walk phase returns file inventory
+- **GIVEN** a directory with markdown files and hidden directories
+- **WHEN** the walk phase executes
+- **THEN** it MUST return a map of relative paths to content hashes, skipping hidden directories and non-.md files
+
+#### Scenario: Diff phase categorizes changes
+- **GIVEN** current file hashes and stored hashes
+- **WHEN** the diff phase executes
+- **THEN** it MUST return changes categorized as added, modified, or deleted
+
+#### Scenario: Diff produces identical results after decomposition
+- **GIVEN** a disk source with known files and stored hashes
+- **WHEN** `Diff` is called before and after refactoring
+- **THEN** the returned changes MUST be identical
+
+## MODIFIED Requirements
+
+### Requirement: CI Quality Gate Headroom
+
+The project MUST maintain increasing headroom below CI quality gates. Previously: CRAPload=10 (gate: 15), GazeCRAPload=33 (gate: 34).
+
+Updated targets:
+- CRAPload MUST be <= 7 (down from 10)
+- GazeCRAPload MUST be <= 28 (down from 33)
+
+## REMOVED Requirements
+
+None.

--- a/openspec/changes/gaze-quality-ratchet-3/tasks.md
+++ b/openspec/changes/gaze-quality-ratchet-3/tasks.md
@@ -1,0 +1,50 @@
+# Tasks
+
+## 1. Decompose `RenamePage` (vault/vault.go)
+
+- [x] 1.1 Extract `renameFile(oldPath, newAbsPath string) error` — creates target directory with `os.MkdirAll` and renames the file with `os.Rename`
+- [x] 1.2 Extract `reindexRenamed(newRelPath, newAbsPath string)` — reads the renamed file content, stats it, and calls `indexFileCore` + `rebuildLinksLocked`
+- [x] 1.3 Extract `cleanupEmptyDirs(startDir, vaultAbs string)` — walks up from startDir removing empty directories until reaching vaultAbs or a non-empty directory
+- [x] 1.4 Refactor `RenamePage` into: validate → compute paths → renameFile → updateLinksAcrossVaultLocked → removePageFromIndexLocked → reindexRenamed → cleanupEmptyDirs
+- [x] 1.5 Run `go test -race -count=1 ./vault/...` and verify all existing tests pass
+- [x] 1.6 Run `gaze crap --format=json ./vault/...` and verify `RenamePage` CRAP score dropped below 15
+
+## 2. Decompose `newSourceAddCmd` (cli.go)
+
+- [x] 2.1 Extract `buildGitHubSource(org, repos, content, refresh string) (source.SourceConfig, error)` — validates required fields, parses comma-separated lists, returns populated SourceConfig
+- [x] 2.2 Extract `buildWebSource(webURL, webName, refresh string, depth int) (source.SourceConfig, error)` — validates URL, derives name from hostname if empty, returns populated SourceConfig
+- [x] 2.3 Extract `saveSourceConfig(sourcesPath string, existing []source.SourceConfig, newSource source.SourceConfig) error` — checks for duplicate source IDs, appends, and saves to YAML
+- [x] 2.4 Refactor `newSourceAddCmd` RunE into orchestrator: get cwd → load existing → switch type → build config → save → log
+- [x] 2.5 Run `go test -race -count=1 ./...` and verify all tests pass
+
+## 3. Add tests for `indexDocuments` (cli.go)
+
+- [x] 3.1 Add `TestIndexDocuments_InsertNew` — create in-memory store, call `indexDocuments` with one document, verify `s.GetPage()` returns page with correct title, content hash, source ID, and source doc ID
+- [x] 3.2 Add `TestIndexDocuments_UpdateExisting` — insert a page first, call `indexDocuments` with same title but different hash, verify page's content hash was updated
+- [x] 3.3 Add `TestIndexDocuments_SourceRecord` — call `indexDocuments` with documents from a new source, verify `s.GetSource()` returns a source record with correct type and status
+- [x] 3.4 Add `TestIndexDocuments_WithProperties` — call with document having non-nil Properties map, verify page's Properties field is valid JSON matching the map
+- [x] 3.5 Run `go test -race -count=1 ./...` and verify all tests pass
+
+## 4. Restructure whiteboard test assertions (tools/whiteboard_test.go)
+
+- [x] 4.1 Refactor `TestGetWhiteboard` assertions to use direct map field access with dedicated `t.Errorf` calls for `embeddedPages`, `connections`, `elementCount`, and `elements` fields
+- [x] 4.2 Add explicit type assertion checks: verify `embeddedPages` is `[]any`, `connections` is `[]any`, each connection has `source` and `target` string fields
+- [x] 4.3 Run `go test -race -count=1 ./tools/...` and verify all tests pass
+
+## 5. Decompose `(*DiskSource).Diff` (source/disk.go)
+
+- [x] 5.1 Extract `walkDiskFiles(basePath string) (map[string]string, error)` — walks directory, skips hidden dirs and non-.md files, returns relPath → content hash map
+- [x] 5.2 Extract `diffFileChanges(currentFiles, storedHashes map[string]string, fetcher func(string) (*Document, error)) []Change` — compares hashes, calls fetcher for added/modified files, returns categorized changes
+- [x] 5.3 Refactor `Diff` into orchestrator: walkDiskFiles → diffFileChanges → return
+- [x] 5.4 Add unit test for `walkDiskFiles` — verify it skips hidden dirs and non-.md files, returns correct hashes for .md files
+- [x] 5.5 Run `go test -race -count=1 ./source/...` and verify all tests pass
+- [x] 5.6 Run `gaze crap --format=json ./source/...` and verify `Diff` CRAP score dropped below 15
+
+## 6. Verification
+
+- [x] 6.1 Run full CI-equivalent checks: `go build ./... && go vet ./... && go test -race -count=1 ./...` — all 11 packages pass
+- [x] 6.2 Gaze threshold gate: CRAPload=6 (pass, gate 15), GazeCRAPload=31 (pass, gate 34)
+- [x] 6.3 CRAPload = 6 (target ≤7, EXCEEDED TARGET)
+- [x] 6.4 GazeCRAPload = 31 (target ≤28 not fully met, improved from 33, CI gate passes comfortably)
+- [x] 6.5 All tests pass including tool count assertions — 40 tools registered
+- [x] 6.6 Constitution alignment verified: Composability First (no new deps), Observable Quality (Gaze gates pass with significant headroom), Testability (all packages pass -race)

--- a/source/disk.go
+++ b/source/disk.go
@@ -118,10 +118,26 @@ func (d *DiskSource) Fetch(id string) (*Document, error) {
 // hashes against stored hashes. Uses the same SHA-256 algorithm as VaultStore.
 // Returns a slice of changes categorized as [ChangeAdded], [ChangeModified],
 // or [ChangeDeleted]. Returns an error if the directory walk fails.
+//
+// Decomposed into walkDiskFiles (directory scan) and diffFileChanges
+// (hash comparison) to keep each function under cyclomatic complexity 10.
 func (d *DiskSource) Diff() ([]Change, error) {
-	currentFiles := make(map[string]string) // relPath → hash
+	currentFiles, err := walkDiskFiles(d.basePath)
+	if err != nil {
+		return nil, err
+	}
 
-	err := filepath.Walk(d.basePath, func(path string, info os.FileInfo, walkErr error) error {
+	return diffFileChanges(currentFiles, d.storedHashes, d.Fetch), nil
+}
+
+// walkDiskFiles walks basePath and returns a map of relPath → SHA-256
+// content hash for every .md file found. Hidden directories (names
+// starting with ".") are skipped entirely. Unreadable files are
+// silently ignored, matching the List behavior.
+func walkDiskFiles(basePath string) (map[string]string, error) {
+	files := make(map[string]string) // relPath → hash
+
+	err := filepath.Walk(basePath, func(path string, info os.FileInfo, walkErr error) error {
 		if walkErr != nil {
 			return nil
 		}
@@ -137,22 +153,32 @@ func (d *DiskSource) Diff() ([]Change, error) {
 			return nil
 		}
 
-		relPath, _ := filepath.Rel(d.basePath, path)
+		relPath, _ := filepath.Rel(basePath, path)
 		relPath = filepath.ToSlash(relPath)
-		currentFiles[relPath] = computeHash(string(content))
+		files[relPath] = computeHash(string(content))
 		return nil
 	})
 	if err != nil {
 		return nil, fmt.Errorf("walk disk source for diff: %w", err)
 	}
 
+	return files, nil
+}
+
+// diffFileChanges compares currentFiles against storedHashes and returns
+// a slice of changes. New files (in current but not stored) are
+// ChangeAdded; files with different hashes are ChangeModified; files
+// in stored but not current are ChangeDeleted. For added and modified
+// files, fetcher is called to retrieve the full Document; fetch errors
+// cause the file to be silently skipped.
+func diffFileChanges(currentFiles, storedHashes map[string]string, fetcher func(string) (*Document, error)) []Change {
 	var changes []Change
 
 	// Detect new and modified files.
 	for relPath, currentHash := range currentFiles {
-		storedHash, exists := d.storedHashes[relPath]
+		storedHash, exists := storedHashes[relPath]
 		if !exists {
-			doc, err := d.Fetch(relPath)
+			doc, err := fetcher(relPath)
 			if err != nil {
 				continue
 			}
@@ -162,7 +188,7 @@ func (d *DiskSource) Diff() ([]Change, error) {
 				ID:       relPath,
 			})
 		} else if storedHash != currentHash {
-			doc, err := d.Fetch(relPath)
+			doc, err := fetcher(relPath)
 			if err != nil {
 				continue
 			}
@@ -175,7 +201,7 @@ func (d *DiskSource) Diff() ([]Change, error) {
 	}
 
 	// Detect deleted files.
-	for relPath := range d.storedHashes {
+	for relPath := range storedHashes {
 		if _, exists := currentFiles[relPath]; !exists {
 			changes = append(changes, Change{
 				Type: ChangeDeleted,
@@ -184,7 +210,7 @@ func (d *DiskSource) Diff() ([]Change, error) {
 		}
 	}
 
-	return changes, nil
+	return changes
 }
 
 // Meta returns metadata about this disk source, including its ID, type

--- a/source/disk_test.go
+++ b/source/disk_test.go
@@ -455,6 +455,58 @@ func TestDiskSource_Diff_UnchangedFilesExcluded(t *testing.T) {
 	}
 }
 
+func TestWalkDiskFiles_FiltersCorrectly(t *testing.T) {
+	dir := t.TempDir()
+
+	// Create two .md files, one .txt file, and a hidden directory with an .md file.
+	layout := map[string]string{
+		"alpha.md":          "# Alpha\nContent A.",
+		"beta.md":           "# Beta\nContent B.",
+		"readme.txt":        "Not markdown — should be excluded.",
+		".hidden/secret.md": "# Secret\nInside hidden dir — should be excluded.",
+	}
+	for name, content := range layout {
+		path := filepath.Join(dir, name)
+		if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+			t.Fatalf("mkdir %s: %v", filepath.Dir(path), err)
+		}
+		if err := os.WriteFile(path, []byte(content), 0o644); err != nil {
+			t.Fatalf("write %s: %v", name, err)
+		}
+	}
+
+	files, err := walkDiskFiles(dir)
+	if err != nil {
+		t.Fatalf("walkDiskFiles: %v", err)
+	}
+
+	// Should contain exactly the two .md files.
+	if len(files) != 2 {
+		t.Fatalf("expected 2 entries, got %d: %v", len(files), files)
+	}
+
+	for _, expected := range []string{"alpha.md", "beta.md"} {
+		hash, ok := files[expected]
+		if !ok {
+			t.Errorf("missing expected file %q", expected)
+			continue
+		}
+		if len(hash) != 64 {
+			t.Errorf("hash for %q has length %d, want 64 (SHA-256 hex)", expected, len(hash))
+		}
+	}
+
+	// Hidden dir contents must not appear.
+	if _, ok := files[".hidden/secret.md"]; ok {
+		t.Error("hidden directory file .hidden/secret.md should have been skipped")
+	}
+
+	// Non-.md file must not appear.
+	if _, ok := files["readme.txt"]; ok {
+		t.Error("non-.md file readme.txt should have been skipped")
+	}
+}
+
 func TestDiskSource_Meta(t *testing.T) {
 	ds := NewDiskSource("disk-local", "local", "/tmp/test")
 	meta := ds.Meta()

--- a/tools/whiteboard_test.go
+++ b/tools/whiteboard_test.go
@@ -57,100 +57,152 @@ func TestGetWhiteboard_Success(t *testing.T) {
 		t.Fatalf("unmarshal result: %v", err)
 	}
 
-	// Verify top-level whiteboard structure fields.
+	// --- Assert: name field ---
 	if parsed["name"] != "my-whiteboard" {
-		t.Errorf("name = %v, want %q", parsed["name"], "my-whiteboard")
+		t.Errorf("parsed[\"name\"] = %v, want %q", parsed["name"], "my-whiteboard")
 	}
 
+	// --- Assert: elementCount field ---
 	elementCount, ok := parsed["elementCount"].(float64)
 	if !ok {
-		t.Fatalf("elementCount missing or not a number, got %T: %v", parsed["elementCount"], parsed["elementCount"])
+		t.Fatalf("parsed[\"elementCount\"] missing or not a number, got %T: %v", parsed["elementCount"], parsed["elementCount"])
 	}
 	if elementCount != 3 {
-		t.Errorf("elementCount = %v, want 3", elementCount)
+		t.Errorf("parsed[\"elementCount\"] = %v, want 3", elementCount)
 	}
 
-	// Verify elements array structure.
+	// --- Assert: elements field ---
 	elements, ok := parsed["elements"].([]any)
 	if !ok {
-		t.Fatalf("elements missing or not an array, got %T", parsed["elements"])
+		t.Fatalf("parsed[\"elements\"] missing or not a []any, got %T", parsed["elements"])
 	}
 	if len(elements) != 3 {
-		t.Errorf("len(elements) = %d, want 3", len(elements))
+		t.Fatalf("len(parsed[\"elements\"]) = %d, want 3", len(elements))
 	}
 
-	// Verify element[0] has uuid, content, and shapeType fields.
+	// elementCount must match len(elements) — cross-field consistency.
+	if int(elementCount) != len(elements) {
+		t.Errorf("parsed[\"elementCount\"] = %v, but len(parsed[\"elements\"]) = %d — mismatch", elementCount, len(elements))
+	}
+
+	// --- Assert: elements[0] — rectangle with content link ---
 	elem0, ok := elements[0].(map[string]any)
 	if !ok {
-		t.Fatalf("elements[0] not a map, got %T", elements[0])
+		t.Fatalf("elements[0] not a map[string]any, got %T", elements[0])
 	}
 	if elem0["uuid"] != "wb-1" {
-		t.Errorf("elements[0].uuid = %v, want %q", elem0["uuid"], "wb-1")
+		t.Errorf("elements[0][\"uuid\"] = %v, want %q", elem0["uuid"], "wb-1")
 	}
 	if elem0["content"] != "Text element [[PageRef]]" {
-		t.Errorf("elements[0].content = %v, want %q", elem0["content"], "Text element [[PageRef]]")
+		t.Errorf("elements[0][\"content\"] = %v, want %q", elem0["content"], "Text element [[PageRef]]")
 	}
 	if elem0["shapeType"] != "rectangle" {
-		t.Errorf("elements[0].shapeType = %v, want %q", elem0["shapeType"], "rectangle")
+		t.Errorf("elements[0][\"shapeType\"] = %v, want %q", elem0["shapeType"], "rectangle")
+	}
+	if _, hasProps0 := elem0["properties"]; !hasProps0 {
+		t.Errorf("elements[0][\"properties\"] missing — expected properties map")
 	}
 
-	// Verify element[0] detected the [[PageRef]] link.
+	// Assert: elements[0].links contains "PageRef" via direct index access.
 	links0, ok := elem0["links"].([]any)
 	if !ok {
-		t.Fatalf("elements[0].links missing or not an array")
+		t.Fatalf("elements[0][\"links\"] missing or not a []any, got %T", elem0["links"])
 	}
-	foundPageRef := false
-	for _, l := range links0 {
-		if l == "PageRef" {
-			foundPageRef = true
-			break
-		}
+	if len(links0) < 1 {
+		t.Fatalf("len(elements[0][\"links\"]) = 0, want at least 1")
 	}
-	if !foundPageRef {
-		t.Errorf("elements[0].links = %v, expected to contain 'PageRef'", links0)
+	if links0[0] != "PageRef" {
+		t.Errorf("elements[0][\"links\"][0] = %v, want %q", links0[0], "PageRef")
 	}
 
-	// Should detect embedded page — verify specific page name.
+	// --- Assert: elements[1] — line connector ---
+	elem1, ok := elements[1].(map[string]any)
+	if !ok {
+		t.Fatalf("elements[1] not a map[string]any, got %T", elements[1])
+	}
+	if elem1["uuid"] != "wb-2" {
+		t.Errorf("elements[1][\"uuid\"] = %v, want %q", elem1["uuid"], "wb-2")
+	}
+	if elem1["content"] != "Another element" {
+		t.Errorf("elements[1][\"content\"] = %v, want %q", elem1["content"], "Another element")
+	}
+	if elem1["shapeType"] != "line" {
+		t.Errorf("elements[1][\"shapeType\"] = %v, want %q", elem1["shapeType"], "line")
+	}
+	if _, hasProps1 := elem1["properties"]; !hasProps1 {
+		t.Errorf("elements[1][\"properties\"] missing — expected properties map")
+	}
+
+	// --- Assert: elements[2] — rectangle with embedded page ---
+	elem2, ok := elements[2].(map[string]any)
+	if !ok {
+		t.Fatalf("elements[2] not a map[string]any, got %T", elements[2])
+	}
+	if elem2["uuid"] != "wb-3" {
+		t.Errorf("elements[2][\"uuid\"] = %v, want %q", elem2["uuid"], "wb-3")
+	}
+	if elem2["shapeType"] != "rectangle" {
+		t.Errorf("elements[2][\"shapeType\"] = %v, want %q", elem2["shapeType"], "rectangle")
+	}
+	if _, hasProps2 := elem2["properties"]; !hasProps2 {
+		t.Errorf("elements[2][\"properties\"] missing — expected properties map")
+	}
+	if elem2["embeddedPage"] != "embedded-page" {
+		t.Errorf("elements[2][\"embeddedPage\"] = %v, want %q", elem2["embeddedPage"], "embedded-page")
+	}
+
+	// --- Assert: embeddedPages field ---
+	// Production code collects pages from logseq.tldraw.page properties and content [[links]].
+	// Expected order: "PageRef" (from elem0 content link), "embedded-page" (from elem2 property).
 	embeddedPages, ok := parsed["embeddedPages"].([]any)
 	if !ok {
-		t.Fatalf("embeddedPages missing or not an array")
+		t.Fatalf("parsed[\"embeddedPages\"] missing or not a []any, got %T", parsed["embeddedPages"])
 	}
-	if len(embeddedPages) < 1 {
-		t.Fatal("expected at least 1 embedded page")
+	if len(embeddedPages) != 2 {
+		t.Fatalf("len(parsed[\"embeddedPages\"]) = %d, want 2", len(embeddedPages))
 	}
-	// Should contain "embedded-page" (from logseq.tldraw.page) and "PageRef" (from content links).
-	embeddedSet := make(map[string]bool)
-	for _, ep := range embeddedPages {
-		if s, ok := ep.(string); ok {
-			embeddedSet[s] = true
-		}
+	// Verify each embedded page name is a string with the expected value.
+	ep0, ok := embeddedPages[0].(string)
+	if !ok {
+		t.Fatalf("parsed[\"embeddedPages\"][0] not a string, got %T", embeddedPages[0])
 	}
-	if !embeddedSet["embedded-page"] {
-		t.Errorf("embeddedPages should contain 'embedded-page', got %v", embeddedPages)
+	if ep0 != "PageRef" {
+		t.Errorf("parsed[\"embeddedPages\"][0] = %q, want %q", ep0, "PageRef")
 	}
-	if !embeddedSet["PageRef"] {
-		t.Errorf("embeddedPages should contain 'PageRef', got %v", embeddedPages)
+	ep1, ok := embeddedPages[1].(string)
+	if !ok {
+		t.Fatalf("parsed[\"embeddedPages\"][1] not a string, got %T", embeddedPages[1])
+	}
+	if ep1 != "embedded-page" {
+		t.Errorf("parsed[\"embeddedPages\"][1] = %q, want %q", ep1, "embedded-page")
 	}
 
-	// Verify connections — source/target relationship.
+	// --- Assert: connections field ---
+	// Production code extracts connections from blocks with both source and target properties.
 	connections, ok := parsed["connections"].([]any)
 	if !ok {
-		t.Fatalf("connections missing or not an array")
+		t.Fatalf("parsed[\"connections\"] missing or not a []any, got %T", parsed["connections"])
 	}
 	if len(connections) != 1 {
-		t.Errorf("expected 1 connection, got %d", len(connections))
+		t.Fatalf("len(parsed[\"connections\"]) = %d, want 1", len(connections))
 	}
-	if len(connections) > 0 {
-		conn0, ok := connections[0].(map[string]any)
-		if !ok {
-			t.Fatalf("connections[0] not a map")
-		}
-		if conn0["source"] != "wb-1" {
-			t.Errorf("connection source = %v, want %q", conn0["source"], "wb-1")
-		}
-		if conn0["target"] != "wb-3" {
-			t.Errorf("connection target = %v, want %q", conn0["target"], "wb-3")
-		}
+	conn0, ok := connections[0].(map[string]any)
+	if !ok {
+		t.Fatalf("parsed[\"connections\"][0] not a map[string]any, got %T", connections[0])
+	}
+	conn0Source, ok := conn0["source"].(string)
+	if !ok {
+		t.Fatalf("parsed[\"connections\"][0][\"source\"] not a string, got %T", conn0["source"])
+	}
+	if conn0Source != "wb-1" {
+		t.Errorf("parsed[\"connections\"][0][\"source\"] = %q, want %q", conn0Source, "wb-1")
+	}
+	conn0Target, ok := conn0["target"].(string)
+	if !ok {
+		t.Fatalf("parsed[\"connections\"][0][\"target\"] not a string, got %T", conn0["target"])
+	}
+	if conn0Target != "wb-3" {
+		t.Errorf("parsed[\"connections\"][0][\"target\"] = %q, want %q", conn0Target, "wb-3")
 	}
 }
 

--- a/vault/vault.go
+++ b/vault/vault.go
@@ -1007,15 +1007,10 @@ func (c *Client) RenamePage(_ context.Context, oldName, newName string) error {
 		return err
 	}
 
-	if err := os.MkdirAll(filepath.Dir(newAbsPath), 0o755); err != nil {
-		return fmt.Errorf("create directory: %w", err)
+	if err := renameFile(oldPath, newAbsPath); err != nil {
+		return err
 	}
 
-	if err := os.Rename(oldPath, newAbsPath); err != nil {
-		return fmt.Errorf("rename file: %w", err)
-	}
-
-	// Update all [[links]] across the vault — log every error.
 	if errs := c.updateLinksAcrossVaultLocked(oldName, newName); len(errs) > 0 {
 		for _, e := range errs {
 			logger.Error("link update error during rename", "err", e)
@@ -1023,15 +1018,40 @@ func (c *Client) RenamePage(_ context.Context, oldName, newName string) error {
 	}
 
 	c.removePageFromIndexLocked(lowerOld)
+	c.reindexRenamed(newRelPath, newAbsPath)
+
+	vaultAbs, _ := filepath.Abs(c.vaultPath)
+	cleanupEmptyDirs(filepath.Dir(oldPath), vaultAbs)
+
+	return nil
+}
+
+// renameFile creates the target directory if needed and renames the file.
+func renameFile(oldPath, newAbsPath string) error {
+	if err := os.MkdirAll(filepath.Dir(newAbsPath), 0o755); err != nil {
+		return fmt.Errorf("create directory: %w", err)
+	}
+	if err := os.Rename(oldPath, newAbsPath); err != nil {
+		return fmt.Errorf("rename file: %w", err)
+	}
+	return nil
+}
+
+// reindexRenamed reads the renamed file and re-indexes it under the new
+// path. Must be called within a locked context.
+func (c *Client) reindexRenamed(newRelPath, newAbsPath string) {
 	content, err := os.ReadFile(newAbsPath)
 	if err == nil {
 		info, _ := os.Stat(newAbsPath)
 		c.indexFileCore(newRelPath, string(content), info)
 	}
 	c.rebuildLinksLocked()
+}
 
-	dir := filepath.Dir(oldPath)
-	vaultAbs, _ := filepath.Abs(c.vaultPath)
+// cleanupEmptyDirs walks up from startDir removing empty directories until
+// it reaches vaultAbs or encounters a non-empty directory.
+func cleanupEmptyDirs(startDir, vaultAbs string) {
+	dir := startDir
 	for dir != vaultAbs {
 		entries, err := os.ReadDir(dir)
 		if err != nil || len(entries) > 0 {
@@ -1042,8 +1062,6 @@ func (c *Client) RenamePage(_ context.Context, oldName, newName string) error {
 		}
 		dir = filepath.Dir(dir)
 	}
-
-	return nil
 }
 
 // removePageFromIndex removes a page and its blocks from all indices.


### PR DESCRIPTION
## Summary

- Decompose `RenamePage` (complexity 17 → ~7) into `renameFile`, `reindexRenamed`, `cleanupEmptyDirs`
- Decompose `newSourceAddCmd` (complexity 19 → ~5) into `buildGitHubSource`, `buildWebSource`, `saveSourceConfig`
- Decompose `DiskSource.Diff` (complexity 15 → ~7) into `walkDiskFiles`, `diffFileChanges`
- Add 4 dedicated tests for `indexDocuments` (insert, update, source record, properties)
- Restructure whiteboard test assertions for Gaze mapper traceability

## Cumulative Results (3 ratchets)

| Metric | Baseline | R1 | R2 | R3 | CI Gate |
|--------|----------|----|----|----|----|
| CRAPload | 15 | 13 | 10 | **6** | ≤15 |
| GazeCRAPload | 34 | 34 | 33 | **31** | ≤34 |
| Q4 Dangerous | 5 | 5 | 3 | **1** | — |
| Root coverage | 77% | — | 84% | **85%** | — |

## Verification

- `go build ./...` — PASS
- `go vet ./...` — PASS
- `go test -race -count=1 ./...` — 11 packages PASS
- `gaze crap --max-crapload=15 --max-gaze-crapload=34` — both PASS with significant headroom

No behavioral changes. All 40 MCP tools produce identical results.