### PR TITLE
fix: dewey init scaffolds slash commands on re-init, not just first init (#48)

### DIFF
--- a/.opencode/command/cobalt-crush.md
+++ b/.opencode/command/cobalt-crush.md
@@ -3,8 +3,9 @@ description: >
   Invoke the Cobalt-Crush developer persona for implementation tasks.
   With arguments: delegates to the cobalt-crush-dev agent. Without
   arguments: detects active workflow and runs /speckit.implement or
-  /opsx:apply.
+  /opsx-apply.
 ---
+<!-- scaffolded by uf vdev -->
 <!-- scaffolded by uf vdev -->
 <!-- scaffolded by uf vdev -->
 <!-- scaffolded by uf vdev -->
@@ -90,9 +91,11 @@ implementation command to the `cobalt-crush-dev` agent:
    > No active implementation context detected. Which workflow
    > should I execute?
    >
+   > - `/unleash` — Autonomous pipeline (parallel swarm,
+   >   recommended for multi-task changes)
    > - `/speckit.implement` — Strategic spec implementation
    >   (requires a feature branch with `specs/NNN-*/tasks.md`)
-   > - `/opsx:apply` — Tactical change implementation
+   > - `/opsx-apply` — Tactical change implementation
    >   (requires an active change in `openspec/changes/`)
 
 ## Branch Safety Guardrails

--- a/.opencode/command/constitution-check.md
+++ b/.opencode/command/constitution-check.md
@@ -5,6 +5,7 @@ agent: constitution-check
 <!-- scaffolded by uf vdev -->
 <!-- scaffolded by uf vdev -->
 <!-- scaffolded by uf vdev -->
+<!-- scaffolded by uf vdev -->
 <!-- scaffolded by uf vv0.6.1 -->
 <!-- scaffolded by uf vdev -->
 

--- a/.opencode/command/finale.md
+++ b/.opencode/command/finale.md
@@ -7,6 +7,7 @@ description: >
 <!-- scaffolded by uf vdev -->
 <!-- scaffolded by uf vdev -->
 <!-- scaffolded by uf vdev -->
+<!-- scaffolded by uf vdev -->
 
 # Command: /finale
 

--- a/.opencode/command/review-council.md
+++ b/.opencode/command/review-council.md
@@ -4,6 +4,7 @@ description: Run the reviewer governance council to audit codebase or spec compl
 <!-- scaffolded by uf vdev -->
 <!-- scaffolded by uf vdev -->
 <!-- scaffolded by uf vdev -->
+<!-- scaffolded by uf vdev -->
 <!-- scaffolded by uf vv0.6.1 -->
 # Command: /review-council
 

--- a/.opencode/command/uf-init.md
+++ b/.opencode/command/uf-init.md
@@ -8,6 +8,7 @@ description: >
 <!-- scaffolded by uf vdev -->
 <!-- scaffolded by uf vdev -->
 <!-- scaffolded by uf vdev -->
+<!-- scaffolded by uf vdev -->
 <!-- scaffolded by uf vv0.6.1 -->
 
 # Command: /uf-init
@@ -511,10 +512,10 @@ The guardrails block to append:
   tasks)
 - **NEVER commit, push, or create PRs** — those are
   /finale's responsibility
-- **NEVER run /opsx-apply or /cobalt-crush** — the
-  user decides when to implement
+- **NEVER run /unleash, /opsx-apply, or /cobalt-crush**
+  — the user decides when to implement
 - After artifacts are complete, STOP and prompt the
-  user to run /opsx-apply or /cobalt-crush
+  user to run /unleash, /opsx-apply, or /cobalt-crush
 ```
 
 ### Step 9: AGENTS.md Behavioral Guidance
@@ -979,6 +980,8 @@ Finally, remind the user:
 
 After customizations are applied:
 
+- Run `/unleash` for autonomous pipeline execution
+  (parallel swarm, recommended for multi-task changes)
 - Run `/cobalt-crush` to start implementing — it
   auto-detects your active workflow (Speckit or OpenSpec)
   and delegates to the correct implementation command.

--- a/.opencode/command/unleash.md
+++ b/.opencode/command/unleash.md
@@ -10,6 +10,7 @@ description: >
 <!-- scaffolded by uf vdev -->
 <!-- scaffolded by uf vdev -->
 <!-- scaffolded by uf vdev -->
+<!-- scaffolded by uf vdev -->
 
 # Command: /unleash
 

--- a/.opencode/skill/speckit-workflow/SKILL.md
+++ b/.opencode/skill/speckit-workflow/SKILL.md
@@ -9,6 +9,7 @@ tags:
 <!-- scaffolded by uf vdev -->
 <!-- scaffolded by uf vdev -->
 <!-- scaffolded by uf vdev -->
+<!-- scaffolded by uf vdev -->
 <!-- scaffolded by uf vv0.6.1 -->
 
 # Speckit Workflow — Swarm Skill
@@ -139,3 +140,13 @@ hero routing and workflow stage context:
 skills_use({ name: "unbound-force-heroes" })
 skills_use({ name: "speckit-workflow" })
 ```
