### PR TITLE
feat: add dewey_store_learning MCP tool for semantic memory (#25)

### DIFF
--- a/server.go
+++ b/server.go
@@ -81,6 +81,12 @@ func newServer(b backend.Backend, readOnly bool, opts ...serverOption) *mcp.Serv
 
 	semantic := tools.NewSemantic(cfg.embedder, cfg.store)
 	registerSemanticTools(srv, semantic)
+
+	if !readOnly {
+		learning := tools.NewLearning(cfg.embedder, cfg.store)
+		registerLearningTools(srv, learning)
+	}
+
 	registerHealthTool(srv, b, readOnly, &cfg)
 
 	// Vault management tools (Obsidian-specific).
@@ -339,6 +345,15 @@ func registerSemanticTools(srv *mcp.Server, semantic *tools.Semantic) {
 		Name:        "dewey_semantic_search_filtered",
 		Description: "Semantic search constrained by metadata filters (source type, repository, properties).",
 	}, semantic.SemanticSearchFiltered)
+}
+
+// registerLearningTools registers the store_learning MCP tool for persisting
+// agent learnings into the knowledge graph with optional embeddings.
+func registerLearningTools(srv *mcp.Server, learning *tools.Learning) {
+	mcp.AddTool(srv, &mcp.Tool{
+		Name:        "dewey_store_learning",
+		Description: "Store a learning (insight, pattern, gotcha) with optional tags. The learning is persisted with embeddings and immediately searchable via dewey_semantic_search. Use to build semantic memory across sessions.",
+	}, learning.StoreLearning)
 }
 
 // registerHealthTool registers the health check tool that reports server status,

--- a/specs/008-store-learning/checklists/requirements.md
+++ b/specs/008-store-learning/checklists/requirements.md
@@ -1,0 +1,37 @@
+# Specification Quality Checklist: Store Learning MCP Tool
+
+**Purpose**: Validate specification completeness and quality before proceeding to planning
+**Created**: 2026-04-03
+**Feature**: [spec.md](../spec.md)
+
+## Content Quality
+
+- [x] No implementation details (languages, frameworks, APIs)
+- [x] Focused on user value and business needs
+- [x] Written for non-technical stakeholders
+- [x] All mandatory sections completed
+
+## Requirement Completeness
+
+- [x] No [NEEDS CLARIFICATION] markers remain
+- [x] Requirements are testable and unambiguous
+- [x] Success criteria are measurable
+- [x] Success criteria are technology-agnostic (no implementation details)
+- [x] All acceptance scenarios are defined
+- [x] Edge cases are identified
+- [x] Scope is clearly bounded
+- [x] Dependencies and assumptions identified
+
+## Feature Readiness
+
+- [x] All functional requirements have clear acceptance criteria
+- [x] User scenarios cover primary flows
+- [x] Feature meets measurable outcomes defined in Success Criteria
+- [x] No implementation details leak into specification
+
+## Notes
+
+- FR-001 through FR-005 directly map to the requirements in GitHub issue #25 (Spec 021 FR-007–FR-011).
+- FR-006 through FR-010 are additions for error handling, persistence, graceful degradation, and tool registration.
+- The Assumptions section references "pages" and "blocks" which are Dewey domain concepts (not implementation details) — they describe the existing data model the tool integrates with.
+- All items pass. Spec is ready for `/speckit.plan` or `/unleash`.

