### PR TITLE
feat: add /dewey-store slash command and scaffold all Dewey commands in dewey init

### DIFF
--- a/.opencode/command/dewey-store.md
+++ b/.opencode/command/dewey-store.md
@@ -1,0 +1,161 @@
+---
+description: Store pasted text as a Dewey learning with intelligent tag and category suggestions.
+---
+
+# Command: /dewey-store
+
+## Description
+
+Store ad-hoc knowledge (Slack DMs, meeting notes, decisions,
+observations) as a Dewey learning. Supports three modes:
+fully specified, suggested (agent analyzes text and proposes
+tag/category), and extract (breaks a long conversation into
+multiple learnings).
+
+## Usage
+
+```
+/dewey-store --tag auth-design --category decision
+Sarah confirmed we need OAuth2 + SAML for enterprise.
+
+/dewey-store
+Just talked to the team — we're switching to PostgreSQL
+for the analytics pipeline. MySQL can't handle the
+partitioning we need.
+
+/dewey-store --extract
+[paste a long Slack conversation or meeting transcript]
+```
+
+## Instructions
+
+### 1. Parse Input
+
+Read the user's message after `/dewey-store`.
+
+**Check for flags**:
+- `--tag <value>`: Topic tag for the learning
+- `--category <value>`: One of `decision`, `pattern`,
+  `gotcha`, `context`, `reference`
+- `--extract`: Enable multi-learning extraction mode
+
+Everything after the flags (or the entire message if no
+flags) is the **text to store**.
+
+If no text is provided, ask:
+> "What knowledge would you like to store? Paste the
+> text (Slack message, meeting note, observation, etc.)"
+
+### 2. Determine Mode
+
+**Mode A: Fully Specified** (both `--tag` and `--category`
+provided)
+
+Call the Dewey MCP tool `store_learning` immediately:
+```
+store_learning(
+  tag: "<provided tag>",
+  category: "<provided category>",
+  information: "<pasted text>"
+)
+```
+Skip to Step 5 (Post-Store).
+
+**Mode B: Suggested** (no `--tag` or no `--category`)
+
+Proceed to Step 3 (Analyze and Suggest).
+
+**Mode C: Extract** (`--extract` flag present)
+
+Proceed to Step 4 (Multi-Learning Extraction).
+
+### 3. Analyze and Suggest (Mode B)
+
+Read the pasted text and identify:
+
+**Tag suggestion**: Identify the primary topic. Suggest
+2-3 tags ranked by specificity:
+1. Most specific (e.g., `oauth2-timeout`)
+2. Broader topic (e.g., `authentication`)
+3. Project-level (e.g., `sprint-review`)
+
+Present as:
+
+> **Suggested tag**: `authentication` — this text
+> discusses auth method selection (OAuth2 vs SAML)
+>
+> Other options: `enterprise-requirements`,
+> `auth-design`
+>
+> Your choice (or type your own):
+
+**Category suggestion**: Classify the text based on
+content patterns:
+- Contains "decided", "agreed", "confirmed", "will use",
+  "switching to", "going with" → suggest `decision`
+- Contains "watch out", "gotcha", "careful", "trap",
+  "bug", "issue" → suggest `gotcha`
+- Contains "pattern", "approach", "technique", "always",
+  "best practice" → suggest `pattern`
+- Contains a URL, "see also", "reference", "docs at" →
+  suggest `reference`
+- Default → suggest `context`
+
+Present as:
+
+> **Suggested category**: `decision` — this contains a
+> confirmed choice about database technology
+>
+> Options: `decision` | `pattern` | `gotcha` | `context`
+> | `reference`
+>
+> Your choice (or press enter for `decision`):
+
+After the user confirms (or says "yes", "ok", "looks
+good", or presses enter), call `store_learning` with
+the confirmed values.
+
+### 4. Multi-Learning Extraction (Mode C)
+
+Read the full pasted text and identify distinct pieces
+of knowledge — decisions, facts, observations, action
+items. Each should be a self-contained statement that
+makes sense without the surrounding conversation.
+
+Present the proposed extractions as a numbered list:
+
+> I found **N** distinct items in this text:
+>
+> 1. **`auth-design`** (decision): "Team decided to
+>    switch from API keys to OAuth2 for scoping support"
+> 2. **`deployment`** (context): "Production deploy
+>    window is Tuesdays and Thursdays 2-4pm ET"
+> 3. **`auth-design`** (decision): "OAuth2 timeout set
+>    to 60 seconds based on beta feedback"
+>
+> Store all? Or type numbers to remove (e.g., "remove 2")
+> or edit (e.g., "2: tag=deploy-schedule"):
+
+After confirmation, call `store_learning` for each item.
+Display each returned identity.
+
+### 5. Post-Store
+
+After successful storage, display:
+
+```
+Stored: {tag}-{sequence}
+```
+
+If multiple items were stored (extract mode):
+```
+Stored:
+  auth-design-4
+  deployment-1
+  auth-design-5
+```
+
+Then suggest:
+
+> Run `/dewey-compile` to synthesize this with existing
+> knowledge, or continue working.

--- a/cli.go
+++ b/cli.go
@@ -305,6 +305,25 @@ sources:
 				}
 			}
 