+
+## Entry Point
+
+The `/unleash` command is the primary way to trigger
+autonomous pipeline execution using this skill. It
+orchestrates the full Speckit pipeline (clarify, plan,
+tasks, spec review, implement, code review,
+retrospective, demo) and uses the task format described
+above for the implementation phase. `/unleash` also
+supports OpenSpec (`opsx/*`) branches.

--- a/.opencode/uf/packs/content.md
+++ b/.opencode/uf/packs/content.md
@@ -5,6 +5,7 @@ version: 1.0.0
 ---
 <!-- scaffolded by uf vdev -->
 <!-- scaffolded by uf vdev -->
+<!-- scaffolded by uf vdev -->
 
 # Convention Pack: Content (Documentation, Blog, PR/Comms)
 

--- a/.opencode/uf/packs/default.md
+++ b/.opencode/uf/packs/default.md
@@ -6,6 +6,7 @@ version: 1.0.0
 <!-- scaffolded by uf vdev -->
 <!-- scaffolded by uf vdev -->
 <!-- scaffolded by uf vdev -->
+<!-- scaffolded by uf vdev -->
 <!-- scaffolded by uf vv0.6.1 -->
 
 # Convention Pack: Default (Language-Agnostic)

--- a/.opencode/uf/packs/go.md
+++ b/.opencode/uf/packs/go.md
@@ -6,6 +6,7 @@ version: 1.0.0
 <!-- scaffolded by uf vdev -->
 <!-- scaffolded by uf vdev -->
 <!-- scaffolded by uf vdev -->
+<!-- scaffolded by uf vdev -->
 <!-- scaffolded by uf vv0.6.1 -->
 
 # Convention Pack: Go

--- a/.opencode/uf/packs/severity.md
+++ b/.opencode/uf/packs/severity.md
@@ -3,6 +3,7 @@ description: "Shared severity level definitions for all Divisor Council personas
 ---
 <!-- scaffolded by uf vdev -->
 <!-- scaffolded by uf vdev -->
+<!-- scaffolded by uf vdev -->
 
 # Severity Convention Pack
 

--- a/.opencode/uf/packs/typescript.md
+++ b/.opencode/uf/packs/typescript.md
@@ -6,6 +6,7 @@ version: 1.0.0
 <!-- scaffolded by uf vdev -->
 <!-- scaffolded by uf vdev -->
 <!-- scaffolded by uf vdev -->
+<!-- scaffolded by uf vdev -->
 <!-- scaffolded by uf vv0.6.1 -->
 
 # Convention Pack: TypeScript

--- a/cli.go
+++ b/cli.go
@@ -228,12 +228,15 @@ func newInitCmd() *cobra.Command {
 
 			deweyDir := filepath.Join(vaultPath, deweyWorkspaceDir)
 
-			// Check if already initialized (idempotent).
+			// Check if already initialized. If so, skip config/sources
+			// creation but still run slash command scaffolding below.
+			alreadyInitialized := false
 			if _, err := os.Stat(deweyDir); err == nil {
+				alreadyInitialized = true
 				logger.Info("already initialized", "path", deweyDir)
-				return nil
 			}
 
+			if !alreadyInitialized {
 			// Create .uf/dewey/ directory (MkdirAll creates .uf/ parent too — D3).
 			if err := os.MkdirAll(deweyDir, 0o755); err != nil {
 				return fmt.Errorf("create .uf/dewey/ directory: %w", err)
@@ -304,6 +307,7 @@ sources:
 					}
 				}
 			}
+			} // end if !alreadyInitialized
 
 			// Scaffold Dewey-specific slash commands into .opencode/command/
 			// if the .opencode/ directory exists (composability — only scaffold
@@ -324,9 +328,10 @@ sources:
 				}
 			}
 
