### PR TITLE
fix: reduce chunk size to 768 chars and retry on embedding context overflow (#37)

### DIFF
--- a/embed/chunker.go
+++ b/embed/chunker.go
@@ -3,13 +3,12 @@ package embed
 import "strings"
 
 // maxChunkChars is the approximate character limit for a chunk.
-// Granite-embedding:30m has a 512-token context window. The original
-// estimate of ~4 chars/token was too optimistic — code blocks, YAML,
-// and special characters tokenize at closer to 2-3 chars/token.
-// At 2 chars/token (worst case), 512 tokens = 1024 chars.
-// We use 1000 as a conservative limit to prevent "input length exceeds
-// context length" errors from Ollama.
-const maxChunkChars = 1000
+// Granite-embedding:30m has a 512-token context window. Code-heavy
+// and YAML content tokenizes at 1-2 chars/token in the worst case.
+// At 1.5 chars/token, 512 tokens = 768 chars. We use 768 as the
+// limit to prevent "input length exceeds context length" errors
+// from Ollama even for code-heavy blocks.
+const maxChunkChars = 768
 
 // PrepareChunk creates an embedding-ready chunk from block content by
 // prepending the heading hierarchy context path. This provides semantic

--- a/openspec/changes/fix-chunk-overflow/.openspec.yaml
+++ b/openspec/changes/fix-chunk-overflow/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: unbound-force
+created: 2026-04-07

--- a/openspec/changes/fix-chunk-overflow/design.md
+++ b/openspec/changes/fix-chunk-overflow/design.md
@@ -1,0 +1,29 @@
+## Context
+
+`granite-embedding:30m` has a 512-token context window. The chunker truncates to 1,000 characters, but code/YAML tokenizes at 1-2 chars/token, so 1,000 chars can produce up to 1,000 tokens — 2x the context limit.
+
+## Goals / Non-Goals
+
+### Goals
+- Reduce chunk size to stay within 512 tokens for worst-case content
+- Log accurate chunk sizes (rune count, not byte count)
+- Recover from context overflow errors instead of skipping blocks
+
+### Non-Goals
+- Token-level truncation (would require a tokenizer, adds complexity)
+- Changing the embedding model
+- Re-embedding existing content (only affects future embeddings)
+
+## Decisions
+
+**D1: Reduce maxChunkChars to 768.** At the worst observed tokenization ratio of 1.5 chars/token, 768 chars = 512 tokens. This is conservative enough for code-heavy content while still providing meaningful context for the embedding model.
+
+**D2: Log rune count, not byte count.** Change `"chunkLen", len(chunk)` to `"chunkLen", len([]rune(chunk))` in `parse_export.go`. This makes the warning directly comparable to `maxChunkChars`.
+
+**D3: Retry with truncation on overflow.** When `Embed()` returns a context-length error, `GenerateEmbeddings` retries with the chunk truncated to half its length. This is a best-effort recovery — a shorter chunk is better than no embedding at all. Maximum one retry to avoid infinite loops.
+
+## Risks / Trade-offs
+
+**Trade-off: Shorter chunks = less context per embedding.** Reducing from 1,000 to 768 chars means embeddings capture ~23% less text. This may slightly reduce semantic search relevance for long blocks. The improvement in coverage (more blocks get embeddings) should outweigh this.
+
+**Risk: Retry masking real errors.** The retry only triggers on the specific "context length" error string. Other embedding errors (network, model not found) are not retried.

--- a/openspec/changes/fix-chunk-overflow/proposal.md
+++ b/openspec/changes/fix-chunk-overflow/proposal.md
@@ -1,0 +1,41 @@
+## Why
+
+`PrepareChunk` truncates blocks to 1,000 **characters** but `granite-embedding:30m` has a 512-**token** context window. For code-heavy, YAML, or special-character content, tokenization averages 1-2 chars/token — meaning a 1,000-char chunk can produce 500-1,000 tokens, exceeding the context window. The embedding fails with `"the input length exceeds the context length"` and the block is silently excluded from semantic search.
+
+The misleading `chunkLen=1410` in the log is the **byte** length of the chunk, not the rune/char count — multi-byte UTF-8 characters inflate the byte count beyond the 1,000-rune truncation limit. The actual issue is that 1,000 chars is too many chars for worst-case tokenization.
+
+Fixes GitHub issue #37.
+
+## What Changes
+
+1. Reduce `maxChunkChars` from 1,000 to 768 — a safer limit that stays within 512 tokens even at 1.5 chars/token (worst case for mixed code/prose)
+2. Log `chunkLen` as **rune count** not byte count — so the warning accurately reflects the char limit, not byte size
+3. Add a defensive truncation in the `Embed` call path — if content still exceeds the model's context window, split into sub-chunks rather than skipping entirely
+
+## Capabilities
+
+### Modified Capabilities
+- `PrepareChunk`: Truncation limit reduced from 1,000 to 768 characters
+- `GenerateEmbeddings`: Warning log uses rune count for `chunkLen` field
+- `Embed`: When the model rejects input as too long, the embedder retries with a truncated version (half the content) rather than skipping the block entirely
+
+## Impact
+
+- `embed/chunker.go`: `maxChunkChars` constant change
+- `embed/embedder.go`: Retry-with-truncation on context overflow error
+- `vault/parse_export.go`: Log `chunkLen` as `len([]rune(chunk))` instead of `len(chunk)`
+- Existing embeddings in the store are not affected — they were already generated successfully. Only future embedding generation uses the new limit.
+
+## Constitution Alignment
+
+### I. Autonomous Collaboration
+**Assessment**: PASS — MCP tool interface unchanged.
+
+### II. Composability First
+**Assessment**: N/A — No dependency changes.
+
+### III. Observable Quality
+**Assessment**: PASS — Warning log becomes more accurate (rune count vs byte count). Retry-with-truncation produces more embeddings, improving search coverage.
+
+### IV. Testability
+**Assessment**: PASS — Existing chunker tests updated for new limit. Retry path testable via mock embedder.

--- a/openspec/changes/fix-chunk-overflow/specs/chunker.md
+++ b/openspec/changes/fix-chunk-overflow/specs/chunker.md
@@ -1,0 +1,34 @@
+## MODIFIED Requirements
+
+### Requirement: Chunk Size Limit
+
+`PrepareChunk` MUST truncate content to 768 characters (was 1,000) to stay within the embedding model's 512-token context window at worst-case tokenization ratios.
+
+Previously: 1,000 characters, which exceeded context window for code-heavy content.
+
+#### Scenario: Code-heavy block
+- **GIVEN** a block with 900 characters of Go source code
+- **WHEN** `PrepareChunk` is called
+- **THEN** the output is truncated to 768 characters (rune-based)
+
+### Requirement: Accurate Chunk Length Logging
+
+Embedding failure warnings MUST log the chunk length as **rune count**, not byte count.
+
+Previously: `len(chunk)` logged byte count, which inflated the number for multi-byte content.
+
+#### Scenario: Warning log accuracy
+- **GIVEN** a chunk that fails embedding
+- **WHEN** the warning is logged
+- **THEN** `chunkLen` reflects the rune count matching `maxChunkChars`
+
+### Requirement: Context Overflow Recovery
+
+When the embedding model rejects input as too long, the system MUST retry with a truncated version (half the content) rather than skipping the block entirely.
+
+#### Scenario: Retry on overflow
+- **GIVEN** a chunk that triggers "context length" error from the embedding model
+- **WHEN** `GenerateEmbeddings` processes the block
+- **THEN** it retries with the chunk truncated to half its rune length
+- **AND** if the retry succeeds, the embedding is stored
+- **AND** if the retry also fails, the block is skipped with a warning

--- a/openspec/changes/fix-chunk-overflow/tasks.md
+++ b/openspec/changes/fix-chunk-overflow/tasks.md
@@ -1,0 +1,24 @@
+## 1. Reduce Chunk Size Limit
+
+- [x] 1.1 In `embed/chunker.go`: change `maxChunkChars` from `1000` to `768`
+- [x] 1.2 Update the comment explaining the rationale — reference 1.5 chars/token worst case for code content
+
+## 2. Fix Chunk Length Logging
+
+- [x] 2.1 In `vault/parse_export.go` line 141: change `"chunkLen", len(chunk)` to `"chunkLen", len([]rune(chunk))` so the warning reports rune count matching `maxChunkChars`
+
+## 3. Add Context Overflow Retry
+
+- [x] 3.1 In `vault/parse_export.go` `GenerateEmbeddings()`: when `embedder.Embed()` returns an error containing "context length", retry once with the chunk truncated to half its rune length
+- [x] 3.2 Log the retry attempt at DEBUG level: `"retrying embedding with truncated chunk"` with original and truncated lengths
+
+## 4. Update Tests
+
+- [x] 4.1 In `embed/chunker_test.go`: update the truncation test to expect 768 chars instead of 1000 (tests use `maxChunkChars` constant directly — auto-updated)
+- [x] 4.2 In `vault/vault_store_test.go`: add `TestGenerateEmbeddings_RetryOnContextOverflow` — mock embedder that fails with "context length" on first call, succeeds on second with shorter input. Verify embedding is stored.
+- [x] 4.3 In `vault/vault_store_test.go`: add `TestGenerateEmbeddings_RetryFailsBoth` — mock embedder that fails both calls. Verify warning logged and block skipped.
+
+## 5. Verification
+
+- [x] 5.1 Run `go build ./...` and `go vet ./...`
+- [x] 5.2 Run `go test -race -count=1 ./...` — all tests pass

--- a/vault/parse_export.go
+++ b/vault/parse_export.go
@@ -137,8 +137,30 @@ func GenerateEmbeddings(s *store.Store, embedder embed.Embedder, pageName string
 
 		vec, err := embedder.Embed(ctx, chunk)
 		if err != nil {
+			// Check for context-length overflow and retry with truncated chunk.
+			if strings.Contains(err.Error(), "context length") {
+				runes := []rune(chunk)
+				truncated := string(runes[:len(runes)/2])
+				logger.Debug("retrying embedding with truncated chunk",
+					"page", pageName, "block", b.UUID,
+					"originalLen", len(runes), "truncatedLen", len(runes)/2)
+				vec, err = embedder.Embed(ctx, truncated)
+				if err == nil {
+					// Retry succeeded — store the embedding with the truncated chunk.
+					if storeErr := s.InsertEmbedding(b.UUID, embedder.ModelID(), vec, truncated); storeErr != nil {
+						logger.Warn("failed to persist embedding after retry",
+							"page", pageName, "block", b.UUID, "err", storeErr)
+					} else {
+						count++
+					}
+					if len(b.Children) > 0 {
+						count += GenerateEmbeddings(s, embedder, pageName, b.Children, currentPath)
+					}
+					continue
+				}
+			}
 			logger.Warn("failed to generate embedding",
-				"page", pageName, "block", b.UUID, "chunkLen", len(chunk), "err", err)
+				"page", pageName, "block", b.UUID, "chunkLen", len([]rune(chunk)), "err", err)
 			continue
 		}
 

--- a/vault/vault_store_test.go
+++ b/vault/vault_store_test.go
@@ -1057,6 +1057,87 @@ func TestGenerateEmbeddings_PartialEmbedError(t *testing.T) {
 	}
 }
 
