### PR TITLE
docs: sync README and AGENTS.md with v3.0.0 features

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -253,7 +253,7 @@ MCP server + CLI tool with flat package layout:
 ```text
 main.go              # Entry point, Cobra root command, serve logic
 cli.go               # CLI subcommands (journal, add, search, init, index, reindex, status, source, doctor, manifest, compile, lint, promote)
-server.go            # MCP server setup, 43 tool registrations
+server.go            # MCP server setup, 48 tool registrations
 backend/             # Backend interface + capability interfaces
 client/              # Logseq HTTP API client with retry/backoff
 vault/               # Obsidian vault backend (file parsing, indexing, watcher, persistence)
@@ -277,6 +277,30 @@ chunker/             # Language-aware source code parsing (Chunker interface, Go
 - **Cobra CLI**: Root command doubles as `serve` for backward compatibility.
 - **charmbracelet/log**: Structured logging throughout. No `fmt.Fprintf` to stderr.
 - **Trust tiers**: Pages have a `tier` field (`authored`, `draft`, `validated`) and optional `category` field for knowledge provenance tracking (013-knowledge-compile).
+- **Background indexing**: The MCP server starts before vault indexing completes. Tools serve from the persistent store (previous session's data) during background indexing. An `atomic.Bool` `indexReady` flag tracks completion (012-background-index).
+- **Ollama auto-start**: `ensureOllama()` detects Ollama state (External/Managed/Unavailable) and auto-starts a subprocess if installed but not running. The subprocess is detached via `Setpgid` so it outlives Dewey (007-ollama-autostart).
+
+### Store Learning API
+
+The `store_learning` MCP tool stores knowledge with temporal awareness:
+
+- **`tag`** (required): Topic namespace (e.g., `authentication`, `vault-walker`). Used for clustering and identity.
+- **`category`** (optional): One of `decision`, `pattern`, `gotcha`, `context`, `reference`. Guides compilation strategy.
+- **`information`** (required): Natural language paragraph describing the learning.
+- **Returns**: `{tag}-{sequence}` identity (e.g., `authentication-3`), auto-incremented per tag.
+- **Automatic fields**: `created_at` (ISO 8601), `tier` (defaults to `draft`).
+
+Backward compatibility: the old `tags` (plural, comma-separated) field is still accepted — the first tag is used.
+
+### Trust Tiers
+
+| Tier | Source | Description |
+|------|--------|-------------|
+| `authored` | disk, GitHub, web, code sources | Human-written content. Highest trust. Default for all indexed sources. |
+| `draft` | `store_learning`, `dewey compile` | Agent-generated content. Unreviewed. Default for learnings and compiled articles. |
+| `validated` | `dewey promote` | Agent content promoted by human review. Middle trust. |
+
+Filter by tier: `semantic_search_filtered(query: "auth", tier: "authored")` returns only human-written content.
 
 ## Coding Conventions
 

--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
 # Dewey
 
-Knowledge graph MCP server that gives AI full access to your knowledge graph. Supports **Logseq** and **Obsidian** — both with full read-write support. Navigate pages, search blocks, analyze link structure, track decisions, manage flashcards, and write content — all through the [Model Context Protocol](https://modelcontextprotocol.io).
+Knowledge graph MCP server that gives AI full access to your knowledge graph. Supports **Logseq** and **Obsidian** — both with full read-write support. Navigate pages, search blocks, analyze link structure, track decisions, manage flashcards, compile knowledge, and write content — all through the [Model Context Protocol](https://modelcontextprotocol.io).
 
-Hard fork of [graphthulhu](https://github.com/skridlevsky/graphthulhu) by Max Skridlevsky, extended with persistence, semantic search, and pluggable content sources for the [Unbound Force](https://github.com/unbound-force) AI agent swarm ecosystem.
+Hard fork of [graphthulhu](https://github.com/skridlevsky/graphthulhu) by Max Skridlevsky, extended with persistent SQLite storage, vector-based semantic search via Ollama, pluggable content sources (disk, GitHub, web crawl, code), knowledge compilation with temporal intelligence, and trust tiers for the [Unbound Force](https://github.com/unbound-force) AI agent swarm ecosystem.
 
 Built in Go with the [official MCP Go SDK](https://github.com/modelcontextprotocol/go-sdk).
 
@@ -26,7 +26,7 @@ It turns "tell me about X" into an AI that actually understands your knowledge g
 
 ## Tools
 
-40 tools across 10 categories. Most work with both backends; some are Logseq-only (DataScript queries, flashcards, whiteboards).
+48 tools across 14 categories. Most work with both backends; some are Logseq-only (DataScript queries, flashcards, whiteboards).
 
 ### Navigate
 
@@ -57,6 +57,7 @@ It turns "tell me about X" into an AI that actually understands your knowledge g
 | `knowledge_gaps` | Both | Orphan pages, dead ends, weakly-linked areas |
 | `list_orphans` | Both | List orphan page names with block counts and property status |
 | `topic_clusters` | Both | Connected components with hub identification |
+| `health` | Both | Check server status: version, backend, read-only mode, page count, embedding status, sources |
 
 ### Write
 
@@ -109,15 +110,41 @@ It turns "tell me about X" into an AI that actually understands your knowledge g
 
 | Tool | Backend | Description |
 |------|---------|-------------|
-| `dewey_semantic_search` | Both | Find documents semantically similar to a natural language query |
-| `dewey_similar` | Both | Find the most similar documents to a given page or block |
-| `dewey_semantic_search_filtered` | Both | Semantic search with metadata filters (source, properties) |
+| `semantic_search` | Both | Find documents semantically similar to a natural language query |
+| `similar` | Both | Find the most similar documents to a given page or block |
+| `semantic_search_filtered` | Both | Semantic search with metadata filters (source, properties, tier) |
 
-### Health
+### Compile
 
 | Tool | Backend | Description |
 |------|---------|-------------|
-| `health` | Both | Check server status: version, backend, read-only mode, page count, embedding status, sources |
+| `compile` | Both | Synthesize stored learnings into compiled knowledge articles |
+
+### Lint
+
+| Tool | Backend | Description |
+|------|---------|-------------|
+| `lint` | Both | Scan knowledge base for quality issues (stale decisions, embedding gaps) |
+
+### Promote
+
+| Tool | Backend | Description |
+|------|---------|-------------|
+| `promote` | Both | Promote draft content to validated after human review |
+
+### Indexing
+
+| Tool | Backend | Description |
+|------|---------|-------------|
+| `index` | Both | Fetch and index configured content sources |
+| `reindex` | Both | Delete and rebuild all external source content |
+| `reload` | Obsidian | Force a full vault re-index from disk |
+
+### Learning
+
+| Tool | Backend | Description |
+|------|---------|-------------|
+| `store_learning` | Both | Store a learning with tag, category, and temporal identity |
 
 ## Install
 
@@ -280,6 +307,8 @@ Add `.uf/dewey/` to your `.gitignore`. The index is machine-local and rebuilt fr
 |------|-------|-------------|
 | `--verbose` | `-v` | Enable debug logging (shows UUID seeds, block insertions, lock detection) |
 | `--log-file PATH` | | Write logs to file in addition to stderr |
+| `--no-embeddings` | | Skip embedding generation (on serve, index, reindex) |
+| `--vault PATH` | | Path to vault (on serve, index, reindex, status, search, doctor, manifest) |
 
 When running as an MCP server (`dewey serve`), Dewey automatically logs to `.uf/dewey/dewey.log` for diagnostics. The log file is truncated when it exceeds 10 MB.
 
@@ -347,9 +376,57 @@ dewey source add github --org ORG --repos REPO1,REPO2 [--refresh INTERVAL]
 dewey source add web --url URL [--name NAME] [--depth N] [--refresh INTERVAL]
 ```
 
