### PR TITLE
refactor: drop dewey_ prefix from MCP tool names to avoid double-prefix in OpenCode

### DIFF
--- a/openspec/changes/archive/2026-04-04-drop-dewey-tool-prefix/.openspec.yaml
+++ b/openspec/changes/archive/2026-04-04-drop-dewey-tool-prefix/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: unbound-force
+created: 2026-04-04

--- a/openspec/changes/archive/2026-04-04-drop-dewey-tool-prefix/design.md
+++ b/openspec/changes/archive/2026-04-04-drop-dewey-tool-prefix/design.md
@@ -1,0 +1,28 @@
+## Context
+
+OpenCode prefixes MCP tool names with the server name. Dewey's 4 custom tools are registered with a `dewey_` prefix, resulting in `dewey_dewey_*` double-prefix in agent UIs. The 37 inherited graphthulhu tools have no prefix and display correctly.
+
+## Goals / Non-Goals
+
+### Goals
+- Remove the `dewey_` prefix from 4 tool registration names so agents see `dewey_semantic_search` (not `dewey_dewey_semantic_search`)
+- Maintain identical tool functionality — only the name string changes
+
+### Non-Goals
+- Renaming inherited graphthulhu tools (they're already correct)
+- Changing tool descriptions, parameter schemas, or return types
+- Modifying the MCP server name in `opencode.json`
+
+## Decisions
+
+**D1: Rename in `server.go` only.** The tool name is a single string literal in each `mcp.AddTool()` call. No schema, handler, or type changes needed.
+
+**D2: No backward compatibility shim.** MCP clients discover tools dynamically via `tools/list`. No client hardcodes tool names. A clean rename is safe.
+
+**D3: Keep the `dewey_store_learning` description reference.** The tool description says "dewey_semantic_search" — update this to "semantic_search" for consistency.
+
+## Risks / Trade-offs
+
+**Risk: Agent prompts referencing old tool names.** Any `.opencode/agents/` file or skill that mentions `dewey_semantic_search` by name would need updating. Mitigation: search and replace across agent/skill files.
+
+**Trade-off: Loss of tool name uniqueness.** `semantic_search` is less globally unique than `dewey_semantic_search`. This is acceptable because MCP tool names are scoped to the server — the full identifier is still `dewey.semantic_search` in the protocol.

--- a/openspec/changes/archive/2026-04-04-drop-dewey-tool-prefix/proposal.md
+++ b/openspec/changes/archive/2026-04-04-drop-dewey-tool-prefix/proposal.md
@@ -1,0 +1,58 @@
+## Why
+
+OpenCode prefixes MCP tool names with the server name: `{server}_{tool}`. Since the Dewey MCP server is named `dewey` in `opencode.json` and the Dewey-specific tools are registered as `dewey_semantic_search`, `dewey_similar`, `dewey_semantic_search_filtered`, and `dewey_store_learning`, agents see them as `dewey_dewey_semantic_search` — a redundant double prefix that is confusing and wastes prompt tokens.
+
+The inherited graphthulhu tools (`get_page`, `search`, `traverse`, etc.) display correctly as `dewey_get_page` because they don't have the `dewey_` prefix in their registration name.
+
+## What Changes
+
+Remove the `dewey_` prefix from the 4 Dewey-added MCP tool registration names in `server.go`:
+
+| Current Name | New Name |
+|-------------|----------|
+| `dewey_semantic_search` | `semantic_search` |
+| `dewey_similar` | `similar` |
+| `dewey_semantic_search_filtered` | `semantic_search_filtered` |
+| `dewey_store_learning` | `store_learning` |
+
+## Capabilities
+
+### Modified Capabilities
+- `semantic_search`: Renamed from `dewey_semantic_search` — same functionality
+- `similar`: Renamed from `dewey_similar` — same functionality
+- `semantic_search_filtered`: Renamed from `dewey_semantic_search_filtered` — same functionality
+- `store_learning`: Renamed from `dewey_store_learning` — same functionality
+
+## Impact
+
+- **server.go**: 4 tool name strings changed in `registerSemanticTools()` and `registerLearningTools()`
+- **Agent prompts**: Any agent or documentation that references `dewey_semantic_search` by name needs updating to `semantic_search`. However, since OpenCode agents call tools by the prefixed name (`dewey_semantic_search`), the effective tool name agents see remains the same — this is transparent to callers.
+- **Backward compatibility**: MCP tool names are the contract. Any client hardcoding `dewey_semantic_search` as the tool name would break. In practice, OpenCode discovers tools dynamically so this is non-breaking.
+
+## Constitution Alignment
+
+Assessed against the Unbound Force org constitution.
+
+### I. Autonomous Collaboration
+
+**Assessment**: PASS
+
+Tool names are the artifact-based communication interface. Removing the redundant prefix makes tool names clearer without changing the communication protocol or payload format.
+
+### II. Composability First
+
+**Assessment**: PASS
+
+Dewey remains independently installable. The tool rename is internal to the MCP server registration — no external dependencies are introduced.
+
+### III. Observable Quality
+
+**Assessment**: PASS
+
+All tool outputs retain their existing structure and provenance metadata. Only the registration name changes, not the response format.
+
+### IV. Testability
+
+**Assessment**: PASS
+
+Tool tests reference tool names via the handler functions, not by string name. The rename does not affect test isolation or testability.

--- a/openspec/changes/archive/2026-04-04-drop-dewey-tool-prefix/specs/tool-names.md
+++ b/openspec/changes/archive/2026-04-04-drop-dewey-tool-prefix/specs/tool-names.md
@@ -1,0 +1,33 @@
+## MODIFIED Requirements
+
+### Requirement: MCP Tool Registration Names
+
+MCP tools added by Dewey (not inherited from graphthulhu) MUST be registered without the `dewey_` prefix. The MCP server name provides the namespace — tool names SHOULD NOT duplicate it.
+
+Previously: Tools were registered as `dewey_semantic_search`, `dewey_similar`, `dewey_semantic_search_filtered`, `dewey_store_learning`.
+
+#### Scenario: Agent discovers semantic search tool
+- **GIVEN** an OpenCode session with Dewey configured as the `dewey` MCP server
+- **WHEN** the agent lists available tools
+- **THEN** the semantic search tool appears as `dewey_semantic_search` (server prefix + `semantic_search`), not `dewey_dewey_semantic_search`
+
+#### Scenario: Agent calls store learning tool
+- **GIVEN** an OpenCode session with Dewey configured as the `dewey` MCP server
+- **WHEN** the agent calls `dewey_store_learning`
+- **THEN** the tool executes successfully (the server routes `store_learning` to the correct handler)
+
+#### Scenario: Inherited graphthulhu tools unaffected
+- **GIVEN** an OpenCode session with Dewey configured
+- **WHEN** the agent lists available tools
+- **THEN** inherited tools like `get_page`, `search`, `traverse` appear as `dewey_get_page`, `dewey_search`, `dewey_traverse` (unchanged)
+
+### Requirement: Tool Description Cross-References
+
+Tool descriptions that reference other Dewey tool names MUST use the unprefixed registration name.
+
+Previously: `dewey_store_learning` description referenced `dewey_semantic_search`.
+
+#### Scenario: Store learning description references search
+- **GIVEN** the `store_learning` tool description
+- **WHEN** an agent reads the tool's help text
+- **THEN** it references `semantic_search` (not `dewey_semantic_search`)

--- a/openspec/changes/archive/2026-04-04-drop-dewey-tool-prefix/tasks.md
+++ b/openspec/changes/archive/2026-04-04-drop-dewey-tool-prefix/tasks.md
@@ -1,0 +1,16 @@
+## 1. Rename Tool Registrations
+
+- [x] 1.1 In `server.go` `registerSemanticTools()`: rename `dewey_semantic_search` → `semantic_search`
+- [x] 1.2 In `server.go` `registerSemanticTools()`: rename `dewey_similar` → `similar`
+- [x] 1.3 In `server.go` `registerSemanticTools()`: rename `dewey_semantic_search_filtered` → `semantic_search_filtered`
+- [x] 1.4 In `server.go` `registerLearningTools()`: rename `dewey_store_learning` → `store_learning`
+
+## 2. Update Tool Description Cross-References
+
+- [x] 2.1 In `server.go` `registerLearningTools()`: update `store_learning` description to reference `semantic_search` instead of `dewey_semantic_search`
+
+## 3. Verification
+
+- [x] 3.1 Run `go build ./...` and `go vet ./...`
+- [x] 3.2 Run `go test -race -count=1 ./...` — all tests pass
+- [x] 3.3 Verify constitution alignment: tool outputs unchanged (Observable Quality), no new dependencies (Composability), tool discovery still works (Autonomous Collaboration)

--- a/server.go
+++ b/server.go
@@ -332,17 +332,17 @@ func registerWhiteboardTools(srv *mcp.Server, whiteboard *tools.Whiteboard) {
 // registerSemanticTools registers vector-based semantic search tools.
 func registerSemanticTools(srv *mcp.Server, semantic *tools.Semantic) {
 	mcp.AddTool(srv, &mcp.Tool{
-		Name:        "dewey_semantic_search",
+		Name:        "semantic_search",
 		Description: "Find documents semantically similar to a natural language query, ranked by cosine similarity. Returns results with provenance metadata.",
 	}, semantic.SemanticSearch)
 
 	mcp.AddTool(srv, &mcp.Tool{
-		Name:        "dewey_similar",
+		Name:        "similar",
 		Description: "Given a document (by page name or block UUID), find the most similar documents in the index.",
 	}, semantic.Similar)
 
 	mcp.AddTool(srv, &mcp.Tool{
-		Name:        "dewey_semantic_search_filtered",
+		Name:        "semantic_search_filtered",
 		Description: "Semantic search constrained by metadata filters (source type, repository, properties).",
 	}, semantic.SemanticSearchFiltered)
 }
@@ -351,8 +351,8 @@ func registerSemanticTools(srv *mcp.Server, semantic *tools.Semantic) {
 // agent learnings into the knowledge graph with optional embeddings.
 func registerLearningTools(srv *mcp.Server, learning *tools.Learning) {
 	mcp.AddTool(srv, &mcp.Tool{
-		Name:        "dewey_store_learning",
-		Description: "Store a learning (insight, pattern, gotcha) with optional tags. The learning is persisted with embeddings and immediately searchable via dewey_semantic_search. Use to build semantic memory across sessions.",
+		Name:        "store_learning",
+		Description: "Store a learning (insight, pattern, gotcha) with optional tags. The learning is persisted with embeddings and immediately searchable via semantic_search. Use to build semantic memory across sessions.",
 	}, learning.StoreLearning)
 }
 

--- a/server_test.go
+++ b/server_test.go
@@ -309,7 +309,7 @@ func TestNewServer_RegistersTools(t *testing.T) {
 		// Journal
 		"journal_range", "journal_search",
 		// Semantic
-		"dewey_semantic_search", "dewey_similar", "dewey_semantic_search_filtered",
+		"semantic_search", "similar", "semantic_search_filtered",
 		// Health
 		"health",
 	}
@@ -378,7 +378,7 @@ func TestNewServer_ReadOnlyMode(t *testing.T) {
 		"search", "query_properties", "find_by_tag",
 		"graph_overview", "find_connections", "knowledge_gaps", "list_orphans", "topic_clusters",
 		"journal_range", "journal_search",
-		"dewey_semantic_search", "dewey_similar", "dewey_semantic_search_filtered",
+		"semantic_search", "similar", "semantic_search_filtered",
 		"health",
 	}
 	for _, name := range readTools {
@@ -456,7 +456,7 @@ func TestNewServer_WithEmbedderOption(t *testing.T) {
 	tools := listServerTools(t, srv)
 
 	semanticTools := []string{
-		"dewey_semantic_search", "dewey_similar", "dewey_semantic_search_filtered",
+		"semantic_search", "similar", "semantic_search_filtered",
 	}
 	for _, name := range semanticTools {
 		if !containsTool(tools, name) {
@@ -491,7 +491,7 @@ func TestNewServer_WithPersistentStoreOption(t *testing.T) {
 
 	// Semantic tools should also be registered (they use the store).
 	for _, name := range []string{
-		"dewey_semantic_search", "dewey_similar", "dewey_semantic_search_filtered",
+		"semantic_search", "similar", "semantic_search_filtered",
 	} {
 		if !containsTool(tools, name) {
 			t.Errorf("semantic tool %q should be registered with persistent store option", name)


### PR DESCRIPTION
## Summary

- Remove `dewey_` prefix from 4 MCP tool registration names in `server.go` to prevent OpenCode from displaying them as `dewey_dewey_*`
- `dewey_semantic_search` → `semantic_search`, `dewey_similar` → `similar`, `dewey_semantic_search_filtered` → `semantic_search_filtered`, `dewey_store_learning` → `store_learning`
- Update test assertions in `server_test.go` and tool description cross-reference
- Archive OpenSpec change artifacts

The inherited graphthulhu tools (`get_page`, `search`, `traverse`, etc.) already have no prefix and display correctly as `dewey_get_page`.