### PR TITLE
fix: update Homebrew cask dependency from ollama to ollama-app

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -34,7 +34,7 @@ homebrew_casks:
     # with signed values, then pushes the complete cask to homebrew-tap.
     skip_upload: true
     dependencies:
-      - cask: ollama
+      - cask: ollama-app
     hooks:
       post:
         install: |

--- a/README.md
+++ b/README.md
@@ -349,7 +349,7 @@ Semantic search requires [Ollama](https://ollama.ai) running locally. All 37 key
 ### Install Ollama and pull the embedding model
 
 ```bash
-brew install ollama       # macOS — or download from https://ollama.ai
+brew install --cask ollama-app  # macOS — or download from https://ollama.ai
 ollama serve              # start the Ollama server (runs in background)
 ollama pull granite-embedding:30m   # IBM Granite, 63 MB, Apache 2.0
 ```

--- a/openspec/changes/archive/2026-03-28-fix-ollama-cask-rename/.openspec.yaml
+++ b/openspec/changes/archive/2026-03-28-fix-ollama-cask-rename/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: unbound-force
+created: 2026-03-28

--- a/openspec/changes/archive/2026-03-28-fix-ollama-cask-rename/design.md
+++ b/openspec/changes/archive/2026-03-28-fix-ollama-cask-rename/design.md
@@ -1,0 +1,41 @@
+## Context
+
+Homebrew has renamed the `ollama` cask to `ollama-app`. Dewey's GoReleaser configuration (`.goreleaser.yaml`) declares `cask: ollama` as a dependency in the `homebrew_casks` section. This causes a deprecation warning during installation:
+
+```
+Warning: Cask ollama was renamed to ollama-app.
+```
+
+The GoReleaser config generates a `Casks/dewey.rb` file that is pushed to the `unbound-force/homebrew-tap` repository by the release workflow. The dependency name flows through the entire pipeline: GoReleaser config -> generated cask -> tap repo -> end-user install.
+
+## Goals / Non-Goals
+
+### Goals
+- Eliminate the Homebrew deprecation warning during `brew install --cask unbound-force/tap/dewey`
+- Update all documentation referencing the old `ollama` cask name
+- Ensure the next release automatically propagates the fix to `unbound-force/homebrew-tap`
+
+### Non-Goals
+- Changing the Ollama runtime integration (the `embed/embed.go` HTTP client is unaffected)
+- Modifying the release workflow pipeline (signing, notarization, checksum patching all remain unchanged)
+- Manually updating `unbound-force/homebrew-tap` (the release pipeline handles this automatically)
+
+## Decisions
+
+**D1: Update `.goreleaser.yaml` dependency from `ollama` to `ollama-app`**
+
+This is the single source of truth for the cask dependency. Line 37 changes from `- cask: ollama` to `- cask: ollama-app`. The release workflow will propagate this to the tap repo on the next tagged release.
+
+**D2: Update README.md install instructions**
+
+The README references Ollama installation. Any references to `brew install ollama` or `brew install --cask ollama` should be updated to `ollama-app` to match the canonical Homebrew name.
+
+**D3: No changes to the release workflow**
+
+The `sign-macos` job in `.github/workflows/release.yml` downloads, patches, and pushes the generated cask file. It does not hardcode the `ollama` dependency name — it works with whatever GoReleaser generates. No workflow changes are needed.
+
+## Risks / Trade-offs
+
+**Low risk**: This is a configuration-only change. The GoReleaser `homebrew_casks` section generates Ruby code for the cask file. Homebrew's dependency resolution already understands `ollama-app` (it currently resolves the old name via a rename redirect). Switching to the new name eliminates the redirect and the warning.
+
+**Propagation delay**: The fix reaches end users only after a new tagged release is cut. Until then, existing `Casks/dewey.rb` in the tap repo still references `ollama`. This is acceptable — there's no urgency since the old name still resolves (with a warning).

--- a/openspec/changes/archive/2026-03-28-fix-ollama-cask-rename/proposal.md
+++ b/openspec/changes/archive/2026-03-28-fix-ollama-cask-rename/proposal.md
@@ -1,0 +1,60 @@
+## Why
+
+Homebrew renamed the `ollama` cask to `ollama-app`. When users install Dewey via `brew install unbound-force --cask`, the installation succeeds but emits a warning on every operation that touches the dependency:
+
+```
+Warning: Cask ollama was renamed to ollama-app.
+```
+
+This warning appears multiple times during install (once per dependency resolution pass) and erodes confidence in the installation — users may wonder if the dependency was correctly installed or if something is misconfigured. The fix is straightforward: update the dependency declaration to use the new canonical name.
+
+## What Changes
+
+- Update the Homebrew cask dependency in `.goreleaser.yaml` from `ollama` to `ollama-app`
+- Update any documentation that references `brew install ollama` or the old cask name
+
+## Capabilities
+
+### New Capabilities
+- None
+
+### Modified Capabilities
+- `homebrew-cask-install`: Dewey's Homebrew cask declares the correct dependency name (`ollama-app` instead of deprecated `ollama`), eliminating the rename warning during installation
+
+### Removed Capabilities
+- None
+
+## Impact
+
+- **`.goreleaser.yaml`**: Change `cask: ollama` to `cask: ollama-app` in the `dependencies` section of `homebrew_casks`
+- **`README.md`**: Update any install instructions that reference the old `ollama` cask name
+- **`unbound-force/homebrew-tap`** (downstream): The next tagged release will automatically push an updated `Casks/dewey.rb` to the tap with the corrected dependency name — no manual changes to the tap repo are needed
+- **Existing users**: Users who already have Ollama installed will see no change. Users doing fresh installs will no longer see the deprecation warning.
+
+## Constitution Alignment
+
+Assessed against the Unbound Force org constitution.
+
+### I. Autonomous Collaboration
+
+**Assessment**: N/A
+
+This change modifies build/distribution configuration only. No MCP tools, tool contracts, or inter-agent communication are affected.
+
+### II. Composability First
+
+**Assessment**: PASS
+
+Dewey remains independently installable. The Ollama dependency is still optional at runtime (semantic search degrades gracefully without it). This change only corrects the package name used by Homebrew's dependency resolver.
+
+### III. Observable Quality
+
+**Assessment**: N/A
+
+No changes to query results, provenance metadata, health reporting, or index state.
+
+### IV. Testability
+
+**Assessment**: N/A
+
+No production code or test code changes. This is a build configuration fix.

--- a/openspec/changes/archive/2026-03-28-fix-ollama-cask-rename/specs/homebrew-dependency.md
+++ b/openspec/changes/archive/2026-03-28-fix-ollama-cask-rename/specs/homebrew-dependency.md
@@ -1,0 +1,36 @@
+## ADDED Requirements
+
+_None_
+
+## MODIFIED Requirements
+
+### Requirement: Homebrew Cask Ollama Dependency
+
+The GoReleaser `homebrew_casks` configuration MUST declare the Ollama dependency using the canonical cask name `ollama-app`. The generated `Casks/dewey.rb` MUST NOT reference the deprecated `ollama` cask name.
+
+Previously: The dependency was declared as `cask: ollama`, which triggers a Homebrew deprecation warning: "Cask ollama was renamed to ollama-app."
+
+#### Scenario: Clean install of Dewey cask
+- **GIVEN** a user has tapped `unbound-force/tap` and Ollama is not installed
+- **WHEN** the user runs `brew install --cask unbound-force/tap/dewey`
+- **THEN** Homebrew MUST install `ollama-app` as a dependency without emitting a rename warning
+
+#### Scenario: Install when Ollama is already present
+- **GIVEN** a user already has `ollama-app` installed via Homebrew
+- **WHEN** the user runs `brew install --cask unbound-force/tap/dewey`
+- **THEN** Homebrew MUST recognize the dependency as satisfied and MUST NOT emit a rename warning
+
+### Requirement: Documentation Accuracy for Ollama Installation
+
+All user-facing documentation MUST reference `ollama-app` as the Homebrew cask name when providing install instructions. References to `brew install --cask ollama` MUST be updated to `brew install --cask ollama-app`.
+
+Previously: README.md referenced `brew install ollama` without specifying the `--cask` flag or the current cask name.
+
+#### Scenario: User follows README install instructions
+- **GIVEN** a user is reading the Dewey README for setup instructions
+- **WHEN** they reach the Ollama installation section
+- **THEN** the documented command MUST use the canonical cask name `ollama-app`
+
+## REMOVED Requirements
+
+_None_

--- a/openspec/changes/archive/2026-03-28-fix-ollama-cask-rename/tasks.md
+++ b/openspec/changes/archive/2026-03-28-fix-ollama-cask-rename/tasks.md
@@ -1,0 +1,13 @@
+## 1. Update GoReleaser Cask Dependency
+
+- [x] 1.1 In `.goreleaser.yaml`, change `- cask: ollama` to `- cask: ollama-app` (line 37)
+
+## 2. Update Documentation
+
+- [x] 2.1 In `README.md`, update the Ollama install command from `brew install ollama` to `brew install --cask ollama-app` (line 352)
+
+## 3. Verification
+
+- [x] 3.1 Run `goreleaser check` to validate the GoReleaser config syntax
+- [x] 3.2 Run CI-equivalent checks: `go build ./...`, `go vet ./...`, `go test -race -count=1 ./...`
+- [x] 3.3 Verify constitution alignment: Composability First is maintained (Ollama remains an optional runtime dependency; the cask name change does not introduce new coupling)

--- a/openspec/specs/homebrew-dependency/spec.md
+++ b/openspec/specs/homebrew-dependency/spec.md
@@ -1,0 +1,29 @@
+# Homebrew Dependency Spec
+
+> Synced from: `openspec/changes/fix-ollama-cask-rename/specs/homebrew-dependency.md`
+> Date: 2026-03-28
+
+## Requirements
+
+### Requirement: Homebrew Cask Ollama Dependency
+
+The GoReleaser `homebrew_casks` configuration MUST declare the Ollama dependency using the canonical cask name `ollama-app`. The generated `Casks/dewey.rb` MUST NOT reference the deprecated `ollama` cask name.
+
+#### Scenario: Clean install of Dewey cask
+- **GIVEN** a user has tapped `unbound-force/tap` and Ollama is not installed
+- **WHEN** the user runs `brew install --cask unbound-force/tap/dewey`
+- **THEN** Homebrew MUST install `ollama-app` as a dependency without emitting a rename warning
+
+#### Scenario: Install when Ollama is already present
+- **GIVEN** a user already has `ollama-app` installed via Homebrew
+- **WHEN** the user runs `brew install --cask unbound-force/tap/dewey`
+- **THEN** Homebrew MUST recognize the dependency as satisfied and MUST NOT emit a rename warning
+
+### Requirement: Documentation Accuracy for Ollama Installation
+
+All user-facing documentation MUST reference `ollama-app` as the Homebrew cask name when providing install instructions. References to `brew install --cask ollama` MUST be updated to `brew install --cask ollama-app`.
+
+#### Scenario: User follows README install instructions
+- **GIVEN** a user is reading the Dewey README for setup instructions
+- **WHEN** they reach the Ollama installation section
+- **THEN** the documented command MUST use the canonical cask name `ollama-app`


### PR DESCRIPTION
## Summary

- Update `.goreleaser.yaml` cask dependency from deprecated `ollama` to canonical `ollama-app`, eliminating the `Warning: Cask ollama was renamed to ollama-app` message during `brew install --cask unbound-force/tap/dewey`
- Update `README.md` install instructions to use `brew install --cask ollama-app`
- Add OpenSpec artifacts (proposal, design, specs, tasks) and synced main spec for homebrew-dependency

## Context

Homebrew renamed the `ollama` cask to `ollama-app`. The old name still resolves via redirect but emits a deprecation warning on every operation that touches the dependency. This is a config-only fix — no production code changes.

## Files Changed

| File | Change |
|------|--------|
| `.goreleaser.yaml` | `cask: ollama` → `cask: ollama-app` |
| `README.md` | `brew install ollama` → `brew install --cask ollama-app` |
| `openspec/changes/archive/...` | Archived change artifacts |
| `openspec/specs/homebrew-dependency/` | Synced main spec |

## Verification

- `goreleaser check` — config validates
- `go build ./...` — passes
- `go vet ./...` — passes  
- `go test -race -count=1 ./...` — all 11 packages pass