+			// Scaffold Dewey-specific slash commands into .opencode/command/
+			// if the .opencode/ directory exists (composability — only scaffold
+			// when OpenCode is present). Idempotent — skip files that already
+			// exist to avoid overwriting user customizations.
+			opencodeCmdDir := filepath.Join(vaultPath, ".opencode", "command")
+			if _, err := os.Stat(filepath.Join(vaultPath, ".opencode")); err == nil {
+				if err := os.MkdirAll(opencodeCmdDir, 0o755); err == nil {
+					for name, content := range deweySlashCommands {
+						cmdPath := filepath.Join(opencodeCmdDir, name)
+						if _, err := os.Stat(cmdPath); err != nil {
+							// File doesn't exist — scaffold it.
+							if writeErr := os.WriteFile(cmdPath, []byte(content), 0o644); writeErr == nil {
+								logger.Info("scaffolded slash command", "path", cmdPath)
+							}
+						}
+					}
+				}
+			}
+
 			logger.Info("initialized", "path", deweyDir)
 			logger.Info("default config", "file", configPath)
 			logger.Info("run 'dewey index' to build the initial index")

--- a/cli_test.go
+++ b/cli_test.go
@@ -402,6 +402,95 @@ func TestInitCmd_GitignoreLegacyPattern(t *testing.T) {
 	}
 }
 
+// TestInitCmd_ScaffoldsSlashCommands verifies that dewey init creates
+// slash command files in .opencode/command/ when .opencode/ exists.
+func TestInitCmd_ScaffoldsSlashCommands(t *testing.T) {
+	tmpDir := t.TempDir()
+
+	// Create .opencode/ directory (simulating an OpenCode-initialized repo).
+	if err := os.MkdirAll(filepath.Join(tmpDir, ".opencode"), 0o755); err != nil {
+		t.Fatalf("create .opencode: %v", err)
+	}
+	// Create .gitignore so init doesn't error.
+	if err := os.WriteFile(filepath.Join(tmpDir, ".gitignore"), []byte(""), 0o644); err != nil {
+		t.Fatalf("write .gitignore: %v", err)
+	}
+
+	cmd := newInitCmd()
+	cmd.SetArgs([]string{"--vault", tmpDir})
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("init failed: %v", err)
+	}
+
+	// Verify all 5 Dewey slash commands were scaffolded.
+	for _, name := range []string{"dewey-store.md", "dewey-index.md", "dewey-reindex.md", "dewey-compile.md", "dewey-lint.md"} {
+		path := filepath.Join(tmpDir, ".opencode", "command", name)
+		if _, err := os.Stat(path); err != nil {
+			t.Errorf("slash command %s was not scaffolded", name)
+		}
+	}
+}
+
+// TestInitCmd_SkipsExistingSlashCommands verifies that dewey init does
+// not overwrite existing slash command files (preserves user customizations).
+func TestInitCmd_SkipsExistingSlashCommands(t *testing.T) {
+	tmpDir := t.TempDir()
+
+	// Create .opencode/command/ with a custom dewey-store.md.
+	cmdDir := filepath.Join(tmpDir, ".opencode", "command")
+	if err := os.MkdirAll(cmdDir, 0o755); err != nil {
+		t.Fatalf("create command dir: %v", err)
+	}
+	customContent := "# My custom dewey-store command\n"
+	if err := os.WriteFile(filepath.Join(cmdDir, "dewey-store.md"), []byte(customContent), 0o644); err != nil {
+		t.Fatalf("write custom command: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(tmpDir, ".gitignore"), []byte(""), 0o644); err != nil {
+		t.Fatalf("write .gitignore: %v", err)
+	}
+
+	cmd := newInitCmd()
+	cmd.SetArgs([]string{"--vault", tmpDir})
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("init failed: %v", err)
+	}
+
+	// Verify custom content was preserved (not overwritten).
+	content, err := os.ReadFile(filepath.Join(cmdDir, "dewey-store.md"))
+	if err != nil {
+		t.Fatalf("read command: %v", err)
+	}
+	if string(content) != customContent {
+		t.Errorf("dewey-store.md was overwritten, got:\n%s", string(content))
+	}
+
+	// Other commands should still be scaffolded.
+	if _, err := os.Stat(filepath.Join(cmdDir, "dewey-index.md")); err != nil {
+		t.Error("dewey-index.md should have been scaffolded (it didn't exist)")
+	}
+}
+
+// TestInitCmd_NoOpenCodeDir verifies that dewey init gracefully skips
+// slash command scaffolding when .opencode/ doesn't exist.
+func TestInitCmd_NoOpenCodeDir(t *testing.T) {
+	tmpDir := t.TempDir()
+
+	if err := os.WriteFile(filepath.Join(tmpDir, ".gitignore"), []byte(""), 0o644); err != nil {
+		t.Fatalf("write .gitignore: %v", err)
+	}
+
+	cmd := newInitCmd()
+	cmd.SetArgs([]string{"--vault", tmpDir})
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("init failed: %v", err)
+	}
+
+	// Verify no .opencode/command/ directory was created.
+	if _, err := os.Stat(filepath.Join(tmpDir, ".opencode", "command")); err == nil {
+		t.Error(".opencode/command/ should NOT exist when .opencode/ was not present")
+	}
+}
+
 // --- Status command tests ---
 
 // TestStatusCmd_Uninitialized verifies status fails when .uf/dewey/ doesn't exist.