+// TestGenerateEmbeddings_RetryOnContextOverflow verifies that when the embedder
+// returns a "context length" error, GenerateEmbeddings retries with a truncated
+// chunk and stores the embedding on success.
+func TestGenerateEmbeddings_RetryOnContextOverflow(t *testing.T) {
+	vs, s := newTestVaultStore(t, t.TempDir())
+
+	callCount := 0
+	me := &mockEmbedder{
+		available: true,
+		modelID:   "test-model",
+		embedFn: func(_ context.Context, text string) ([]float32, error) {
+			callCount++
+			if callCount == 1 {
+				// First call: context too long.
+				return nil, fmt.Errorf("the input length exceeds the context length")
+			}
+			// Second call (truncated): succeed.
+			return []float32{0.4, 0.5, 0.6}, nil
+		},
+	}
+	vs.SetEmbedder(me)
+
+	blocks := []types.BlockEntity{
+		{UUID: "overflow-block", Content: "Some content that is pretend-long"},
+	}
+
+	insertTestPageAndBlocks(t, s, "overflow-page", blocks)
+
+	count := GenerateEmbeddings(s, me, "overflow-page", blocks, nil)
+	if count != 1 {
+		t.Errorf("GenerateEmbeddings count = %d, want 1 (retry should succeed)", count)
+	}
+	if callCount != 2 {
+		t.Errorf("embedder called %d times, want 2 (original + retry)", callCount)
+	}
+
+	// Verify embedding was stored.
+	emb, err := s.GetEmbedding("overflow-block", "test-model")
+	if err != nil {
+		t.Fatalf("GetEmbedding: %v", err)
+	}
+	if emb == nil {
+		t.Fatal("overflow-block should have an embedding after retry")
+	}
+}
+
+// TestGenerateEmbeddings_RetryFailsBoth verifies that when both the original
+// and retry embedding calls fail, the block is skipped with a warning.
+func TestGenerateEmbeddings_RetryFailsBoth(t *testing.T) {
+	vs, s := newTestVaultStore(t, t.TempDir())
+
+	me := &mockEmbedder{
+		available: true,
+		modelID:   "test-model",
+		embedFn: func(_ context.Context, _ string) ([]float32, error) {
+			return nil, fmt.Errorf("the input length exceeds the context length")
+		},
+	}
+	vs.SetEmbedder(me)
+
+	blocks := []types.BlockEntity{
+		{UUID: "double-fail-block", Content: "Content that always fails"},
+	}
+
+	insertTestPageAndBlocks(t, s, "double-fail-page", blocks)
+
+	count := GenerateEmbeddings(s, me, "double-fail-page", blocks, nil)
+	if count != 0 {
+		t.Errorf("GenerateEmbeddings count = %d, want 0 (both attempts failed)", count)
+	}
+
+	// Verify no embedding was stored.
+	emb, err := s.GetEmbedding("double-fail-block", "test-model")
+	if err != nil {
+		t.Fatalf("GetEmbedding: %v", err)
+	}
+	if emb != nil {
+		t.Error("double-fail-block should have no embedding after both attempts failed")
+	}
+}
+
 // BenchmarkIncrementalStartup measures the time from store.Open() to ready-to-serve
 // for a vault with 200 files and <10 changes. Target: <2s per SC-001.
 // This is the benchmark test for T066.


### PR DESCRIPTION
## Summary

- Reduce `maxChunkChars` from 1,000 to 768 to stay within `granite-embedding:30m`'s 512-token context window at worst-case tokenization (1.5 chars/token for code-heavy content)
- Add retry-with-truncation in `GenerateEmbeddings()` — when the embedder returns a "context length" error, retry once with the chunk truncated to half its rune length instead of silently skipping the block
- Fix `chunkLen` in warning logs to use rune count (not byte count) for accurate comparison with `maxChunkChars`
- 2 new tests: retry-success and retry-both-fail paths

Closes #37