--- a/specs/008-store-learning/plan.md
+++ b/specs/008-store-learning/plan.md
@@ -1,0 +1,75 @@
+# Implementation Plan: Store Learning MCP Tool
+
+**Branch**: `008-store-learning` | **Date**: 2026-04-03 | **Spec**: [spec.md](spec.md)
+**Input**: Feature specification from `/specs/008-store-learning/spec.md`
+
+## Summary
+
+Add a `dewey_store_learning` MCP tool (tool #41) that allows AI agents to persist natural language learnings with optional tags into Dewey's existing SQLite store. Learnings are stored as pages with `source_id = "learning"`, making them immediately searchable via the existing `dewey_semantic_search` and `dewey_semantic_search_filtered` tools. No schema changes are needed — the feature reuses the existing page/block/embedding pipeline with a new source type convention.
+
+## Technical Context
+
+**Language/Version**: Go 1.25 (per `go.mod`)
+**Primary Dependencies**: `github.com/modelcontextprotocol/go-sdk/mcp` (MCP SDK), `modernc.org/sqlite` (pure-Go SQLite), `github.com/charmbracelet/log` (logging)
+**Storage**: SQLite via `modernc.org/sqlite` — single database `.dewey/graph.db` (existing, no schema changes)
+**Testing**: Standard library `testing` package with in-memory SQLite (`:memory:`) and mock embedder
+**Target Platform**: darwin/linux x amd64/arm64 (cross-platform CLI/MCP server)
+**Project Type**: CLI + MCP server
+**Performance Goals**: Round-trip store-and-retrieve under 2 seconds (SC-001)
+**Constraints**: No CGO, no external services required for core functionality, local-only processing
+**Scale/Scope**: Single new MCP tool, 4 files modified/created
+
+## Constitution Check
+
+*GATE: Must pass before Phase 0 research. Re-check after Phase 1 design.*
+
+### I. Composability First — PASS
+
+The `dewey_store_learning` tool is registered alongside the existing 40 MCP tools. It requires the persistent store (`store.Store`) to function — when the store is nil (in-memory mode), the tool returns a clear error message. This matches the existing pattern used by `dewey_semantic_search` and other store-dependent tools. Dewey remains independently installable; the learning tool is an additive capability that does not create new external dependencies.
+
+### II. Autonomous Collaboration — PASS
+
+The tool communicates exclusively through the MCP tool call interface with a structured JSON input schema (`information` + `tags`) and a structured JSON response (UUID on success, error message on failure). No runtime coupling, shared memory, or direct function calls. Agents discover the tool through the MCP tool registry.
+
+### III. Observable Quality — PASS
+
+Stored learnings include provenance metadata: `source_id = "learning"` distinguishes them from disk/GitHub/web sources. The `inferSourceType()` function in `store/embeddings.go` will extract "learning" from the source ID, making it visible in search results via the `source` field. The `health` tool will automatically report learning source statistics since it iterates `ListSources()`.
+
+### IV. Testability — PASS
+
+The tool implementation follows the existing `tools/semantic.go` pattern: dependencies (`embed.Embedder`, `store.Store`) are injected via constructor. Tests use in-memory SQLite (`:memory:`) and the existing `mockEmbedder` from `tools/semantic_test.go`. No external services required. Coverage strategy: test the happy path (store + retrieve), error paths (nil store, nil embedder, empty input), and the Ollama-unavailable graceful degradation path.
+
+**Coverage Strategy**: Contract-level tests covering:
+- Happy path: store learning, verify page/block/embedding created, verify searchable
+- Error: empty `information` parameter
+- Error: nil store (in-memory mode)
+- Error: nil embedder (graceful degradation — store without embedding)
+- Graceful degradation: embedder unavailable (store text, skip embedding, return informational message)
+- Tags: verify tags stored as page properties and filterable via `has_tag`
+
+## Project Structure
+
+### Documentation (this feature)
+
+```text
+specs/008-store-learning/
+├── plan.md              # This file
+├── research.md          # Phase 0 output
+├── quickstart.md        # Phase 1 output
+└── tasks.md             # Phase 2 output (/speckit.tasks command)
+```
+
+### Source Code (repository root)
+
+```text
+types/tools.go           # ADD StoreLearningInput struct (alongside existing input types)
+tools/learning.go        # NEW — Learning tool handler (store learning implementation)
+tools/learning_test.go   # NEW — Tests for learning tool
+server.go                # ADD registerLearningTools() call + function
+```
+
+**Structure Decision**: This feature adds a single MCP tool following the established flat package layout. The `tools/learning.go` file follows the same pattern as `tools/semantic.go` — a struct with injected dependencies and handler methods. No new packages are needed. The input type goes in `types/tools.go` alongside all other tool input types.
+
+## Complexity Tracking
+
+No constitution violations. The implementation reuses existing infrastructure (store, embedder, page/block model) with no new abstractions or dependencies.

--- a/specs/008-store-learning/quickstart.md
+++ b/specs/008-store-learning/quickstart.md
@@ -1,0 +1,178 @@
+# Quickstart: Store Learning MCP Tool
+
+**Branch**: `008-store-learning` | **Date**: 2026-04-03
+
+## Overview
+
+This document provides the implementation blueprint for the `dewey_store_learning` MCP tool. It maps each file change to the spec requirements and provides pseudocode for the key implementation.
+
+## File-by-File Implementation Guide
+
+### 1. `types/tools.go` — Add Input Struct
+
+**What**: Add `StoreLearningInput` struct alongside existing tool input types.
+
+**Where**: After the `SemanticSearchFilteredInput` section (line ~231), before the Journal section.
+
+```go
+// --- Learning tool inputs ---
+
+// StoreLearningInput is the input for the dewey_store_learning MCP tool.
+type StoreLearningInput struct {
+    Information string `json:"information" jsonschema:"The learning text to store. Required."`
+    Tags        string `json:"tags,omitempty" jsonschema:"Optional comma-separated tags for filtering (e.g. 'gotcha, vault-walker, 006-unified-ignore')"`
+}
+```
+
+**Maps to**: FR-001 (information required, tags optional)
+
+---
+
+### 2. `tools/learning.go` — Tool Implementation (NEW FILE)
+
+**What**: Create the `Learning` struct and `StoreLearning` handler method.
+
+**Dependencies**: `embed.Embedder` (for embedding generation), `store.Store` (for persistence)
+
+**Handler pseudocode**:
+
+```
+func (l *Learning) StoreLearning(ctx, req, input StoreLearningInput):
+    // 1. Validate input (FR-007)
+    if input.Information is empty:
+        return errorResult("information parameter is required and must not be empty")
+    
+    if l.store is nil:
+        return errorResult("store_learning requires persistent storage. Configure --vault with a .dewey/ directory.")
+    
+    // 2. Generate unique page name and document ID
+    timestamp = time.Now().UnixMilli()
+    pageName = fmt.Sprintf("learning/%d", timestamp)
+    docID = fmt.Sprintf("learning-%d", timestamp)
+    
+    // 3. Build properties JSON (FR-004 — tags for filtering)
+    properties = "{}"
+    if input.Tags != "":
+        properties = json.Marshal(map{"tags": input.Tags})
+    
+    // 4. Insert page (FR-002, FR-003, FR-008)
+    page = &store.Page{
+        Name:         pageName,
+        OriginalName: pageName,
+        SourceID:     "learning",       // FR-003: distinguishes from other sources
+        SourceDocID:  docID,
+        Properties:   properties,
+        ContentHash:  sha256(input.Information)[:16],
+    }
+    store.InsertPage(page)
+    
+    // 5. Parse content into blocks and persist (FR-002)
+    _, blocks = vault.ParseDocument(docID, input.Information)
+    vault.PersistBlocks(store, pageName, blocks, sql.NullString{}, 0)
+    
+    // 6. Generate embeddings if embedder available (FR-005, FR-009)
+    embeddingMsg = ""
+    if l.embedder != nil && l.embedder.Available():
+        count = vault.GenerateEmbeddings(store, embedder, pageName, blocks, nil)
+        // count logged but not returned
+    else:
+        embeddingMsg = "Note: Embeddings were not generated (Ollama unavailable). The learning is stored and searchable via keyword search. Semantic search will be available after embeddings are generated."
+    
+    // 7. Return success with UUID (FR-006)
+    // Use the first block's UUID as the learning's identifier
+    result = map{
+        "uuid": blocks[0].UUID,
+        "page": pageName,
+        "message": "Learning stored successfully." + embeddingMsg,
+    }
+    return jsonTextResult(result)
+```
+
+**Key design decisions**:
+- Uses `vault.ParseDocument()` to parse the learning text into blocks, reusing the existing parsing pipeline (DRY)
+- Uses `vault.PersistBlocks()` and `vault.GenerateEmbeddings()` — the same exported functions used by the CLI indexing pipeline (DRY)
+- Graceful degradation when embedder is unavailable: stores text without embeddings, returns informational message (FR-009)
+- Returns first block UUID as the learning identifier (FR-006)
+
+---
+
+### 3. `tools/learning_test.go` — Tests (NEW FILE)
+
+**Test cases** (maps to coverage strategy in plan.md):
+
+| Test | Validates | Priority |
+|------|-----------|----------|
+| `TestStoreLearning_Basic` | Store learning, verify page/block created, verify UUID returned | P1 (FR-001, FR-002, FR-006) |
+| `TestStoreLearning_Searchable` | Store learning, query via semantic search, verify it appears | P1 (FR-002, SC-001) |
+| `TestStoreLearning_WithTags` | Store with tags, verify properties contain tags | P1 (FR-004) |
+| `TestStoreLearning_EmptyInformation` | Empty input returns error | P1 (FR-007) |
+| `TestStoreLearning_NilStore` | Nil store returns clear error | P1 (FR-007) |
+| `TestStoreLearning_EmbedderUnavailable` | Store succeeds without embeddings, returns informational message | P1 (FR-009) |
+| `TestStoreLearning_NilEmbedder` | Nil embedder stores text, returns informational message | P2 (FR-009) |
+| `TestStoreLearning_FilterBySourceType` | Store learning, filter via `source_type: "learning"`, verify only learnings returned | P2 (FR-003, SC-004) |
+
+**Test infrastructure**: Reuses `mockEmbedder` and `newTestStoreWithData()` from `semantic_test.go` (already in the same package).
+
+---
+
+### 4. `server.go` — Register the Tool
+
+**What**: Add `registerLearningTools()` function and call it from `newServer()`.
+
+**Where in `newServer()`**: After `registerSemanticTools()` (line ~83), before `registerHealthTool()`. The learning tool is a write operation (creates content), so it should be gated by `!readOnly` like the write and decision tools.
+
+```go
+// In newServer(), after registerSemanticTools:
+if !readOnly {
+    learning := tools.NewLearning(cfg.embedder, cfg.store)
+    registerLearningTools(srv, learning)
+}
+```
+
+```go
+// registerLearningTools registers the store_learning MCP tool.
+func registerLearningTools(srv *mcp.Server, learning *tools.Learning) {
+    mcp.AddTool(srv, &mcp.Tool{
+        Name:        "dewey_store_learning",
+        Description: "Store a learning (insight, pattern, gotcha) with optional tags. The learning is persisted with embeddings and immediately searchable via dewey_semantic_search. Use to build semantic memory across sessions.",
+    }, learning.StoreLearning)
+}
+```
+
+**Maps to**: FR-010 (tool #41, registered alongside existing tools)
+
+---
+
+## Dependency Graph
+
+```
+types/tools.go (StoreLearningInput)
+    ↓ used by
+tools/learning.go (Learning struct + StoreLearning handler)
+    ↓ used by
+server.go (registerLearningTools)
+```
+
+No circular dependencies. The `tools/learning.go` file depends on:
+- `types` package (input struct)
+- `store` package (persistence)
+- `embed` package (embedder interface)
+- `vault` package (ParseDocument, PersistBlocks, GenerateEmbeddings)
+
+All are existing dependencies already used by `tools/semantic.go`.
+
+## Existing Infrastructure Reuse
+
+| Component | Existing Location | Reused For |
+|-----------|------------------|------------|
+| `store.InsertPage()` | `store/store.go` | Persisting learning page |
+| `vault.ParseDocument()` | `vault/parse_export.go` | Parsing learning text into blocks |
+| `vault.PersistBlocks()` | `vault/parse_export.go` | Persisting blocks to store |
+| `vault.GenerateEmbeddings()` | `vault/parse_export.go` | Creating embeddings for learning |
+| `store.SearchSimilar()` | `store/embeddings.go` | Searching learnings (no changes) |
+| `store.SearchSimilarFiltered()` | `store/embeddings.go` | Filtering by source_type "learning" (no changes) |
+| `inferSourceType()` | `store/embeddings.go` | Extracting "learning" from source_id (no changes) |
+| `mockEmbedder` | `tools/semantic_test.go` | Test double for embedder |
+| `errorResult()` / `jsonTextResult()` | `tools/helpers.go` | MCP response formatting |
+
+**Zero new dependencies** — everything uses existing packages.

--- a/specs/008-store-learning/research.md
+++ b/specs/008-store-learning/research.md
@@ -1,0 +1,102 @@
+# Research: Store Learning MCP Tool
+
+**Branch**: `008-store-learning` | **Date**: 2026-04-03
+
+## R1: Existing Store Pipeline (Page → Block → Embedding)
+
+**Question**: How does Dewey currently persist content and generate embeddings?
+
+**Finding**: The pipeline is well-established across three layers:
+
+1. **Page insertion** (`store.InsertPage`): Creates a page record with `Name`, `OriginalName`, `SourceID`, `SourceDocID`, `Properties` (JSON string), `ContentHash`, timestamps. The `SourceID` field uses a convention of `"type-name"` (e.g., `"disk-local"`, `"github-gaze"`, `"web-docs"`).
+
+2. **Block insertion** (`vault.PersistBlocks`): Recursively inserts blocks with UUID, page name, parent UUID, content, heading level, and position. Block UUIDs are generated deterministically from a seed (the document ID).
+
+3. **Embedding generation** (`vault.GenerateEmbeddings`): Iterates blocks, prepares chunks via `embed.PrepareChunk()` (which prepends page name and heading path), calls `embedder.Embed()`, and persists via `store.InsertEmbedding()`. Failures are logged but don't block the pipeline (graceful degradation).
+
+**Implication**: The learning tool can reuse all three layers directly. No new store methods are needed.
+
+## R2: Source Type Filtering Mechanism
+
+**Question**: How does `dewey_semantic_search_filtered` filter by source type?
+
+**Finding**: The `SearchSimilarFiltered()` method in `store/embeddings.go` (line 204-209) filters by source type using a SQL `LIKE` prefix match on `pages.source_id`:
+
+```sql
+AND p.source_id LIKE ? ESCAPE '\'
+```
+
+With the argument `escapeLike(filters.SourceType) + "%"`. The `inferSourceType()` function (line 363-371) extracts the type by splitting on the first `-` character.
+
+**Implication**: If we set `source_id = "learning"` (no dash suffix), `inferSourceType("learning")` returns `"learning"`. Filtering with `source_type: "learning"` will match `LIKE 'learning%'`. This works correctly. However, for consistency with the existing convention (`type-name`), we should use `source_id = "learning-agent"` or similar. But the spec says `source_id = "learning"` — let's use that since it's simpler and `inferSourceType` handles it correctly (returns the full string when no `-` is found).
+
+**Decision**: Use `source_id = "learning"` as specified. The `inferSourceType()` function returns `"learning"` for this ID, and the `LIKE 'learning%'` filter matches it. Both `source_type: "learning"` and `source_id: "learning"` filters will work.
+
+## R3: Tag Storage Mechanism
+
+**Question**: How are tags stored so `dewey_semantic_search_filtered(has_tag: "gotcha")` works?
+
+**Finding**: The `SearchSimilarFiltered()` method checks for tags in two places (line 221-228):
+1. Page properties JSON: `p.properties LIKE '%tag%'`
+2. Block content: `b.content LIKE '%#tag%'`
+
+Page properties are stored as a JSON string in `pages.properties`. The spec says tags should be stored as page properties.
+
+**Implication**: We need to store tags in the page's `Properties` field as a JSON object. The format `{"tags": "tag1, tag2, tag3"}` would be matched by the `LIKE` check. Alternatively, we can store individual tag properties. The simplest approach that works with the existing filter: store `{"tags": "006-unified-ignore, gotcha, vault-walker"}` as the properties JSON. The `has_tag: "gotcha"` filter does `LIKE '%gotcha%'` on properties, which matches.
+
+**Decision**: Store tags as `{"tags": "tag1, tag2, ..."}` in the page properties JSON. This is the simplest approach that works with the existing `has_tag` filter without any changes to the search infrastructure.
+
+## R4: MCP Tool Registration Pattern
+
+**Question**: What pattern do existing tools follow for registration?
+
+**Finding**: Two patterns exist in `server.go`:
+
+1. **Typed handler** (preferred, used by most tools): `mcp.AddTool(srv, &mcp.Tool{Name, Description}, handler.Method)` where the method signature is `func(ctx, *mcp.CallToolRequest, InputType) (*mcp.CallToolResult, any, error)`. The MCP SDK auto-generates the JSON schema from the input struct's `json` and `jsonschema` tags.
+
+2. **Raw handler** (used by `upsert_blocks` and `reload`): `srv.AddTool(&mcp.Tool{Name, Description, InputSchema}, rawHandler)` where the handler manually parses JSON. Used when the input has recursive types the schema generator can't handle.
+
+**Implication**: The learning tool has a simple, flat input (two string fields). Use the typed handler pattern (pattern 1).
+
+## R5: Tool Handler Struct Pattern
+
+**Question**: How are tool handler structs organized?
+
+**Finding**: Each tool category has its own struct in the `tools` package:
+- `tools.Semantic` — holds `embedder` and `store`, created via `NewSemantic(embedder, store)`
+- `tools.Write` — holds `backend`, created via `NewWrite(backend)`
+- `tools.Navigate` — holds `backend`, created via `NewNavigate(backend)`
+
+Each struct has methods matching the MCP handler signature. The struct is created in `newServer()` and its methods are registered as tool handlers.
+
+**Implication**: Create a `tools.Learning` struct with `embedder` and `store` fields (same as `Semantic`), plus a `NewLearning()` constructor. Register via `registerLearningTools()` in `server.go`.
+
+## R6: Block UUID Generation
+
+**Question**: How are block UUIDs generated for programmatically created content?
+
+**Finding**: `vault.ParseDocument(docID, content)` calls `parseMarkdownBlocks(docID, body)` which generates deterministic UUIDs from the document ID seed. For learnings, we need unique UUIDs. The simplest approach: use a UUID based on a combination of timestamp and content hash, or use the `crypto/rand` package for random UUIDs.
+
+Looking at the existing code, `parseMarkdownBlocks` uses a deterministic seed. For learnings, since each is unique, we can either:
+1. Use `ParseDocument()` with a unique docID (e.g., `"learning-" + timestamp`)
+2. Generate UUIDs manually
+
+**Decision**: Use `vault.ParseDocument()` with a unique document ID (`"learning-" + timestamp`). This reuses the existing parsing pipeline and generates deterministic UUIDs from the document ID, which is unique per learning.
+
+## R7: Reindex Protection
+
+**Question**: How do we ensure learnings survive `dewey reindex`?
+
+**Finding**: The `reindex` command in `cli.go` deletes pages by source before re-indexing. It operates on configured sources (disk, GitHub, web). Since learnings use `source_id = "learning"` which is not a configured source in `sources.yaml`, the reindex command will not touch them.
+
+Specifically, `DeletePagesBySource(sourceID)` is called per configured source. The learning source is never configured as a source, so its pages are never deleted during reindex.
+
+**Implication**: No special protection needed. Learnings are naturally preserved because they use a source ID that is not part of the configured source pipeline.
+
+## R8: Page Name Uniqueness
+
+**Question**: How do we ensure learning page names don't collide with existing pages?
+
+**Finding**: The `pages` table has a unique constraint on `name`. We need a naming scheme that avoids collisions with vault pages, GitHub pages, and other learnings.
+
+**Decision**: Use the format `learning/{timestamp}` (e.g., `learning/1712150400000`). The `learning/` namespace prefix avoids collisions with all other content. The Unix millisecond timestamp ensures uniqueness across learnings (sub-millisecond collisions are astronomically unlikely for agent-generated learnings).

--- a/specs/008-store-learning/spec.md
+++ b/specs/008-store-learning/spec.md
@@ -1,0 +1,99 @@
+# Feature Specification: Store Learning MCP Tool
+
+**Feature Branch**: `008-store-learning`
+**Created**: 2026-04-03
+**Status**: Draft
+**Input**: GitHub issue #25 — Add dewey_store_learning MCP tool for semantic memory (Spec 021 FR-007–FR-011)
+
+## User Scenarios & Testing *(mandatory)*
+
+### User Story 1 - Store and Retrieve Learnings (Priority: P1)
+
+An AI agent completes a complex task — fixing a subtle race condition, discovering an undocumented API constraint, or identifying a pattern that worked well during implementation. The agent calls `dewey_store_learning` with a natural language paragraph describing the learning and optional tags. The learning is persisted in Dewey's index with an embedding, making it immediately searchable via `dewey_semantic_search`. The next time any agent encounters a similar problem, the learning surfaces in search results alongside specs, code docs, and other indexed content.
+
+**Why this priority**: This is the core capability — without store and retrieve, there is no semantic memory. This single story delivers the full value loop: store a learning, search for it later, find it.
+
+**Independent Test**: Call `dewey_store_learning` with a learning about "scaffold patterns." Query `dewey_semantic_search` for "scaffold patterns." Verify the learning appears in results with provenance metadata indicating it's a learning document.
+
+**Acceptance Scenarios**:
+
+1. **Given** a running Dewey instance with embeddings enabled, **When** an agent calls `dewey_store_learning` with `information: "The vault walker must build its ignore matcher in New(), not Load(), because IncrementalIndex() runs before Load() on the persistent store path."`, **Then** the tool returns a UUID identifying the stored learning
+2. **Given** a learning was just stored, **When** an agent calls `dewey_semantic_search` with `query: "ignore matcher lifecycle vault startup"`, **Then** the learning appears in the results with its content and provenance metadata
+3. **Given** a learning was stored with `tags: "006-unified-ignore, gotcha, vault-walker"`, **When** an agent calls `dewey_semantic_search_filtered` with `has_tag: "gotcha"`, **Then** only learnings and other documents tagged "gotcha" appear in results
+
+---
+
+### User Story 2 - Learnings Persist Across Sessions (Priority: P2)
+
+An agent stores a learning during one OpenCode session. The developer closes OpenCode, restarts it the next day, and starts a new session with a new agent. The new agent searches for context and finds the learning from the previous session. Learnings survive `dewey serve` restarts because they are persisted in the same SQLite store as all other indexed content.
+
+**Why this priority**: Without persistence, learnings are lost when the MCP server restarts — defeating the purpose of a memory layer. This is the second most important capability after basic store/retrieve.
+
+**Independent Test**: Store a learning. Restart `dewey serve`. Query for the learning. Verify it persists.
+
+**Acceptance Scenarios**:
+
+1. **Given** a learning was stored in a previous session, **When** `dewey serve` restarts and an agent queries `dewey_semantic_search` with terms related to the learning, **Then** the learning appears in results
+2. **Given** a learning was stored, **When** `dewey reindex` is run, **Then** the learning is preserved (reindex only rebuilds disk-source content, not stored learnings)
+
+---
+
+### User Story 3 - Learnings Coexist with Other Content (Priority: P3)
+
+A developer has indexed local Markdown files, GitHub issues, and web documentation in Dewey. When they store learnings, those learnings are searchable alongside all other content — not in a separate silo. A search for "authentication timeout" might return a specification, a GitHub issue, and a learning about a past debugging session — all in a single query. Learnings are distinguished from other documents by their provenance metadata, allowing agents to filter for learnings specifically when needed.
+
+**Why this priority**: The value of unified search is that learnings enhance the existing knowledge graph rather than living in a separate system. This is what makes Dewey's approach superior to Swarm's separate Hivemind store.
+
+**Independent Test**: Store a learning about "authentication timeout." Index a spec that mentions authentication. Query `dewey_semantic_search` for "authentication timeout." Verify both the learning and the spec appear in results. Query `dewey_semantic_search_filtered` with `source_type: "learning"` to verify learnings can be filtered specifically.
+
+**Acceptance Scenarios**:
+
+1. **Given** a learning and a spec document both discuss "authentication," **When** an agent queries `dewey_semantic_search` for "authentication timeout," **Then** both the learning and the spec appear in results, ranked by semantic similarity
+2. **Given** multiple learnings and specs exist in the index, **When** an agent queries `dewey_semantic_search_filtered` with a source type filter for learnings, **Then** only learning documents are returned
+
+---
+
+### Edge Cases
+
+- What happens when Ollama is unavailable (keyword-only mode)? The learning text is stored in the index but without an embedding. It will be findable via `dewey_search` (keyword search) but not via `dewey_semantic_search` until embeddings are generated. An informational message is returned with the UUID.
+- What happens when the `information` parameter is empty? The tool returns an error: "information parameter is required and must not be empty."
+- What happens when the same learning is stored twice? Two separate documents are created with different UUIDs. Deduplication is the agent's responsibility — Dewey does not merge or deduplicate learnings.
+- What happens when `dewey reindex` is run? Learnings are preserved. Reindex only rebuilds content from disk/GitHub/web sources. Learnings have a distinct source type and are not affected by reindex operations.
+- What happens when the store is not configured (in-memory mode)? The tool returns an error explaining that persistent storage is required for learnings.
+
+## Requirements *(mandatory)*
+
+### Functional Requirements
+
+- **FR-001**: Dewey MUST provide an MCP tool named `dewey_store_learning` that accepts `information` (required string) and `tags` (optional comma-separated string) parameters
+- **FR-002**: Stored learnings MUST be persisted in Dewey's index and be immediately searchable via `dewey_semantic_search` and `dewey_search`
+- **FR-003**: Learnings MUST include provenance metadata distinguishing them from other document types — specifically a source type of "learning" that is visible in search results
+- **FR-004**: Learnings MUST support tags for filtering via `dewey_semantic_search_filtered` using the existing `has_tag` parameter
+- **FR-005**: The tool MUST generate embeddings for the learning text using the same embedding model and chunking strategy as other indexed content
+- **FR-006**: The tool MUST return the UUID of the stored learning on success
+- **FR-007**: The tool MUST return a clear error when `information` is empty, when the persistent store is not configured, or when any storage operation fails
+- **FR-008**: Learnings MUST survive `dewey serve` restarts and `dewey reindex` operations
+- **FR-009**: When Ollama is unavailable, the tool MUST store the learning text without embeddings and return an informational message indicating that semantic search will be unavailable until embeddings are generated
+- **FR-010**: The `dewey_store_learning` tool MUST be registered alongside the existing 40 MCP tools in the server setup, bringing the total to 41
+
+### Key Entities
+
+- **Learning**: A stored piece of knowledge with natural language content, optional tags, provenance metadata (source type "learning"), and a vector embedding. Created by agents via the MCP tool and persisted in the same store as all other indexed content.
+
+## Success Criteria *(mandatory)*
+
+### Measurable Outcomes
+
+- **SC-001**: An agent can store a learning and retrieve it via semantic search within the same session — round-trip time under 2 seconds
+- **SC-002**: Learnings persist across `dewey serve` restarts — 100% of previously stored learnings are searchable after restart
+- **SC-003**: Learnings appear in unified search results alongside specs, issues, and other content — no separate query endpoint needed
+- **SC-004**: Learnings can be filtered specifically via source type metadata — `dewey_semantic_search_filtered(source_type: "learning")` returns only learnings
+- **SC-005**: All existing 40 MCP tools continue to function identically after the new tool is added
+
+## Assumptions
+
+- Learnings are stored as pages in Dewey's existing store with a special source ID prefix (e.g., `learning-{branch}-{timestamp}`) that distinguishes them from disk/GitHub/web sources.
+- The existing `dewey_semantic_search_filtered` tool's `source_type` parameter can filter by the learning source type without modification — the filter already supports arbitrary source type matching.
+- Tags are stored as page properties (matching the existing property system) so `dewey_semantic_search_filtered(has_tag: "gotcha")` works without changes to the search infrastructure.
+- The learning document is represented as a single page with one block containing the full learning text. This matches the existing page/block model and enables the block-level chunking and embedding pipeline to process it naturally.
+- Deduplication of learnings is the agent's responsibility. Dewey stores every `dewey_store_learning` call as a new document.

--- a/specs/008-store-learning/tasks.md
+++ b/specs/008-store-learning/tasks.md
@@ -1,0 +1,107 @@
+# Tasks: Store Learning MCP Tool
+
+**Input**: Design documents from `/specs/008-store-learning/`
+**Prerequisites**: plan.md (required), spec.md (required for user stories), research.md, quickstart.md
+
+## Format: `[ID] [P?] [Story] Description`
+
+- **[P]**: Can run in parallel (different files, no dependencies)
+- **[Story]**: Which user story this task belongs to (e.g., US1, US2, US3)
+- Include exact file paths in descriptions
+
+---
+
+## Phase 1: Setup (Input Type)
+
+**Purpose**: Define the MCP tool input struct that all subsequent phases depend on
+
+- [x] T001 [US1] Add `StoreLearningInput` struct to `types/tools.go` after the `SemanticSearchFilteredInput` section (line ~231), before the Journal section. Fields: `Information string` (required, `json:"information"`) and `Tags string` (optional, `json:"tags,omitempty"`). Include GoDoc comment and `jsonschema` tags per existing conventions. Maps to FR-001.
+
+**Checkpoint**: `go build ./...` passes — new type is valid Go
+
+---
+
+## Phase 2: Core Implementation (Tool Handler)
+
+**Purpose**: Create the `Learning` struct and `StoreLearning` handler — the core business logic
+
+- [x] T002 [US1] Create `tools/learning.go` with package declaration, imports, `Learning` struct (fields: `embedder embed.Embedder`, `store *store.Store`), and `NewLearning(e embed.Embedder, s *store.Store) *Learning` constructor. Follow the `tools/semantic.go` pattern (Dependency Inversion Principle). Include GoDoc comments on struct and constructor.
+- [x] T003 [US1] Implement `StoreLearning` handler method on `Learning` struct in `tools/learning.go`. Signature: `func (l *Learning) StoreLearning(ctx context.Context, req *mcp.CallToolRequest, input types.StoreLearningInput) (*mcp.CallToolResult, any, error)`. Implement: (1) validate `input.Information` is non-empty (FR-007), (2) validate `l.store` is non-nil (FR-007), (3) generate unique page name `learning/{unixMillis}` and doc ID `learning-{unixMillis}` (R8), (4) build properties JSON with tags if provided (FR-004, R3), (5) call `store.InsertPage` with `SourceID: "learning"` (FR-003, R2), (6) call `vault.ParseDocument` + `vault.PersistBlocks` (FR-002, R6), (7) call `vault.GenerateEmbeddings` if embedder available, else set informational message (FR-005, FR-009), (8) return JSON with UUID, page name, and message (FR-006). Use `errorResult()` and `jsonTextResult()` helpers from `tools/helpers.go`.
+
+**Checkpoint**: `go build ./...` passes — handler compiles with all dependencies resolved
+
+---
+
+## Phase 3: Registration (Wire into Server)
+
+**Purpose**: Register the new tool in the MCP server, gated by `!readOnly`
+
+- [x] T004 [US1] Add `registerLearningTools(srv *mcp.Server, learning *tools.Learning)` function to `server.go`. Register `dewey_store_learning` tool using the typed handler pattern (`mcp.AddTool`). Tool description: "Store a learning (insight, pattern, gotcha) with optional tags. The learning is persisted with embeddings and immediately searchable via dewey_semantic_search. Use to build semantic memory across sessions." Maps to FR-010.
+- [x] T005 [US1] Add learning tool instantiation and registration call in `newServer()` in `server.go`. Place inside the existing `if !readOnly` block (after write/decision tools) or in a new `if !readOnly` block after `registerSemanticTools`. Create `learning := tools.NewLearning(cfg.embedder, cfg.store)` and call `registerLearningTools(srv, learning)`. Maps to FR-010.
+
+**Checkpoint**: `go build ./...` passes — tool #41 is registered. `go vet ./...` clean.
+
+---
+
+## Phase 4: Tests
+
+**Purpose**: Contract-level tests covering happy path, error paths, and graceful degradation
+
+- [x] T006 [P] [US1] Create `tools/learning_test.go` with `TestStoreLearning_Basic`: create in-memory store, mock embedder, call `StoreLearning` with valid information text. Assert: no error, result contains UUID (non-empty), result contains page name matching `learning/` prefix, result is not an error result. Validates FR-001, FR-002, FR-006.
+- [x] T007 [P] [US1] Add `TestStoreLearning_EmptyInformation` to `tools/learning_test.go`: call `StoreLearning` with empty `Information` field. Assert: result `IsError` is true, error text contains "information parameter is required". Validates FR-007.
+- [x] T008 [P] [US1] Add `TestStoreLearning_NilStore` to `tools/learning_test.go`: create `Learning` with nil store. Call `StoreLearning` with valid input. Assert: result `IsError` is true, error text mentions persistent storage. Validates FR-007.
+- [x] T009 [P] [US1] Add `TestStoreLearning_WithTags` to `tools/learning_test.go`: call `StoreLearning` with `Tags: "gotcha, vault-walker"`. Assert: stored page properties contain `"tags"` key with the tag values. Query store to verify page properties JSON. Validates FR-004.
+- [x] T010 [P] [US1] Add `TestStoreLearning_EmbedderUnavailable` to `tools/learning_test.go`: create `Learning` with a mock embedder whose `Available()` returns false. Call `StoreLearning`. Assert: result is NOT an error (learning is stored), result message contains informational text about embeddings not generated. Validates FR-009.
+- [x] T011 [P] [US1] Add `TestStoreLearning_NilEmbedder` to `tools/learning_test.go`: create `Learning` with nil embedder. Call `StoreLearning`. Assert: result is NOT an error (learning is stored), result message contains informational text about embeddings. Validates FR-009.
+- [x] T012 [US1] Add `TestStoreLearning_Searchable` to `tools/learning_test.go`: store a learning about "scaffold patterns in Go templates", then call `store.SearchSimilar` (or verify page exists via `store.GetPageByName`). Assert: the stored learning page exists in the store with correct source_id "learning" and content block. Validates FR-002, SC-001.
+- [x] T013 [US3] Add `TestStoreLearning_FilterBySourceType` to `tools/learning_test.go`: store a learning, then call `store.SearchSimilarFiltered` with `SourceType: "learning"`. Assert: the learning appears in filtered results. If embedder mock doesn't support full vector search, verify via `store.GetPageByName` that `source_id` is "learning" and `inferSourceType` would return "learning". Validates FR-003, SC-004.
+
+**Checkpoint**: `go test -race -count=1 ./tools/...` — all 8 tests pass
+
+---
+
+## Phase 5: Verification (CI Parity Gate)
+
+**Purpose**: Full CI-equivalent validation before declaring implementation complete
+
+- [x] T014 Run CI parity gate: execute `go build ./...`, `go vet ./...`, and `go test -race -count=1 ./...` from repo root. All must pass. Fix any failures before proceeding. Validates SC-005 (existing 40 tools unaffected).
+- [x] T015 Validate documentation: verify GoDoc comments exist on `StoreLearningInput`, `Learning` struct, `NewLearning`, `StoreLearning` method, and `registerLearningTools`. Update `AGENTS.md` if needed (tool count reference). Assess README.md impact.
+
+**Checkpoint**: All CI checks pass. Implementation is complete and ready for review.
+
+---
+
+## Dependencies & Execution Order
+
+### Phase Dependencies
+
+- **Phase 1 (Setup)**: No dependencies — start immediately
+- **Phase 2 (Core)**: Depends on Phase 1 (uses `StoreLearningInput` type)
+- **Phase 3 (Registration)**: Depends on Phase 2 (uses `Learning` struct and `NewLearning`)
+- **Phase 4 (Tests)**: Depends on Phase 2 (tests the handler). T006-T011 are parallel (different test functions, same file). T012-T013 depend on T006 pattern but can be written in any order.
+- **Phase 5 (Verification)**: Depends on all previous phases
+
+### Parallel Opportunities
+
+```
+Phase 4 parallel batch:
+  T006: TestStoreLearning_Basic
+  T007: TestStoreLearning_EmptyInformation
+  T008: TestStoreLearning_NilStore
+  T009: TestStoreLearning_WithTags
+  T010: TestStoreLearning_EmbedderUnavailable
+  T011: TestStoreLearning_NilEmbedder
+```
+
+All six tests touch the same file (`tools/learning_test.go`) but are independent test functions. When implemented by a single agent, write them sequentially in one pass. The `[P]` marker indicates they have no logical dependencies on each other.
+
+### User Story Coverage
+
+| Story | Tasks | Coverage |
+|-------|-------|----------|
+| US1 — Store and Retrieve | T001-T012 | FR-001 through FR-010, SC-001, SC-005 |
+| US2 — Persist Across Sessions | (inherent) | FR-008 — SQLite persistence is automatic; no task needed |
+| US3 — Coexist with Other Content | T013 | FR-003, SC-003, SC-004 |
+
+US2 requires no dedicated implementation task because learnings use `source_id = "learning"` which is not a configured source — `dewey reindex` never deletes them (R7). Persistence is inherent to the SQLite store.
+<!-- spec-review: passed -->

--- a/tools/learning.go
+++ b/tools/learning.go
@@ -1,0 +1,124 @@
+package tools
+
+import (
+	"context"
+	"crypto/sha256"
+	"database/sql"
+	"encoding/json"
+	"fmt"
+	"time"
+
+	"github.com/modelcontextprotocol/go-sdk/mcp"
+	"github.com/unbound-force/dewey/embed"
+	"github.com/unbound-force/dewey/store"
+	"github.com/unbound-force/dewey/types"
+	"github.com/unbound-force/dewey/vault"
+)
+
+// Learning implements the dewey_store_learning MCP tool for persisting
+// agent learnings (insights, patterns, gotchas) into the knowledge graph.
+//
+// Design decision: The embedder and store are injected as dependencies
+// (Dependency Inversion Principle) following the same pattern as Semantic.
+// This enables testing with mocks and supports graceful degradation when
+// Ollama is unavailable — learnings are stored without embeddings and
+// remain searchable via keyword search.
+type Learning struct {
+	embedder embed.Embedder
+	store    *store.Store
+}
+
+// NewLearning creates a new Learning tool handler with the given embedder
+// and store. The embedder may be nil — the tool stores learnings without
+// embeddings when unavailable (graceful degradation). The store must be
+// non-nil for the tool to function; a clear error is returned at call time
+// if it is nil.
+func NewLearning(e embed.Embedder, s *store.Store) *Learning {
+	return &Learning{embedder: e, store: s}
+}
+
+// StoreLearning handles the dewey_store_learning MCP tool. Persists a
+// learning (insight, pattern, gotcha) into the knowledge graph with optional
+// tags. The learning is parsed into blocks, stored in SQLite, and optionally
+// embedded for semantic search.
+//
+// Returns a JSON result with the learning's UUID, page name, and a status
+// message. Returns an MCP error result (not a Go error) if the input is
+// invalid or the store is unavailable.
+func (l *Learning) StoreLearning(ctx context.Context, req *mcp.CallToolRequest, input types.StoreLearningInput) (*mcp.CallToolResult, any, error) {
+	if input.Information == "" {
+		return errorResult("information parameter is required and must not be empty"), nil, nil
+	}
+	if l.store == nil {
+		return errorResult("store_learning requires persistent storage. Configure --vault with a .dewey/ directory."), nil, nil
+	}
+
+	// Generate unique page name and document ID using Unix millisecond timestamp.
+	// The learning/ namespace keeps learnings visually distinct from vault pages.
+	timestamp := time.Now().UnixMilli()
+	pageName := fmt.Sprintf("learning/%d", timestamp)
+	docID := fmt.Sprintf("learning-%d", timestamp)
+
+	// Build properties JSON with tags if provided (FR-004).
+	properties := "{}"
+	if input.Tags != "" {
+		propsMap := map[string]string{"tags": input.Tags}
+		propsJSON, err := json.Marshal(propsMap)
+		if err != nil {
+			return errorResult(fmt.Sprintf("failed to marshal properties: %v", err)), nil, nil
+		}
+		properties = string(propsJSON)
+	}
+
+	// Compute a short content hash for deduplication support.
+	hash := sha256.Sum256([]byte(input.Information))
+	contentHash := fmt.Sprintf("%x", hash[:8])
+
+	// Insert the page with source_id "learning" to distinguish from other
+	// content sources (FR-003). This ensures learnings are never deleted by
+	// dewey reindex (which only purges configured sources).
+	page := &store.Page{
+		Name:         pageName,
+		OriginalName: pageName,
+		SourceID:     "learning",
+		SourceDocID:  docID,
+		Properties:   properties,
+		ContentHash:  contentHash,
+	}
+	if err := l.store.InsertPage(page); err != nil {
+		return errorResult(fmt.Sprintf("failed to store learning: %v", err)), nil, nil
+	}
+
+	// Parse the learning text into blocks using the shared parsing pipeline.
+	_, blocks := vault.ParseDocument(docID, input.Information)
+
+	// Persist blocks to the store.
+	if err := vault.PersistBlocks(l.store, pageName, blocks, sql.NullString{}, 0); err != nil {
+		return errorResult(fmt.Sprintf("failed to persist learning blocks: %v", err)), nil, nil
+	}
+
+	// Generate embeddings if the embedder is available (FR-005, FR-009).
+	// Graceful degradation: learnings are stored without embeddings when
+	// Ollama is unavailable, remaining searchable via keyword search.
+	var embeddingMsg string
+	if l.embedder != nil && l.embedder.Available() {
+		vault.GenerateEmbeddings(l.store, l.embedder, pageName, blocks, nil)
+	} else {
+		embeddingMsg = " Note: Embeddings were not generated (Ollama unavailable). The learning is stored and searchable via keyword search. Semantic search will be available after embeddings are generated."
+	}
+
+	// Return the first block's UUID as the learning identifier (FR-006).
+	learningUUID := ""
+	if len(blocks) > 0 {
+		learningUUID = blocks[0].UUID
+	}
+
+	result := map[string]any{
+		"uuid":    learningUUID,
+		"page":    pageName,
+		"message": "Learning stored successfully." + embeddingMsg,
+	}
+
+	res, err := jsonTextResult(result)
+	return res, nil, err
+}

--- a/tools/learning_test.go
+++ b/tools/learning_test.go
@@ -1,0 +1,331 @@
+package tools
+
+import (
+	"context"
+	"encoding/json"
+	"strings"
+	"testing"
+
+	"github.com/unbound-force/dewey/store"
+	"github.com/unbound-force/dewey/types"
+)
+
+// newTestStore creates an in-memory store for learning tests.
+// Registers a cleanup function to close the store when the test completes.
+func newTestStore(t *testing.T) *store.Store {
+	t.Helper()
+	s, err := store.New(":memory:")
+	if err != nil {
+		t.Fatalf("store.New: %v", err)
+	}
+	t.Cleanup(func() { _ = s.Close() })
+	return s
+}
+
+// TestStoreLearning_Basic verifies the happy path: storing a learning with
+// a valid information string and nil embedder returns a successful result
+// containing a UUID and page name with the "learning/" prefix.
+func TestStoreLearning_Basic(t *testing.T) {
+	s := newTestStore(t)
+	l := NewLearning(nil, s)
+
+	result, _, err := l.StoreLearning(context.Background(), nil, types.StoreLearningInput{
+		Information: "The vault walker must build its ignore matcher in New()",
+	})
+	if err != nil {
+		t.Fatalf("StoreLearning error: %v", err)
+	}
+	if result == nil {
+		t.Fatal("expected non-nil result")
+	}
+	if result.IsError {
+		t.Fatalf("StoreLearning returned error result: %s", resultText(result))
+	}
+
+	// Parse the JSON result to verify structure.
+	text := resultText(result)
+	var parsed map[string]any
+	if err := json.Unmarshal([]byte(text), &parsed); err != nil {
+		t.Fatalf("unmarshal result: %v", err)
+	}
+
+	// Assert UUID is present and non-empty.
+	uuid, ok := parsed["uuid"].(string)
+	if !ok || uuid == "" {
+		t.Errorf("expected non-empty uuid in result, got %v", parsed["uuid"])
+	}
+
+	// Assert page name has "learning/" prefix.
+	page, ok := parsed["page"].(string)
+	if !ok || !strings.HasPrefix(page, "learning/") {
+		t.Errorf("expected page with 'learning/' prefix, got %q", page)
+	}
+
+	// Assert message indicates success.
+	msg, ok := parsed["message"].(string)
+	if !ok || !strings.Contains(msg, "stored successfully") {
+		t.Errorf("expected success message, got %q", msg)
+	}
+}
+
+// TestStoreLearning_EmptyInformation verifies that an empty information
+// string returns an error result mentioning "information".
+func TestStoreLearning_EmptyInformation(t *testing.T) {
+	s := newTestStore(t)
+	l := NewLearning(nil, s)
+
+	result, _, err := l.StoreLearning(context.Background(), nil, types.StoreLearningInput{
+		Information: "",
+	})
+	if err != nil {
+		t.Fatalf("StoreLearning error: %v", err)
+	}
+	if !result.IsError {
+		t.Fatal("expected error result for empty information")
+	}
+
+	text := resultText(result)
+	if !strings.Contains(text, "information") {
+		t.Errorf("error message = %q, should mention 'information'", text)
+	}
+}
+
+// TestStoreLearning_NilStore verifies that a nil store returns an error
+// result mentioning persistent storage.
+func TestStoreLearning_NilStore(t *testing.T) {
+	l := NewLearning(nil, nil)
+
+	result, _, err := l.StoreLearning(context.Background(), nil, types.StoreLearningInput{
+		Information: "test learning",
+	})
+	if err != nil {
+		t.Fatalf("StoreLearning error: %v", err)
+	}
+	if !result.IsError {
+		t.Fatal("expected error result when store is nil")
+	}
+
+	text := resultText(result)
+	if !strings.Contains(text, "persistent storage") {
+		t.Errorf("error message = %q, should mention 'persistent storage'", text)
+	}
+}
+
+// TestStoreLearning_WithTags verifies that tags are stored as page
+// properties when provided.
+func TestStoreLearning_WithTags(t *testing.T) {
+	s := newTestStore(t)
+	l := NewLearning(nil, s)
+
+	result, _, err := l.StoreLearning(context.Background(), nil, types.StoreLearningInput{
+		Information: "test learning with tags",
+		Tags:        "gotcha, vault-walker",
+	})
+	if err != nil {
+		t.Fatalf("StoreLearning error: %v", err)
+	}
+	if result.IsError {
+		t.Fatalf("StoreLearning returned error result: %s", resultText(result))
+	}
+
+	// Extract the page name from the result to look it up in the store.
+	text := resultText(result)
+	var parsed map[string]any
+	if err := json.Unmarshal([]byte(text), &parsed); err != nil {
+		t.Fatalf("unmarshal result: %v", err)
+	}
+	pageName, ok := parsed["page"].(string)
+	if !ok || pageName == "" {
+		t.Fatalf("expected non-empty page name in result, got %v", parsed["page"])
+	}
+
+	// Query the store directly to verify properties contain tags.
+	page, err := s.GetPage(pageName)
+	if err != nil {
+		t.Fatalf("GetPage(%q): %v", pageName, err)
+	}
+	if page == nil {
+		t.Fatalf("page %q not found in store", pageName)
+	}
+
+	// Verify the properties JSON contains the tags.
+	var props map[string]string
+	if err := json.Unmarshal([]byte(page.Properties), &props); err != nil {
+		t.Fatalf("unmarshal properties: %v", err)
+	}
+	if props["tags"] != "gotcha, vault-walker" {
+		t.Errorf("tags = %q, want %q", props["tags"], "gotcha, vault-walker")
+	}
+}
+
+// TestStoreLearning_EmbedderUnavailable verifies that when the embedder
+// reports Available() == false, the learning is still stored successfully
+// and the message mentions embeddings.
+func TestStoreLearning_EmbedderUnavailable(t *testing.T) {
+	s := newTestStore(t)
+	e := newMockEmbedder(false) // Available() returns false
+	l := NewLearning(e, s)
+
+	result, _, err := l.StoreLearning(context.Background(), nil, types.StoreLearningInput{
+		Information: "learning with unavailable embedder",
+	})
+	if err != nil {
+		t.Fatalf("StoreLearning error: %v", err)
+	}
+	// Learning should still be stored — not an error result.
+	if result.IsError {
+		t.Fatalf("expected successful result even when embedder unavailable, got error: %s", resultText(result))
+	}
+
+	// Message should mention that embeddings were not generated.
+	text := resultText(result)
+	var parsed map[string]any
+	if err := json.Unmarshal([]byte(text), &parsed); err != nil {
+		t.Fatalf("unmarshal result: %v", err)
+	}
+	msg, _ := parsed["message"].(string)
+	if !strings.Contains(msg, "Embeddings") && !strings.Contains(msg, "embeddings") {
+		t.Errorf("message = %q, should mention embeddings", msg)
+	}
+}
+
+// TestStoreLearning_NilEmbedder verifies that when the embedder is nil,
+// the learning is still stored successfully and the message mentions
+// embeddings not being generated.
+func TestStoreLearning_NilEmbedder(t *testing.T) {
+	s := newTestStore(t)
+	l := NewLearning(nil, s) // nil embedder
+
+	result, _, err := l.StoreLearning(context.Background(), nil, types.StoreLearningInput{
+		Information: "learning with nil embedder",
+	})
+	if err != nil {
+		t.Fatalf("StoreLearning error: %v", err)
+	}
+	// Learning should still be stored — not an error result.
+	if result.IsError {
+		t.Fatalf("expected successful result even when embedder is nil, got error: %s", resultText(result))
+	}
+
+	// Message should mention that embeddings were not generated.
+	text := resultText(result)
+	var parsed map[string]any
+	if err := json.Unmarshal([]byte(text), &parsed); err != nil {
+		t.Fatalf("unmarshal result: %v", err)
+	}
+	msg, _ := parsed["message"].(string)
+	if !strings.Contains(msg, "Embeddings") && !strings.Contains(msg, "embeddings") {
+		t.Errorf("message = %q, should mention embeddings", msg)
+	}
+}
+
+// TestStoreLearning_Searchable verifies that a stored learning creates a
+// page in the store that can be found by listing pages, with source_id
+// set to "learning".
+func TestStoreLearning_Searchable(t *testing.T) {
+	s := newTestStore(t)
+	l := NewLearning(nil, s)
+
+	result, _, err := l.StoreLearning(context.Background(), nil, types.StoreLearningInput{
+		Information: "searchable learning content",
+	})
+	if err != nil {
+		t.Fatalf("StoreLearning error: %v", err)
+	}
+	if result.IsError {
+		t.Fatalf("StoreLearning returned error: %s", resultText(result))
+	}
+
+	// Extract the page name from the result.
+	text := resultText(result)
+	var parsed map[string]any
+	if err := json.Unmarshal([]byte(text), &parsed); err != nil {
+		t.Fatalf("unmarshal result: %v", err)
+	}
+	pageName, _ := parsed["page"].(string)
+
+	// Verify the page exists in the store.
+	pages, err := s.ListPages()
+	if err != nil {
+		t.Fatalf("ListPages: %v", err)
+	}
+
+	var found bool
+	for _, p := range pages {
+		if p.Name == pageName {
+			found = true
+			if p.SourceID != "learning" {
+				t.Errorf("page %q source_id = %q, want %q", pageName, p.SourceID, "learning")
+			}
+			break
+		}
+	}
+	if !found {
+		t.Errorf("page %q not found in store after StoreLearning", pageName)
+	}
+
+	// Verify blocks were persisted for the page.
+	blocks, err := s.GetBlocksByPage(pageName)
+	if err != nil {
+		t.Fatalf("GetBlocksByPage(%q): %v", pageName, err)
+	}
+	if len(blocks) == 0 {
+		t.Errorf("expected at least 1 block for page %q, got 0", pageName)
+	}
+}
+
+// TestStoreLearning_FilterBySourceType verifies that the stored learning
+// page has source_id = "learning", which enables filtering via
+// dewey_semantic_search_filtered. This proves the learning is distinguishable
+// from other content sources.
+func TestStoreLearning_FilterBySourceType(t *testing.T) {
+	s := newTestStore(t)
+	l := NewLearning(nil, s)
+
+	// Store a learning.
+	result, _, err := l.StoreLearning(context.Background(), nil, types.StoreLearningInput{
+		Information: "filterable learning",
+	})
+	if err != nil {
+		t.Fatalf("StoreLearning error: %v", err)
+	}
+	if result.IsError {
+		t.Fatalf("StoreLearning returned error: %s", resultText(result))
+	}
+
+	// Also insert a non-learning page to verify filtering.
+	err = s.InsertPage(&store.Page{
+		Name:         "regular-page",
+		OriginalName: "regular-page",
+		SourceID:     "disk-local",
+		SourceDocID:  "regular.md",
+		ContentHash:  "abc",
+	})
+	if err != nil {
+		t.Fatalf("InsertPage: %v", err)
+	}
+
+	// List pages by source "learning" — only the learning page should appear.
+	learningPages, err := s.ListPagesBySource("learning")
+	if err != nil {
+		t.Fatalf("ListPagesBySource: %v", err)
+	}
+	if len(learningPages) != 1 {
+		t.Fatalf("expected 1 learning page, got %d", len(learningPages))
+	}
+	if learningPages[0].SourceID != "learning" {
+		t.Errorf("source_id = %q, want %q", learningPages[0].SourceID, "learning")
+	}
+
+	// Verify the regular page is NOT in the learning source.
+	diskPages, err := s.ListPagesBySource("disk-local")
+	if err != nil {
+		t.Fatalf("ListPagesBySource(disk-local): %v", err)
+	}
+	if len(diskPages) != 1 {
+		t.Fatalf("expected 1 disk-local page, got %d", len(diskPages))
+	}
+	if diskPages[0].Name != "regular-page" {
+		t.Errorf("disk page name = %q, want %q", diskPages[0].Name, "regular-page")
+	}
+}

--- a/types/tools.go
+++ b/types/tools.go
@@ -243,6 +243,14 @@ type SemanticSearchResult struct {
 	IndexedAt  string  `json:"indexed_at"`
 }
 
+// --- Learning tool inputs ---
+
+// StoreLearningInput is the input for the dewey_store_learning MCP tool.
+type StoreLearningInput struct {
+	Information string `json:"information" jsonschema:"The learning text to store. Required."`
+	Tags        string `json:"tags,omitempty" jsonschema:"Optional comma-separated tags for filtering (e.g. 'gotcha, vault-walker, 006-unified-ignore')"`
+}
+
 // --- Journal tool inputs ---
 
 type JournalRangeInput struct {


### PR DESCRIPTION
## Summary

- New `dewey_store_learning` MCP tool (tool #41) that lets agents store learnings as persistent, searchable documents
- Learnings stored as pages with `source_id="learning"`, immediately searchable via existing `dewey_semantic_search` and `dewey_semantic_search_filtered` tools
- Graceful degradation: stores text without embeddings when Ollama is unavailable
- 8 contract tests covering happy path, error handling, tags, embedder unavailability, searchability, and source type filtering
- Registered in `server.go` inside `!readOnly` gate (write operation)

Closes #25

## Spec Artifacts

Full Speckit spec in `specs/008-store-learning/` — spec (3 user stories, 10 FRs), plan, research (8 items), quickstart, tasks (15 tasks, all complete).

## Test Results

All 12 packages pass: `go build ./... && go vet ./... && go test -race -count=1 ./...`