-			logger.Info("initialized", "path", deweyDir)
-			logger.Info("default config", "file", configPath)
-			logger.Info("run 'dewey index' to build the initial index")
+			if !alreadyInitialized {
+				logger.Info("initialized", "path", deweyDir)
+				logger.Info("run 'dewey index' to build the initial index")
+			}
 
 			return nil
 		},

--- a/cli_test.go
+++ b/cli_test.go
@@ -491,6 +491,50 @@ func TestInitCmd_NoOpenCodeDir(t *testing.T) {
 	}
 }
 
+// TestInitCmd_ReInitScaffoldsNewCommands verifies that running dewey init
+// on an already-initialized repo still scaffolds missing slash commands.
+func TestInitCmd_ReInitScaffoldsNewCommands(t *testing.T) {
+	tmpDir := t.TempDir()
+
+	// Create .opencode/ and .gitignore.
+	if err := os.MkdirAll(filepath.Join(tmpDir, ".opencode"), 0o755); err != nil {
+		t.Fatalf("create .opencode: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(tmpDir, ".gitignore"), []byte(""), 0o644); err != nil {
+		t.Fatalf("write .gitignore: %v", err)
+	}
+
+	// First init — creates everything.
+	cmd := newInitCmd()
+	cmd.SetArgs([]string{"--vault", tmpDir})
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("first init failed: %v", err)
+	}
+
+	// Verify slash commands were created.
+	storePath := filepath.Join(tmpDir, ".opencode", "command", "dewey-store.md")
+	if _, err := os.Stat(storePath); err != nil {
+		t.Fatalf("dewey-store.md not created on first init")
+	}
+
+	// Delete one slash command to simulate upgrading dewey with a new command.
+	if err := os.Remove(storePath); err != nil {
+		t.Fatalf("remove dewey-store.md: %v", err)
+	}
+
+	// Second init — should re-scaffold the deleted command.
+	cmd2 := newInitCmd()
+	cmd2.SetArgs([]string{"--vault", tmpDir})
+	if err := cmd2.Execute(); err != nil {
+		t.Fatalf("second init failed: %v", err)
+	}
+
+	// Verify the deleted command was re-scaffolded.
+	if _, err := os.Stat(storePath); err != nil {
+		t.Error("dewey-store.md should have been re-scaffolded on second init")
+	}
+}
+
 // --- Status command tests ---
 
 // TestStatusCmd_Uninitialized verifies status fails when .uf/dewey/ doesn't exist.

--- a/openspec/changes/fix-init-scaffolding/.openspec.yaml
+++ b/openspec/changes/fix-init-scaffolding/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: unbound-force
+created: 2026-04-19

--- a/openspec/changes/fix-init-scaffolding/design.md
+++ b/openspec/changes/fix-init-scaffolding/design.md
@@ -1,0 +1,16 @@
+## Context
+
+`newInitCmd()` in `cli.go` has an early return at line 232-234 that prevents any code after it from executing on already-initialized repos.
+
+## Goals / Non-Goals
+
+### Goals
+- Slash command scaffolding runs on every `dewey init`, not just the first
+- Config/sources creation still skipped when already initialized
+
+### Non-Goals
+- No `--force` flag (scaffolding is already idempotent)
+
+## Decisions
+
+**D1: Replace early return with conditional block.** Wrap the config/sources/gitignore creation in an `if !alreadyInitialized` block instead of returning early. Slash command scaffolding runs unconditionally after.

--- a/openspec/changes/fix-init-scaffolding/proposal.md
+++ b/openspec/changes/fix-init-scaffolding/proposal.md
@@ -1,0 +1,24 @@
+## Why
+
+`dewey init` returns early with "already initialized" when `.uf/dewey/` exists, preventing slash command scaffolding from running on already-initialized repos. Users upgrading dewey never get the new slash commands.
+
+Fixes GitHub issue #48.
+
+## What Changes
+
+Restructure `newInitCmd()` so the "already initialized" check only skips config/sources file creation. Slash command scaffolding always runs (idempotently).
+
+## Capabilities
+
+### Modified Capabilities
+- `dewey init`: Always scaffolds slash commands into `.opencode/command/` when `.opencode/` exists, even if `.uf/dewey/` already exists
+
+## Impact
+
+- `cli.go`: ~10 line restructure of `newInitCmd()`
+- `cli_test.go`: Update existing test + add test for scaffolding on re-init
+
+## Constitution Alignment
+
+### II. Composability First
+**Assessment**: PASS — Slash commands only scaffolded when `.opencode/` exists.