--- a/openspec/changes/dewey-store-command/.openspec.yaml
+++ b/openspec/changes/dewey-store-command/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: unbound-force
+created: 2026-04-19

--- a/openspec/changes/dewey-store-command/design.md
+++ b/openspec/changes/dewey-store-command/design.md
@@ -1,0 +1,40 @@
+## Context
+
+Developers paste ad-hoc knowledge (Slack DMs, meeting notes, decisions) into the OpenCode prompt. Today they must know the `store_learning` MCP tool API. A `/dewey-store` slash command makes this discoverable and adds intelligent tag/category suggestion.
+
+## Goals / Non-Goals
+
+### Goals
+- Create a slash command that accepts pasted text and stores it as a Dewey learning
+- Suggest tag and category when not provided, based on text analysis
+- Support batch extraction from long conversations via `--extract`
+- Suggest `/dewey-compile` after storing
+
+### Non-Goals
+- No new MCP tools — the command calls the existing `store_learning` tool
+- No Go code changes
+- No automated ingestion from external sources (that's a separate concern)
+
+## Decisions
+
+**D1: Three interaction modes.**
+- **Fully specified**: `--tag` and `--category` provided → call `store_learning` immediately
+- **Suggested**: No flags → agent analyzes text, suggests 2-3 tags and a category with reasoning, asks for confirmation
+- **Extract**: `--extract` flag → agent identifies multiple distinct facts/decisions in the text, proposes each as a separate learning with tag/category, asks for confirmation, then stores all
+
+**D2: Tag suggestion strategy.** The agent reads the pasted text and identifies the primary topic. It suggests 2-3 tags ranked by specificity: the most specific first (e.g., `oauth2-timeout`), then broader (e.g., `authentication`), then project-level (e.g., `sprint-review`). The user picks one or types their own.
+
+**D3: Category suggestion strategy.** The agent classifies the text into one of the 5 categories based on content patterns:
+- Contains "decided", "agreed", "confirmed", "will use" → `decision`
+- Contains "watch out", "gotcha", "be careful", "trap" → `gotcha`
+- Contains "pattern", "approach", "technique", "always" → `pattern`
+- Contains a URL, reference, link, "see also" → `reference`
+- Default → `context`
+
+**D4: Post-store suggestion.** After successful storage, the command outputs the `{tag}-{sequence}` identity and suggests: "Run `/dewey-compile` to synthesize this with existing knowledge."
+
+**D5: Extract mode confirmation.** In `--extract` mode, the agent shows all proposed learnings in a numbered list with tag/category before storing. The user can approve all, remove specific items, or edit tag/category for individual items.
+
+## Risks / Trade-offs
+
+**Trade-off: Tag suggestion quality.** The agent's tag suggestions depend on its ability to identify the topic from short, informal text. Slack messages may lack context. Mitigation: always show suggestions as options, never auto-store without confirmation in suggested mode.

--- a/openspec/changes/dewey-store-command/proposal.md
+++ b/openspec/changes/dewey-store-command/proposal.md
@@ -1,0 +1,40 @@
+## Why
+
+Developers frequently encounter useful information in Slack DMs, meeting chats, or other sources that aren't configured as Dewey sources. Today, storing this knowledge requires the developer to know the `store_learning` MCP tool API — specifically the `tag`, `category`, and `information` parameters. There's no discoverable slash command in the command palette.
+
+A `/dewey-store` command gives developers a frictionless way to paste text and store it as searchable knowledge. When tag and category aren't provided, the agent analyzes the text and suggests appropriate values — the developer confirms or overrides with a single keystroke.
+
+## What Changes
+
+Create a new slash command at `.opencode/command/dewey-store.md` that:
+
+1. Accepts text with optional `--tag` and `--category` flags (fully specified mode)
+2. When flags are omitted, analyzes the pasted text and suggests tag and category with reasoning
+3. Supports `--extract` mode that breaks a long conversation into multiple distinct learnings
+4. After storing, suggests running `/dewey-compile` to synthesize with existing knowledge
+
+No Go code changes — this is a command definition file only.
+
+## Capabilities
+
+### New Capabilities
+- `/dewey-store` slash command: 3 interaction modes (fully specified, suggested, extract)
+
+## Impact
+
+- `.opencode/command/dewey-store.md`: New file (command definition only)
+- No production code changes, no test changes, no schema changes
+
+## Constitution Alignment
+
+### I. Autonomous Collaboration
+**Assessment**: PASS — Uses the existing `store_learning` MCP tool. No new runtime coupling.
+
+### II. Composability First
+**Assessment**: PASS — Command is a thin wrapper around an existing MCP tool. Works only when Dewey is available; no degradation needed for a store command.
+
+### III. Observable Quality
+**Assessment**: PASS — Returns the `{tag}-{sequence}` identity so the developer can verify storage.
+
+### IV. Testability
+**Assessment**: N/A — Command definition file, not code.

--- a/openspec/changes/dewey-store-command/specs/command-behavior.md
+++ b/openspec/changes/dewey-store-command/specs/command-behavior.md
@@ -1,0 +1,30 @@
+## NEW Requirements
+
+### Requirement: /dewey-store Slash Command
+
+A `/dewey-store` slash command MUST exist at `.opencode/command/dewey-store.md` that instructs the agent to store pasted text as a Dewey learning via the `store_learning` MCP tool.
+
+#### Scenario: Fully specified (tag and category provided)
+- **GIVEN** the user types `/dewey-store --tag auth-design --category decision` followed by text
+- **WHEN** the agent processes the command
+- **THEN** `store_learning` is called immediately with the provided tag, category, and text
+- **AND** the returned `{tag}-{sequence}` identity is displayed
+
+#### Scenario: Text only (no flags)
+- **GIVEN** the user types `/dewey-store` followed by text with no flags
+- **WHEN** the agent processes the command
+- **THEN** the agent suggests 2-3 tags ranked by specificity with reasoning
+- **AND** the agent suggests a category with reasoning
+- **AND** the agent waits for the user to confirm or override before calling `store_learning`
+
+#### Scenario: Extract mode
+- **GIVEN** the user types `/dewey-store --extract` followed by a long conversation
+- **WHEN** the agent processes the command
+- **THEN** the agent identifies multiple distinct facts/decisions in the text
+- **AND** displays each proposed learning with tag and category in a numbered list
+- **AND** waits for user confirmation before storing
+
+#### Scenario: Post-store suggestion
+- **GIVEN** one or more learnings have been stored
+- **WHEN** the storage completes
+- **THEN** the agent suggests running `/dewey-compile` to synthesize with existing knowledge

--- a/openspec/changes/dewey-store-command/tasks.md
+++ b/openspec/changes/dewey-store-command/tasks.md
@@ -1,0 +1,22 @@
+## 1. Create the Slash Command
+
+- [x] 1.1 Create `.opencode/command/dewey-store.md` with frontmatter, description, usage examples, and full instruction set covering all 3 modes (fully specified, suggested, extract)
+
+## 2. Scaffold Slash Commands in `dewey init`
+
+- [x] 2.1 In `cli.go` `newInitCmd()`: after creating `.uf/dewey/` directory and config files, scaffold all Dewey-specific slash commands into `.opencode/command/` if the `.opencode/` directory exists
+- [x] 2.2 Embed the slash command content as Go string constants or use `embed` directive for the command files: `dewey-store.md`, `dewey-index.md`, `dewey-reindex.md`, `dewey-compile.md`, `dewey-lint.md`
+- [x] 2.3 Only write command files that don't already exist (idempotent — don't overwrite user customizations)
+- [x] 2.4 Log each scaffolded file at INFO level: `logger.Info("scaffolded slash command", "path", path)`
+
+## 3. Tests
+
+- [x] 3.1 Add `TestInitCmd_ScaffoldsSlashCommands` in `cli_test.go`: create temp dir with `.opencode/` directory, run init, verify all 5 command files exist
+- [x] 3.2 Add `TestInitCmd_SkipsExistingSlashCommands` in `cli_test.go`: create temp dir with `.opencode/command/dewey-store.md` already present (custom content), run init, verify the file was NOT overwritten
+- [x] 3.3 Add `TestInitCmd_NoOpenCodeDir` in `cli_test.go`: create temp dir WITHOUT `.opencode/`, run init, verify no slash commands are created (graceful skip)
+
+## 4. Verification
+
+- [x] 4.1 Run `go build ./...` and `go vet ./...`
+- [x] 4.2 Run `go test -race -count=1 ./...` — all tests pass
+<!-- spec-review: passed -->