+### dewey manifest
+
+Generate `.uf/dewey/manifest.md` — a structured summary of CLI commands, MCP tools, and exported packages discovered via AST parsing of Go source files.
+
+```bash
+dewey manifest [--vault PATH]
+```
+
+### dewey journal
+
+Append a block to a Logseq journal page.
+
+```bash
+dewey journal [--vault PATH] CONTENT
+```
+
+### dewey add
+
+Append a block to a named Logseq page.
+
+```bash
+dewey add [--vault PATH] PAGE CONTENT
+```
+
+### dewey compile
+
+Synthesize stored learnings into compiled knowledge articles. Reads all learnings, clusters them by topic tag, and produces current-state articles that resolve temporal contradictions — newer facts replace older ones.
+
+```bash
+dewey compile [--vault PATH]
+```
+
+### dewey lint
+
+Scan the knowledge base for quality issues: stale decisions, embedding gaps, contradictions, and orphaned content.
+
+```bash
+dewey lint [--vault PATH] [--fix]
+```
+
+### dewey promote
+
+Promote a page from `draft` tier to `validated` after human review. Only draft-tier pages (agent-generated content) can be promoted.
+
+```bash
+dewey promote [--vault PATH] PAGE_NAME
+```
+
 ## Content Sources
 
-Dewey indexes content from three pluggable source types. Configure them in `.uf/dewey/sources.yaml`:
+Dewey indexes content from four pluggable source types. Configure them in `.uf/dewey/sources.yaml`:
 
 ```yaml
 sources:
@@ -394,15 +471,46 @@ dewey index             # incremental — only fetches sources past their refres
 dewey index --force     # full rebuild — re-fetches everything
 ```
 
