### PR TITLE
fix: resolve relative source paths against vault basePath (#40)

### DIFF
--- a/.opencode/command/opsx-apply.md
+++ b/.opencode/command/opsx-apply.md
@@ -26,6 +26,23 @@ Implement tasks from an OpenSpec change.
      > "Must be on branch `opsx/<change-name>` to implement this change.
      > Run: `git checkout opsx/<change-name>`"
 
+2b. **Retrieve implementation context from Dewey** (optional)
+
+   Before implementing, query Dewey for relevant patterns:
+
+   - `dewey_semantic_search` with the task description to find
+     similar implementations in other repos
+   - `dewey_semantic_search_filtered` with `source_type: "web"`
+     to find relevant toolstack documentation
+   - `dewey_search` for convention pack references related to the
+     task's domain
+
+   Use the retrieved context to follow established patterns and
+   avoid reinventing solutions that already exist in the ecosystem.
+
+   If Dewey is unavailable, proceed with direct file reads of
+   convention packs and local code examples.
+
 3. **Check status to understand the schema**
    ```bash
    openspec status --change "<name>" --json

--- a/.opencode/command/opsx-propose.md
+++ b/.opencode/command/opsx-propose.md
@@ -43,6 +43,24 @@ When ready to implement, run /opsx-apply
    - If on a different `opsx/*` branch: **STOP** with error: "Already on branch `opsx/<other>` -- finish or archive that change first."
    - If on `main` or any non-opsx branch: create and checkout `opsx/<name>`.
 
+3b. **Retrieve context from Dewey** (optional)
+
+   Before drafting the proposal, query Dewey for relevant context:
+
+   - `dewey_semantic_search` with the change description to find
+     related specs, past proposals, and similar changes
+   - `dewey_semantic_search_filtered` with `source_type: "github"`
+     to find related issues across the organization
+   - `dewey_traverse` on any discovered related specs to understand
+     dependencies
+
+   Use the retrieved context to inform the proposal's scope,
+   identify potential conflicts with existing work, and reference
+   relevant prior decisions.
+
+   If Dewey is unavailable, proceed without cross-repo context --
+   use direct file reads of local specs and backlog items instead.
+
 4. **Get the artifact build order**
    ```bash
    openspec status --change "<name>" --json

--- a/.opencode/skills/openspec-apply-change/SKILL.md
+++ b/.opencode/skills/openspec-apply-change/SKILL.md
@@ -33,6 +33,45 @@ Implement tasks from an OpenSpec change.
      > "Must be on branch `opsx/<change-name>` to implement this change.
      > Run: `git checkout opsx/<change-name>`"
 
+2b. **Retrieve implementation context from Dewey** (optional)
+
+   Before implementing, query Dewey for relevant patterns:
+
+   - `dewey_semantic_search` with the task description to find
+     similar implementations in other repos
+   - `dewey_semantic_search_filtered` with `source_type: "web"`
+     to find relevant toolstack documentation
+   - `dewey_search` for convention pack references related to the
+     task's domain
+
+   Use the retrieved context to follow established patterns and
+   avoid reinventing solutions that already exist in the ecosystem.
+
+   If Dewey is unavailable, proceed with direct file reads of
+   convention packs and local code examples.
+
+   **Dewey Availability Tiers**
+
+   Adjust context retrieval based on Dewey availability:
+
+   **Tier 3 (Full Dewey)**: Use `dewey_semantic_search`,
+   `dewey_search`, `dewey_traverse`, and
+   `dewey_semantic_search_filtered` for comprehensive cross-repo
+   and toolstack context.
+
+   **Tier 2 (Graph-only, no embedding model)**: Use
+   `dewey_search` and `dewey_traverse` for keyword-based and
+   structural queries. Semantic search is unavailable.
+
+   **Tier 1 (No Dewey)**: Fall back to direct file operations:
+   - Use the Read tool to read local specs, backlog items, and
+     convention packs
+   - Use the Grep tool for keyword search across the codebase
+   - Reference `.opencode/uf/packs/` for coding standards
+
+   All tiers produce valid results. Higher tiers provide richer
+   cross-repo context but are never required.
+
 3. **Check status to understand the schema**
    ```bash
    openspec status --change "<name>" --json

--- a/.opencode/skills/openspec-explore/SKILL.md
+++ b/.opencode/skills/openspec-explore/SKILL.md
@@ -28,6 +28,52 @@ Enter explore mode. Think deeply. Visualize freely. Follow the conversation wher
 
 ---
 
+## Use Dewey for Investigation
+
+When exploring ideas or investigating problems, use Dewey as
+the primary context source:
+
+- `dewey_semantic_search` to find conceptually related content
+  across all indexed sources (specs, issues, docs)
+- `dewey_similar` to find documents similar to the one being
+  explored
+- `dewey_traverse` to follow relationships between related
+  documents
+- `dewey_semantic_search_filtered` to narrow searches by source
+  type (e.g., only GitHub issues, only web docs)
+
+Dewey provides cross-repo context that direct file reads cannot
+-- it finds related content even when different terminology is
+used.
+
+If Dewey is unavailable, fall back to direct file reads using
+the Read and Grep tools, and reference convention packs for
+standards.
+
+**Dewey Availability Tiers**
+
+Adjust context retrieval based on Dewey availability:
+
+**Tier 3 (Full Dewey)**: Use `dewey_semantic_search`,
+`dewey_search`, `dewey_traverse`, and
+`dewey_semantic_search_filtered` for comprehensive cross-repo
+and toolstack context.
+
+**Tier 2 (Graph-only, no embedding model)**: Use
+`dewey_search` and `dewey_traverse` for keyword-based and
+structural queries. Semantic search is unavailable.
+
+**Tier 1 (No Dewey)**: Fall back to direct file operations:
+- Use the Read tool to read local specs, backlog items, and
+  convention packs
+- Use the Grep tool for keyword search across the codebase
+- Reference `.opencode/uf/packs/` for coding standards
+
+All tiers produce valid results. Higher tiers provide richer
+cross-repo context but are never required.
+
+---
+
 ## What You Might Do
 
 Depending on what the user brings, you might:

--- a/.opencode/skills/openspec-propose/SKILL.md
+++ b/.opencode/skills/openspec-propose/SKILL.md
@@ -50,6 +50,46 @@ When ready to implement, run /opsx-apply
    - If on a different `opsx/*` branch: **STOP** with error: "Already on branch `opsx/<other>` -- finish or archive that change first."
    - If on `main` or any non-opsx branch: create and checkout `opsx/<name>`.
 
+3b. **Retrieve context from Dewey** (optional)
+
+   Before drafting the proposal, query Dewey for relevant context:
+
+   - `dewey_semantic_search` with the change description to find
+     related specs, past proposals, and similar changes
+   - `dewey_semantic_search_filtered` with `source_type: "github"`
+     to find related issues across the organization
+   - `dewey_traverse` on any discovered related specs to understand
+     dependencies
+
+   Use the retrieved context to inform the proposal's scope,
+   identify potential conflicts with existing work, and reference
+   relevant prior decisions.
+
+   If Dewey is unavailable, proceed without cross-repo context --
+   use direct file reads of local specs and backlog items instead.
+
+   **Dewey Availability Tiers**
+
+   Adjust context retrieval based on Dewey availability:
+
+   **Tier 3 (Full Dewey)**: Use `dewey_semantic_search`,
+   `dewey_search`, `dewey_traverse`, and
+   `dewey_semantic_search_filtered` for comprehensive cross-repo
+   and toolstack context.
+
+   **Tier 2 (Graph-only, no embedding model)**: Use
+   `dewey_search` and `dewey_traverse` for keyword-based and
+   structural queries. Semantic search is unavailable.
+
+   **Tier 1 (No Dewey)**: Fall back to direct file operations:
+   - Use the Read tool to read local specs, backlog items, and
+     convention packs
+   - Use the Grep tool for keyword search across the codebase
+   - Reference `.opencode/uf/packs/` for coding standards
+
+   All tiers produce valid results. Higher tiers provide richer
+   cross-repo context but are never required.
+
 4. **Get the artifact build order**
    ```bash
    openspec status --change "<name>" --json

--- a/openspec/changes/fix-relative-source-paths/.openspec.yaml
+++ b/openspec/changes/fix-relative-source-paths/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: unbound-force
+created: 2026-04-10

--- a/openspec/changes/fix-relative-source-paths/design.md
+++ b/openspec/changes/fix-relative-source-paths/design.md
@@ -1,0 +1,27 @@
+## Context
+
+`createDiskSource()` and `createCodeSource()` in `source/manager.go` only resolve `path == "."` to the absolute vault path. Any other relative path (e.g., `"../gaze"`) is passed to `filepath.Walk` as-is, which resolves against the process CWD — not the vault root.
+
+## Goals / Non-Goals
+
+### Goals
+- Resolve all relative source paths against the vault basePath
+- Fix both disk and code source creation functions
+- Add tests verifying relative path resolution
+
+### Non-Goals
+- Changing how basePath is determined (that's the caller's responsibility)
+- Adding path validation (e.g., checking the directory exists)
+- Modifying the sources.yaml format
+
+## Decisions
+
+**D1: Use `filepath.Join(basePath, path)` for relative paths.** `filepath.Join` handles `../` correctly — `filepath.Join("/a/b/c", "../gaze")` produces `/a/b/gaze`. No need for `filepath.Abs` since `basePath` is already absolute (guaranteed by `resolveVaultPath` in main.go).
+
+**D2: Keep the `path == "."` special case.** It's equivalent to the new code (`filepath.Join(basePath, ".")` == `basePath`) but the explicit check makes the intent clear and preserves backward compatibility in test assertions.
+
+**D3: Log the resolved path at DEBUG level.** Add `logger.Debug("resolved source path", "source", cfg.ID, "raw", rawPath, "resolved", path)` so path resolution issues are visible in verbose mode.
+
+## Risks / Trade-offs
+
+**Risk: None identified.** `filepath.Join` with an absolute basePath and a relative path is a well-defined operation. The only edge case is an absolute path in the config (e.g., `path: "/opt/data"`) — `filepath.Join` preserves it, which is correct.

--- a/openspec/changes/fix-relative-source-paths/proposal.md
+++ b/openspec/changes/fix-relative-source-paths/proposal.md
@@ -1,0 +1,37 @@
+## Why
+
+Disk and code sources with relative paths (e.g., `../gaze`, `../website`) show 0 pages because the relative path is passed directly to `filepath.Walk` without resolving against the vault root. When dewey's working directory differs from the vault root (which happens when OpenCode spawns the process), the path resolves to the wrong location or a nonexistent directory.
+
+This affects all cross-repo source indexing — the primary value proposition of multi-repo Dewey. Only `path: "."` sources work reliably because they're special-cased to use the absolute vault path.
+
+Fixes GitHub issue #40.
+
+## What Changes
+
+In `source/manager.go`, resolve all non-absolute source paths against `basePath` (the vault root) — not just `"."`. A 3-line fix in both `createDiskSource()` and `createCodeSource()`.
+
+## Capabilities
+
+### Modified Capabilities
+- `createDiskSource()`: Resolves relative paths against vault basePath using `filepath.Join`
+- `createCodeSource()`: Same fix applied
+
+## Impact
+
+- **source/manager.go**: 2 functions modified (~3 lines each)
+- **source/manager_test.go**: New tests for relative path resolution
+- No API changes, no schema changes, no new dependencies
+
+## Constitution Alignment
+
+### I. Autonomous Collaboration
+**Assessment**: PASS — MCP tool interface unchanged.
+
+### II. Composability First
+**Assessment**: PASS — No new dependencies. Path resolution uses stdlib `filepath.Join`.
+
+### III. Observable Quality
+**Assessment**: PASS — Previously silent failure (0 pages) becomes correct indexing. Structured diagnostics log the resolved path.
+
+### IV. Testability
+**Assessment**: PASS — Testable with temp directories and relative path fixtures.

--- a/openspec/changes/fix-relative-source-paths/specs/path-resolution.md
+++ b/openspec/changes/fix-relative-source-paths/specs/path-resolution.md
@@ -1,0 +1,27 @@
+## MODIFIED Requirements
+
+### Requirement: Source Path Resolution
+
+All source types with a `path` config field MUST resolve relative paths against the vault basePath. Only absolute paths are used for filesystem operations.
+
+Previously: Only `path: "."` was resolved. Other relative paths were used as-is.
+
+#### Scenario: Relative sibling path
+- **GIVEN** a disk source with `path: "../gaze"` and basePath `/Users/x/unbound-force/dewey`
+- **WHEN** the source is created
+- **THEN** the resolved path is `/Users/x/unbound-force/gaze`
+
+#### Scenario: Dot path (existing behavior)
+- **GIVEN** a disk source with `path: "."` and basePath `/Users/x/unbound-force/dewey`
+- **WHEN** the source is created
+- **THEN** the resolved path is `/Users/x/unbound-force/dewey`
+
+#### Scenario: Absolute path (passthrough)
+- **GIVEN** a disk source with `path: "/opt/data"` and basePath `/Users/x/dewey`
+- **WHEN** the source is created
+- **THEN** the resolved path is `/opt/data` (unchanged)
+
+#### Scenario: Code source relative path
+- **GIVEN** a code source with `path: "../replicator"` and basePath `/Users/x/unbound-force/dewey`
+- **WHEN** the source is created
+- **THEN** the resolved path is `/Users/x/unbound-force/replicator`

--- a/openspec/changes/fix-relative-source-paths/tasks.md
+++ b/openspec/changes/fix-relative-source-paths/tasks.md
@@ -1,0 +1,16 @@
+## 1. Fix Path Resolution
+
+- [x] 1.1 In `source/manager.go` `createDiskSource()` (~line 84): replace `if path == "." { path = basePath }` with path resolution that handles both `.` and other relative paths via `filepath.Join(basePath, path)` when `!filepath.IsAbs(path)`
+- [x] 1.2 In `source/manager.go` `createCodeSource()` (~line 114): apply the same fix
+- [x] 1.3 Add DEBUG log: `logger.Debug("resolved source path", "source", cfg.ID, "raw", rawPath, "resolved", path)` in both functions
+
+## 2. Tests
+
+- [x] 2.1 Add `TestCreateDiskSource_RelativePath` in `source/manager_test.go`: verify `path: "../sibling"` resolves to `basePath/../sibling`
+- [x] 2.2 Add `TestCreateDiskSource_AbsolutePath` in `source/manager_test.go`: verify absolute path passes through unchanged
+- [x] 2.3 Add `TestCreateCodeSource_RelativePath` in `source/manager_test.go`: verify same behavior for code sources
+
+## 3. Verification
+
+- [x] 3.1 Run `go build ./...` and `go vet ./...`
+- [x] 3.2 Run `go test -race -count=1 ./...` — all tests pass

--- a/source/manager.go
+++ b/source/manager.go
@@ -2,6 +2,7 @@ package source
 
 import (
 	"fmt"
+	"path/filepath"
 	"time"
 )
 
@@ -81,9 +82,11 @@ func createDiskSource(cfg SourceConfig, basePath string) Source {
 	if p, ok := cfg.Config["path"].(string); ok {
 		path = p
 	}
-	if path == "." {
-		path = basePath
+	rawPath := path
+	if !filepath.IsAbs(path) {
+		path = filepath.Join(basePath, path)
 	}
+	logger.Debug("resolved source path", "source", cfg.ID, "raw", rawPath, "resolved", path)
 
 	var opts []DiskSourceOption
 
@@ -104,16 +107,18 @@ func createDiskSource(cfg SourceConfig, basePath string) Source {
 
 // createCodeSource creates a CodeSource from config, extracting path,
 // languages, and optional include/exclude/ignore/recursive settings
-// from the config map. Resolves the path relative to basePath when
-// configured as "." (same pattern as createDiskSource).
+// from the config map. Resolves all relative paths against basePath
+// (same pattern as createDiskSource).
 func createCodeSource(cfg SourceConfig, basePath string) Source {
 	path := "."
 	if p, ok := cfg.Config["path"].(string); ok {
 		path = p
 	}
-	if path == "." {
-		path = basePath
+	rawPath := path
+	if !filepath.IsAbs(path) {
+		path = filepath.Join(basePath, path)
 	}
+	logger.Debug("resolved source path", "source", cfg.ID, "raw", rawPath, "resolved", path)
 
 	languages := extractStringList(cfg.Config["languages"])
 

--- a/source/manager_test.go
+++ b/source/manager_test.go
@@ -2,6 +2,7 @@ package source
 
 import (
 	"fmt"
+	"path/filepath"
 	"testing"
 	"time"
 )
@@ -755,4 +756,95 @@ func searchStr(s, substr string) bool {
 		}
 	}
 	return false
+}
+
+// TestCreateDiskSource_RelativePath verifies that relative paths like
+// "../sibling" are resolved against basePath.
+func TestCreateDiskSource_RelativePath(t *testing.T) {
+	cfg := SourceConfig{
+		ID:   "disk-sibling",
+		Name: "sibling",
+		Type: "disk",
+		Config: map[string]any{
+			"path": "../sibling",
+		},
+	}
+	basePath := "/users/dev/projects/myrepo"
+	src := createDiskSource(cfg, basePath)
+	ds, ok := src.(*DiskSource)
+	if !ok {
+		t.Fatal("expected *DiskSource")
+	}
+	want := filepath.Join(basePath, "../sibling")
+	if ds.basePath != want {
+		t.Errorf("basePath = %q, want %q", ds.basePath, want)
+	}
+}
+
+// TestCreateDiskSource_AbsolutePath verifies that absolute paths are
+// passed through unchanged.
+func TestCreateDiskSource_AbsolutePath(t *testing.T) {
+	cfg := SourceConfig{
+		ID:   "disk-abs",
+		Name: "absolute",
+		Type: "disk",
+		Config: map[string]any{
+			"path": "/opt/data/docs",
+		},
+	}
+	basePath := "/users/dev/projects/myrepo"
+	src := createDiskSource(cfg, basePath)
+	ds, ok := src.(*DiskSource)
+	if !ok {
+		t.Fatal("expected *DiskSource")
+	}
+	if ds.basePath != "/opt/data/docs" {
+		t.Errorf("basePath = %q, want %q", ds.basePath, "/opt/data/docs")
+	}
+}
+
+// TestCreateDiskSource_DotPath verifies that "." is resolved to basePath
+// (existing behavior preserved).
+func TestCreateDiskSource_DotPath(t *testing.T) {
+	cfg := SourceConfig{
+		ID:   "disk-local",
+		Name: "local",
+		Type: "disk",
+		Config: map[string]any{
+			"path": ".",
+		},
+	}
+	basePath := "/users/dev/projects/myrepo"
+	src := createDiskSource(cfg, basePath)
+	ds, ok := src.(*DiskSource)
+	if !ok {
+		t.Fatal("expected *DiskSource")
+	}
+	if ds.basePath != basePath {
+		t.Errorf("basePath = %q, want %q", ds.basePath, basePath)
+	}
+}
+
+// TestCreateCodeSource_RelativePath verifies that code sources also
+// resolve relative paths against basePath.
+func TestCreateCodeSource_RelativePath(t *testing.T) {
+	cfg := SourceConfig{
+		ID:   "code-sibling",
+		Name: "sibling-code",
+		Type: "code",
+		Config: map[string]any{
+			"path":      "../replicator",
+			"languages": []any{"go"},
+		},
+	}
+	basePath := "/users/dev/projects/myrepo"
+	src := createCodeSource(cfg, basePath)
+	cs, ok := src.(*CodeSource)
+	if !ok {
+		t.Fatal("expected *CodeSource")
+	}
+	want := filepath.Join(basePath, "../replicator")
+	if cs.basePath != want {
+		t.Errorf("basePath = %q, want %q", cs.basePath, want)
+	}
 }


### PR DESCRIPTION
## Summary

- Fix relative path resolution in `createDiskSource()` and `createCodeSource()` in `source/manager.go`
- Replace `if path == "." { path = basePath }` with `if !filepath.IsAbs(path) { path = filepath.Join(basePath, path) }` — all relative paths (e.g., `../gaze`, `../website`) now resolve against the vault root regardless of dewey's CWD
- Add DEBUG logging with raw and resolved paths for diagnostics
- 4 new tests: relative path, absolute passthrough, dot path, code source relative
- Also includes /uf-init customizations: Dewey context queries and 3-tier degradation in OpenSpec skill/command files

Closes #40