--- a/slash_commands.go
+++ b/slash_commands.go
@@ -1,0 +1,202 @@
+package main
+
+// deweySlashCommands contains the slash command definitions that
+// `dewey init` scaffolds into `.opencode/command/` when the
+// `.opencode/` directory exists. Each entry maps a filename to
+// the command content. Files that already exist are not overwritten
+// to preserve user customizations.
+var deweySlashCommands = map[string]string{
+	"dewey-store.md": `---
+description: Store pasted text as a Dewey learning with intelligent tag and category suggestions.
+---
+
+# Command: /dewey-store
+
+## Description
+
+Store ad-hoc knowledge (Slack DMs, meeting notes, decisions,
+observations) as a Dewey learning. Supports three modes:
+fully specified, suggested (agent analyzes text and proposes
+tag/category), and extract (breaks a long conversation into
+multiple learnings).
+
+## Usage
+
+` + "```" + `
+/dewey-store --tag auth-design --category decision
+Sarah confirmed we need OAuth2 + SAML for enterprise.
+
+/dewey-store
+Just talked to the team — we're switching to PostgreSQL.
+
+/dewey-store --extract
+[paste a long Slack conversation or meeting transcript]
+` + "```" + `
+
+## Instructions
+
+### 1. Parse Input
+
+Read the user's message after ` + "`/dewey-store`" + `.
+
+**Check for flags**:
+- ` + "`--tag <value>`" + `: Topic tag for the learning
+- ` + "`--category <value>`" + `: One of decision, pattern, gotcha, context, reference
+- ` + "`--extract`" + `: Enable multi-learning extraction mode
+
+Everything after the flags is the **text to store**.
+
+If no text is provided, ask:
+> "What knowledge would you like to store? Paste the text."
+
+### 2. Determine Mode
+
+**Mode A: Fully Specified** (both --tag and --category provided)
+Call store_learning immediately. Skip to Step 5.
+
+**Mode B: Suggested** (no --tag or no --category)
+Proceed to Step 3.
+
+**Mode C: Extract** (--extract flag present)
+Proceed to Step 4.
+
+### 3. Analyze and Suggest (Mode B)
+
+**Tag suggestion**: Suggest 2-3 tags ranked by specificity.
+
+**Category suggestion**: Classify based on content:
+- "decided", "agreed", "confirmed" → decision
+- "watch out", "gotcha", "careful" → gotcha
+- "pattern", "approach", "technique" → pattern
+- URL, "see also", "reference" → reference
+- Default → context
+
+Wait for user confirmation before calling store_learning.
+
+### 4. Multi-Learning Extraction (Mode C)
+
+Identify distinct pieces of knowledge. Present as numbered
+list with tag/category for each. Wait for confirmation.
+
+### 5. Post-Store
+
+Display the returned identity and suggest /dewey-compile.
+`,
+
+	"dewey-index.md": `---
+description: Trigger an incremental re-index of all configured content sources.
+---
+
+# Command: /dewey-index
+
+## Description
+
+Trigger an incremental re-index of all configured content sources.
+Updates the Dewey knowledge graph with new and changed content from
+disk, GitHub, web, and code sources without leaving the OpenCode session.
+
+## Usage
+
+` + "```" + `
+/dewey-index
+/dewey-index disk-website
+` + "```" + `
+
+## Instructions
+
+Call the Dewey MCP tool ` + "`index`" + ` to re-index configured sources.
+
+If the user provided a source ID argument (e.g., disk-website),
+pass it as the source_id parameter to index only that source.
+
+If no argument is provided, call index with no parameters to
+index all configured sources.
+
+Display the returned summary showing sources processed, pages
+new/changed/deleted, embeddings generated, and elapsed time.
+`,
+
+	"dewey-reindex.md": `---
+description: Delete and rebuild all external source content in the Dewey index.
+---
+
+# Command: /dewey-reindex
+
+## Description
+
+Delete and rebuild all external source content in the Dewey index.
+Preserves local vault content and stored learnings. Use when the
+index appears stale or corrupted.
+
+## Usage
+
+` + "```" + `
+/dewey-reindex
+` + "```" + `
+
+## Instructions
+
+**Warning**: This deletes all external source content and rebuilds
+from scratch. Local vault content and stored learnings are preserved.
+
+Call the Dewey MCP tool ` + "`reindex`" + ` with no parameters.
+
+Display the returned summary showing pages deleted, sources
+re-indexed, new page counts, and elapsed time.
+`,
+
+	"dewey-compile.md": `---
+description: Synthesize stored learnings into compiled knowledge articles.
+---
+
+# Command: /dewey-compile
+
+## Description
+
+Synthesize stored learnings into compiled knowledge articles.
+Groups learnings by topic, resolves contradictions temporally,
+and produces current-state articles with history.
+
+## Usage
+
+` + "```" + `
+/dewey-compile
+` + "```" + `
+
+## Instructions
+
+Call the Dewey MCP tool ` + "`compile`" + ` to synthesize stored learnings.
+
+Display the returned summary showing topics compiled, articles
+generated, and elapsed time.
+`,
+
+	"dewey-lint.md": `---
+description: Scan the knowledge base for quality issues.
+---
+
+# Command: /dewey-lint
+
+## Description
+
+Scan the knowledge base for quality issues: stale decisions,
+uncompiled learnings, embedding gaps, and potential contradictions.
+
+## Usage
+
+` + "```" + `
+/dewey-lint
+/dewey-lint --fix
+` + "```" + `
+
+## Instructions
+
+Call the Dewey MCP tool ` + "`lint`" + ` to scan for quality issues.
+
+If --fix is specified, pass fix: true to auto-repair
+mechanical issues (regenerate missing embeddings).
+
+Display the returned report showing findings and remediation
+suggestions.
+`,
+}


### PR DESCRIPTION
## Summary

- New `/dewey-store` slash command with 3 interaction modes:
  - **Fully specified**: `--tag` and `--category` provided, calls `store_learning` immediately
  - **Suggested**: Agent analyzes pasted text, suggests 2-3 tags ranked by specificity and a category based on content patterns, asks for confirmation
  - **Extract**: `--extract` flag breaks long conversations into multiple distinct learnings with individual tag/category proposals
- `dewey init` now scaffolds 5 Dewey slash commands into `.opencode/command/` when `.opencode/` exists: `dewey-store`, `dewey-index`, `dewey-reindex`, `dewey-compile`, `dewey-lint`
- Idempotent: existing command files are not overwritten (preserves user customizations)
- New `slash_commands.go` embeds command content as Go string constants
- 3 new tests: scaffolding creates files, skips existing files, graceful skip without `.opencode/`