--- a/openspec/changes/fix-init-scaffolding/specs/init-flow.md
+++ b/openspec/changes/fix-init-scaffolding/specs/init-flow.md
@@ -1,0 +1,19 @@
+## MODIFIED Requirements
+
+### Requirement: dewey init Slash Command Scaffolding
+
+`dewey init` MUST scaffold Dewey slash commands on every invocation, not just the first.
+
+Previously: Early return on "already initialized" prevented scaffolding.
+
+#### Scenario: Re-init scaffolds new commands
+- **GIVEN** a repo with `.uf/dewey/` already initialized and `.opencode/` present
+- **WHEN** the developer runs `dewey init`
+- **THEN** any missing slash commands are created in `.opencode/command/`
+- **AND** existing slash commands are NOT overwritten
+
+#### Scenario: First init still works
+- **GIVEN** a repo with no `.uf/dewey/` directory
+- **WHEN** the developer runs `dewey init`
+- **THEN** `.uf/dewey/` is created with config and sources
+- **AND** slash commands are scaffolded into `.opencode/command/`

--- a/openspec/changes/fix-init-scaffolding/tasks.md
+++ b/openspec/changes/fix-init-scaffolding/tasks.md
@@ -1,0 +1,14 @@
+## 1. Restructure Init Flow
+
+- [x] 1.1 In `cli.go` `newInitCmd()`: replace the early return at "already initialized" with a conditional block that only skips config/sources/gitignore creation. Slash command scaffolding must run unconditionally after.
+
+## 2. Tests
+
+- [x] 2.1 Add `TestInitCmd_ReInitScaffoldsNewCommands`: init once (creates everything), delete one slash command, init again, verify the deleted command is re-scaffolded
+- [x] 2.2 Verify existing `TestInitCmd_Idempotent` still passes (re-init doesn't error)
+
+## 3. Verification
+
+- [x] 3.1 Run `go build ./...` and `go vet ./...`
+- [x] 3.2 Run `go test -race -count=1 ./...` — all tests pass
+<!-- spec-review: passed -->

--- a/openspec/schemas/unbound-force/schema.yaml
+++ b/openspec/schemas/unbound-force/schema.yaml
@@ -69,3 +69,4 @@ apply:
 # scaffolded by uf vdev
 # scaffolded by uf vdev
 # scaffolded by uf vdev
+# scaffolded by uf vdev

--- a/openspec/schemas/unbound-force/templates/design.md
+++ b/openspec/schemas/unbound-force/templates/design.md
@@ -21,3 +21,4 @@
 <!-- scaffolded by uf vdev -->
 <!-- scaffolded by uf vdev -->
 <!-- scaffolded by uf vdev -->
+<!-- scaffolded by uf vdev -->

--- a/openspec/schemas/unbound-force/templates/proposal.md
+++ b/openspec/schemas/unbound-force/templates/proposal.md
@@ -58,3 +58,4 @@ Are components testable in isolation? -->
 <!-- scaffolded by uf vdev -->
 <!-- scaffolded by uf vdev -->
 <!-- scaffolded by uf vdev -->
+<!-- scaffolded by uf vdev -->

--- a/openspec/schemas/unbound-force/templates/spec.md
+++ b/openspec/schemas/unbound-force/templates/spec.md
@@ -24,3 +24,4 @@
 <!-- scaffolded by uf vdev -->
 <!-- scaffolded by uf vdev -->
 <!-- scaffolded by uf vdev -->
+<!-- scaffolded by uf vdev -->

--- a/openspec/schemas/unbound-force/templates/tasks.md
+++ b/openspec/schemas/unbound-force/templates/tasks.md
@@ -10,3 +10,4 @@
 <!-- scaffolded by uf vdev -->
 <!-- scaffolded by uf vdev -->
 <!-- scaffolded by uf vdev -->
+<!-- scaffolded by uf vdev -->


### PR DESCRIPTION
## Summary

- `dewey init` now scaffolds slash commands on every invocation, not just the first
- Previously, the "already initialized" early return at cli.go:232 prevented slash command scaffolding from running on already-initialized repos — users upgrading dewey never got new slash commands
- Fix: replaced `return nil` with a `alreadyInitialized` boolean flag that only skips config/sources creation while letting scaffolding run unconditionally
- New `TestInitCmd_ReInitScaffoldsNewCommands` test: inits, deletes a command, re-inits, verifies re-scaffolding

Closes #48