+### Code Source
+
+The `code` source type indexes source code files using language-aware AST chunking. Currently supports Go, with a pluggable architecture for additional languages.
+
+```yaml
+  - name: project-code
+    type: code
+    config:
+      path: "../replicator"
+      languages:
+        - go
+```
+
+The Go chunker extracts: package doc comments, exported function/method signatures, type declarations, Cobra CLI commands, and MCP tool registrations. Test files are excluded by default.
+
+### Ignore Support
+
+Dewey respects `.gitignore` files at the root of each source directory. Additionally, disk and code sources support `ignore` and `recursive` fields in `sources.yaml`:
+
+```yaml
+  - name: disk-website
+    type: disk
+    config:
+      path: "../website"
+      ignore: [drafts, temp]     # additional patterns beyond .gitignore
+      recursive: true            # set false for top-level files only
+```
+
 ## Semantic Search Setup
 
-Semantic search requires [Ollama](https://ollama.ai) running locally. All 37 keyword-based tools work without it — only the 3 semantic search tools (`dewey_semantic_search`, `dewey_similar`, `dewey_semantic_search_filtered`) require Ollama.
+Semantic search requires [Ollama](https://ollama.ai) running locally. All keyword-based tools work without it — only the 3 semantic search tools (`semantic_search`, `similar`, `semantic_search_filtered`) require Ollama.
+
+### Ollama Auto-Start
+
+Dewey auto-starts Ollama if it's installed but not running. No manual `ollama serve` needed — Dewey detects Ollama's state (External/Managed/Unavailable) and starts a subprocess if necessary. The subprocess is detached so it outlives Dewey.
 
 ### Install Ollama and pull the embedding model
 
 ```bash
 brew install --cask ollama-app  # macOS — or download from https://ollama.ai
-ollama serve              # start the Ollama server (runs in background)
 ollama pull granite-embedding:30m   # IBM Granite, 63 MB, Apache 2.0
 ```
 
@@ -423,12 +531,33 @@ The embedding model and endpoint are configurable via environment variables or `
 | `DEWEY_EMBEDDING_MODEL` | `granite-embedding:30m` | Ollama model name |
 | `DEWEY_EMBEDDING_ENDPOINT` | `http://localhost:11434` | Ollama API endpoint |
 
+## Knowledge Compilation
+
+Dewey can synthesize stored learnings into compiled knowledge articles using an LLM. The `compile` tool reads all learnings, clusters them by topic tag, and produces current-state articles that resolve temporal contradictions — newer facts replace older ones, while non-contradicted information carries forward.
+
+### Trust Tiers
+
+All content in Dewey's index has a trust tier:
+
+| Tier | Source | Description |
+|------|--------|-------------|
+| `authored` | Disk, GitHub, web, code sources | Human-written content. Highest trust. |
+| `draft` | `store_learning`, `compile` | Agent-generated. Unreviewed. |
+| `validated` | `promote` | Agent content promoted by human review. |
+
+Filter search by tier: `semantic_search_filtered(query: "auth", tier: "authored")`
+
+### Instant Startup
+
+When `dewey serve` starts, the MCP server is ready within 1 second. Vault indexing runs in the background — tools serve from the persistent store (previous session's data) while indexing completes. The `health` tool reports indexing status.
+
 ## Architecture
 
 ```
 main.go              Entry point — backend routing, MCP server startup
-cli.go               CLI subcommands: journal, add, search, init, index, status, source
-server.go            MCP server setup — conditional tool registration
+cli.go               CLI subcommands: journal, add, search, init, index, reindex, status,
+                     source, doctor, manifest, compile, lint, promote
+server.go            MCP server setup — 48 tool registrations
 backend/backend.go   Backend interface + optional capability interfaces
 client/logseq.go     Logseq HTTP API client with retry/backoff
 vault/
@@ -436,6 +565,7 @@ vault/
   markdown.go        Markdown → block tree parser (heading-based sectioning)
   frontmatter.go     YAML frontmatter parser
   index.go           Backlink index builder from [[wikilinks]]
+  parse_export.go    Exported parsing and persistence functions
 tools/
   navigate.go        Page, block, links, references, BFS traversal
   search.go          Full-text, property, DataScript/frontmatter, tag search
@@ -445,6 +575,8 @@ tools/
   journal.go         Date range and search within journals
   flashcard.go       SRS overview, due cards, card creation
   whiteboard.go      List and inspect whiteboards
+  semantic.go        Semantic search, similar, filtered search, store_learning
+  compile.go         Knowledge compilation, linting, promotion
   helpers.go         Result formatting utilities
 graph/
   builder.go         In-memory graph construction from any backend
@@ -452,7 +584,9 @@ graph/
 parser/content.go    Regex extraction of [[links]], ((refs)), #tags, properties
 types/
   logseq.go          Shared types with custom JSON unmarshaling
-  tools.go           Input types for all 40 tools
+  tools.go           Input types for all 48 tools
+  semantic.go        Semantic search types
+llm/                 LLM synthesis interface (Synthesizer, OllamaSynthesizer, NoopSynthesizer)
 store/
   store.go           SQLite persistence (pages, blocks, links, sources)
   embeddings.go      Vector embedding storage and cosine similarity search
@@ -467,6 +601,7 @@ source/
   github.go          GitHub API source (issues, PRs, READMEs)
   web.go             Web crawl source (HTML-to-text, robots.txt)
   manager.go         Source orchestration (refresh, failures)
+chunker/             Language-aware source code parsing (Go chunker, registry)
 ```
 
 ## Attribution

--- a/specs/014-docs-sync/checklists/requirements.md
+++ b/specs/014-docs-sync/checklists/requirements.md
@@ -1,0 +1,36 @@
+# Specification Quality Checklist: Documentation Sync
+
+**Purpose**: Validate specification completeness and quality before proceeding to planning
+**Created**: 2026-04-11
+**Feature**: [spec.md](../spec.md)
+
+## Content Quality
+
+- [x] No implementation details (languages, frameworks, APIs)
+- [x] Focused on user value and business needs
+- [x] Written for non-technical stakeholders
+- [x] All mandatory sections completed
+
+## Requirement Completeness
+
+- [x] No [NEEDS CLARIFICATION] markers remain
+- [x] Requirements are testable and unambiguous
+- [x] Success criteria are measurable
+- [x] Success criteria are technology-agnostic (no implementation details)
+- [x] All acceptance scenarios are defined
+- [x] Edge cases are identified
+- [x] Scope is clearly bounded
+- [x] Dependencies and assumptions identified
+
+## Feature Readiness
+
+- [x] All functional requirements have clear acceptance criteria
+- [x] User scenarios cover primary flows
+- [x] Feature meets measurable outcomes defined in Success Criteria
+- [x] No implementation details leak into specification
+
+## Notes
+
+- This is a documentation-only spec — no production code changes, no tests, no schema changes.
+- Edge cases are not applicable for documentation updates.
+- All items pass. Ready for implementation.

--- a/specs/014-docs-sync/spec.md
+++ b/specs/014-docs-sync/spec.md
@@ -1,0 +1,69 @@
+# Feature Specification: Documentation Sync
+
+**Feature Branch**: `014-docs-sync`
+**Created**: 2026-04-11
+**Status**: Draft
+**Input**: Comprehensive README and AGENTS.md update to reflect v3.0.0 features
+
+## User Scenarios & Testing *(mandatory)*
+
+### User Story 1 - Accurate README for New Users (Priority: P1)
+
+A developer discovers Dewey on GitHub and reads the README. Today it says "40 tools across 10 categories" and lists only the original graphthulhu tool categories. The developer has no idea Dewey has knowledge compilation, trust tiers, source code indexing, Ollama auto-start, background indexing, or 48 tools. The README should accurately represent what Dewey v3.0.0 can do so the developer can make an informed decision about whether to use it.
+
+**Why this priority**: The README is the first thing new users see. Inaccurate documentation erodes trust.
+
+**Independent Test**: Read the README and verify every feature claim matches the actual codebase. Verify tool counts, CLI commands, source types, and MCP tool names are all current.
+
+**Acceptance Scenarios**:
+
+1. **Given** the README, **When** a developer reads the tool count, **Then** it says "48 tools across 14 categories" (not 40/10)
+2. **Given** the README, **When** a developer looks for `dewey compile`, **Then** it appears in the CLI commands section
+3. **Given** the README, **When** a developer reads about semantic search tools, **Then** the tool names use the unprefixed format (`semantic_search`, not `dewey_semantic_search`)
+
+---
+
+### User Story 2 - Accurate AGENTS.md for AI Agents (Priority: P2)
+
+An AI agent reads AGENTS.md to understand the project. Today it has a stale `server.go` comment ("43 tool registrations") and doesn't document the `store_learning` API change (tag/category/{tag}-{sequence} identity). The agent operates with incomplete context about the project's capabilities.
+
+**Why this priority**: AGENTS.md is the primary context document for AI agents working on this codebase.
+
+**Independent Test**: Grep AGENTS.md for stale references and verify all feature documentation is current.
+
+**Acceptance Scenarios**:
+
+1. **Given** AGENTS.md, **When** an AI reads the `server.go` comment, **Then** it says "48 tool registrations" (not 43)
+2. **Given** AGENTS.md, **When** an AI looks for `store_learning` API documentation, **Then** it finds the `tag`/`category`/`{tag}-{sequence}` identity scheme documented
+
+## Requirements *(mandatory)*
+
+### Functional Requirements
+
+- **FR-001**: README tool count MUST be updated to 48 tools across 14 categories
+- **FR-002**: README MUST document all 14 tool categories including Compile, Lint, Promote, Indexing, and Learning
+- **FR-003**: README MUST use unprefixed tool names (`semantic_search`, not `dewey_semantic_search`)
+- **FR-004**: README MUST document `dewey compile`, `dewey lint`, `dewey promote` CLI commands
+- **FR-005**: README MUST document `store_learning`, `compile`, `lint`, `promote`, `index`, `reindex` MCP tools
+- **FR-006**: README MUST document trust tiers (authored/validated/draft)
+- **FR-007**: README MUST document background indexing (instant MCP startup)
+- **FR-008**: README MUST document Ollama auto-start behavior
+- **FR-009**: README MUST document `.gitignore` support and `ignore`/`recursive` source config
+- **FR-010**: README MUST document code source type (`type: code`)
+- **FR-011**: AGENTS.md `server.go` comment MUST say "48 tool registrations"
+- **FR-012**: AGENTS.md MUST document the `store_learning` API change: `tag` (required), `category` (optional), `{tag}-{sequence}` identity, `created_at` timestamp
+- **FR-013**: AGENTS.md MUST include a Trust Tiers section explaining authored/validated/draft
+
+## Success Criteria *(mandatory)*
+
+### Measurable Outcomes
+
+- **SC-001**: Zero stale tool counts in README or AGENTS.md — `grep -c "40 tools\|43 tool" README.md AGENTS.md` returns 0
+- **SC-002**: All 14 CLI commands appear in README — `dewey serve`, `init`, `index`, `reindex`, `status`, `search`, `source`, `doctor`, `manifest`, `journal`, `add`, `compile`, `lint`, `promote`
+- **SC-003**: All existing tests continue to pass — documentation changes have no code impact
+
+## Assumptions
+
+- This is a documentation-only change — no production code, no tests, no schema changes.
+- The README structure (sections, ordering) may be reorganized to accommodate new features. The existing content is the starting point, not a constraint.
+- AGENTS.md changes are minimal (3 targeted fixes) since it was partially updated during feature implementation.


### PR DESCRIPTION
## Summary

Comprehensive documentation sync bringing README.md and AGENTS.md up to date with Dewey v3.0.0.

### README.md (+163 lines)
- Tool count 40 -> 48 across 14 categories (was 10)
- 5 new tool category sections: Compile, Lint, Promote, Indexing, Learning
- Unprefixed tool names (`semantic_search` not `dewey_semantic_search`)
- 3 new CLI commands: `dewey compile`, `dewey lint`, `dewey promote`
- Trust tiers section (authored/validated/draft)
- Background indexing (instant MCP startup)
- Ollama auto-start behavior
- `.gitignore` support and `ignore`/`recursive` source config
- Code source type (`type: code`) with Go AST chunker

### AGENTS.md (+26 lines)
- `server.go` comment: 43 -> 48 tool registrations
- `store_learning` API documentation: `tag` (required), `category` (optional), `{tag}-{sequence}` identity, `created_at` timestamp
- Trust Tiers table (authored/validated/draft with filter example)
- Background indexing and Ollama auto-start key patterns