### PR TITLE
feat: pluggable embedding and synthesis providers (Ollama + Vertex AI)

### DIFF
--- a/.opencode/command/review-council.md
+++ b/.opencode/command/review-council.md
@@ -179,6 +179,18 @@ Review the current codebase for compliance with the Behavioral Constraints in `A
 
 2. Delegate the review to all **discovered** reviewer agents in parallel using the Task tool. For each discovered agent, use the focus area from the Known Reviewer Roles reference table to provide targeted context. For any discovered agent not in the table, use a generic prompt: "Review the current changes for quality, correctness, and compliance. Return your verdict (APPROVE or REQUEST CHANGES) along with all findings."
 
+   **CRITICAL — Review Scope Rule**: The review scope is
+   ALWAYS the **full branch diff** (`git diff main...HEAD`),
+   meaning ALL files changed on the branch relative to
+   `main`. Do NOT narrow the scope to only recent commits,
+   only uncommitted changes, or only files touched in the
+   current session. Every agent MUST be instructed to read
+   and review ALL changed files from the branch diff. The
+   list of changed files from auto-detection step 2 MUST
+   be included in each agent's prompt. Violating this rule
+   produces incomplete reviews that miss findings in
+   earlier commits on the branch.
+
    **When Gaze data is available** (from Phase 1b):
    append a "Quality Context" section to each Divisor
    agent's review prompt containing the Gaze Report
@@ -193,7 +205,7 @@ Review the current codebase for compliance with the Behavioral Constraints in `A
    standard prompt without a "Quality Context"
    section. Agents review based on file reading only.
 
-   For each agent, instruct it to review the current changes and return its verdict (**APPROVE** or **REQUEST CHANGES**) along with all findings.
+   For each agent, instruct it to review the full branch diff (all changed files vs `main`) and return its verdict (**APPROVE** or **REQUEST CHANGES**) along with all findings.
 
 3. Collect all **REQUEST CHANGES** findings from the discovered reviewers. If all discovered reviewers return **APPROVE**, report the result and stop.
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -335,6 +335,7 @@ curate/              # Knowledge store configuration parsing + curation pipeline
 - **Background indexing**: The MCP server starts before vault indexing completes. Tools serve from the persistent store (previous session's data) during background indexing. An `atomic.Bool` `indexReady` flag tracks completion (012-background-index).
 - **Ollama auto-start**: `ensureOllama()` detects Ollama state (External/Managed/Unavailable) and auto-starts a subprocess if installed but not running. The subprocess is detached via `Setpgid` so it outlives Dewey (007-ollama-autostart). Only triggered when the embedding provider is `ollama`.
 - **Pluggable providers**: Both `Embedder` and `Synthesizer` interfaces support multiple backends (ollama, vertex). Configured via `config.yaml` `embedding` and `synthesis` sections. Factory functions `embed.NewEmbedderFromConfig()` and `llm.NewSynthesizerFromConfig()` centralize construction. Backward compatible — existing configs and env vars continue to work.
+- **Vertex AI rate limiting**: Both `VertexEmbedder` and `VertexSynthesizer` retry on HTTP 429 with exponential backoff (base 1s, max 60s, up to 5 attempts). Respects the `Retry-After` header when present. Context cancellation is honored between retries. Retries are logged at warn level via `charmbracelet/log`.
 
 ### Provider Configuration
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -2,7 +2,7 @@
 
 ## Project Overview
 
-Dewey is a knowledge graph MCP server that gives AI agents full access to Markdown knowledge bases. It supports **Logseq** and **Obsidian** with full read-write support — 49 MCP tools across navigate, search, analyze, write, decision, journal, flashcard, whiteboard, semantic search, compile, lint, promote, indexing, learning, and curate categories. Hard fork of [graphthulhu](https://github.com/skridlevsky/graphthulhu), extended with persistent SQLite storage, vector-based semantic search via Ollama, pluggable content sources (disk, GitHub, web crawl, code), knowledge compilation with temporal intelligence, curated knowledge stores, and trust tiers.
+Dewey is a knowledge graph MCP server that gives AI agents full access to Markdown knowledge bases. It supports **Logseq** and **Obsidian** with full read-write support — 50 MCP tools across navigate, search, analyze, write, decision, journal, flashcard, whiteboard, semantic search, compile, lint, promote, indexing, learning, and curate categories. Hard fork of [graphthulhu](https://github.com/skridlevsky/graphthulhu), extended with persistent SQLite storage, vector-based semantic search via Ollama, pluggable content sources (disk, GitHub, web crawl, code), knowledge compilation with temporal intelligence, curated knowledge stores, pluggable LLM providers (Ollama, Vertex AI), and trust tiers.
 
 - **Language**: Go 1.25+
 - **Module**: `github.com/unbound-force/dewey`
@@ -78,7 +78,7 @@ proceeding with out-of-phase changes.
 
 - **CI Parity Gate**: Before marking any implementation task complete or declaring a PR ready, agents MUST replicate the CI checks locally. Read `.github/workflows/` to identify the exact commands CI runs, then execute those same commands. Any failure is a blocking error — a task is not complete until all CI-equivalent checks pass locally. Do not rely on a memorized list of commands; always derive them from the workflow files, which are the source of truth.
 - **No CGO**: All dependencies MUST be pure Go. The constitution prohibits CGO unless no pure-Go alternative exists.
-- **Local-Only Processing**: No data MUST leave the developer's machine. Embedding generation uses Ollama locally.
+- **Local-Only Processing**: No data leaves the developer's machine by default. Embedding generation uses Ollama locally. Cloud providers (Vertex AI) are opt-in via `config.yaml`.
 - **Backward Compatibility**: All 37 inherited graphthulhu MCP tools MUST produce identical results after any change.
 
 ## Council Governance Protocol
@@ -307,18 +307,18 @@ MCP server + CLI tool with flat package layout:
 ```text
 main.go              # Entry point, Cobra root command, serve logic
 cli.go               # CLI subcommands (journal, add, search, init, index, reindex, status, source, doctor, manifest, compile, lint, promote, curate)
-server.go            # MCP server setup, 49 tool registrations
+server.go            # MCP server setup, 50 tool registrations
 backend/             # Backend interface + capability interfaces
 client/              # Logseq HTTP API client with retry/backoff
 vault/               # Obsidian vault backend (file parsing, indexing, watcher, persistence)
 vault/parse_export.go # Exported parsing and persistence functions (ParseDocument, PersistBlocks, PersistLinks, GenerateEmbeddings)
 tools/               # MCP tool implementations (navigate, search, analyze, write, decision, journal, flashcard, whiteboard, semantic, compile, lint, promote, curate)
 types/               # Shared types (PageEntity, BlockEntity, tool inputs, semantic search types)
-llm/                 # LLM synthesis interface (Synthesizer, OllamaSynthesizer, NoopSynthesizer for tests)
+llm/                 # LLM synthesis interface (Synthesizer, OllamaSynthesizer, VertexSynthesizer, NoopSynthesizer for tests)
 parser/              # Content parser (wikilinks, tags, properties)
 graph/               # In-memory graph construction + algorithms
 store/               # SQLite persistence layer (pages, blocks, links, embeddings, sources)
-embed/               # Embedding generation (Ollama client, chunker)
+embed/               # Embedding generation (Ollama + Vertex AI clients, provider factory, config, chunker)
 source/              # Pluggable content sources (disk, GitHub, web crawl, code, manager)
 chunker/             # Language-aware source code parsing (Chunker interface, Go implementation, registry)
 curate/              # Knowledge store configuration parsing + curation pipeline (config, extraction, quality analysis)
@@ -333,7 +333,29 @@ curate/              # Knowledge store configuration parsing + curation pipeline
 - **charmbracelet/log**: Structured logging throughout. No `fmt.Fprintf` to stderr.
 - **Trust tiers**: Pages have a `tier` field (`authored`, `curated`, `validated`, `draft`) and optional `category` field for knowledge provenance tracking (013-knowledge-compile, 015-curated-knowledge-stores).
 - **Background indexing**: The MCP server starts before vault indexing completes. Tools serve from the persistent store (previous session's data) during background indexing. An `atomic.Bool` `indexReady` flag tracks completion (012-background-index).
-- **Ollama auto-start**: `ensureOllama()` detects Ollama state (External/Managed/Unavailable) and auto-starts a subprocess if installed but not running. The subprocess is detached via `Setpgid` so it outlives Dewey (007-ollama-autostart).
+- **Ollama auto-start**: `ensureOllama()` detects Ollama state (External/Managed/Unavailable) and auto-starts a subprocess if installed but not running. The subprocess is detached via `Setpgid` so it outlives Dewey (007-ollama-autostart). Only triggered when the embedding provider is `ollama`.
+- **Pluggable providers**: Both `Embedder` and `Synthesizer` interfaces support multiple backends (ollama, vertex). Configured via `config.yaml` `embedding` and `synthesis` sections. Factory functions `embed.NewEmbedderFromConfig()` and `llm.NewSynthesizerFromConfig()` centralize construction. Backward compatible — existing configs and env vars continue to work.
+
+### Provider Configuration
+
+Embedding and synthesis backends are configurable in `.uf/dewey/config.yaml`:
+
+```yaml
+embedding:
+  provider: ollama  # or: vertex
+  model: granite-embedding:30m
+  endpoint: http://localhost:11434
+
+synthesis:
+  provider: vertex
+  model: claude-sonnet-4-6
+  project: my-gcp-project
+  region: us-east5
+```
+
+Vertex providers use `golang.org/x/oauth2/google` application-default credentials. If no provider is specified, defaults to Ollama.
+
+**Global config**: `~/.config/dewey/config.yaml` (or `$XDG_CONFIG_HOME/dewey/config.yaml`) provides defaults for all vaults. Per-vault config overrides global. This avoids repeating provider config in every project.
 
 ### Store Learning API
 
@@ -507,6 +529,7 @@ specs/
   010-code-source-index/       # Code source indexing, Go chunker, manifest generation (In Progress)
   013-knowledge-compile/       # Knowledge compilation, temporal intelligence, linting, trust tiers (Complete)
   015-curated-knowledge-stores/ # File-backed learnings, curation pipeline, knowledge stores, curated tier (In Progress)
+  016-pluggable-providers/       # Pluggable embedding/synthesis providers (Ollama, Vertex AI), store_compiled, global config (Complete)
 ```
 
 ## Active Technologies
@@ -534,6 +557,7 @@ specs/
 - N/A (no schema changes — `curated` is a new value in the existing `tier TEXT` column. File-backed learnings use filesystem, not new tables) (015-curated-knowledge-stores)
 
 ## Recent Changes
+- 016-pluggable-providers: Added Vertex AI embedding and synthesis providers, `store_compiled` MCP tool, global config fallback (`~/.config/dewey/config.yaml`), factory functions `embed.NewEmbedderFromConfig()` and `llm.NewSynthesizerFromConfig()`, `golang.org/x/oauth2/google` dependency
 - learning-identity-collision-fix (OpenSpec): Changed learning identity format from `{tag}-{sequence}` to `{tag}-{YYYYMMDDTHHMMSS}-{author}` with three-tier author resolution (`DEWEY_AUTHOR` env var → `git config user.name` → `"anonymous"`), sub-second collision avoidance via `O_CREATE|O_EXCL` with suffix fallback, removed `NextLearningSequence` from store, backward-compatible re-ingestion of old-format files
 - 015-curated-knowledge-stores: Added `curate/` package (config parsing + curation pipeline), `dewey curate` CLI command, `curate` MCP tool, file-backed learnings (`.uf/dewey/learnings/`), `curated` trust tier, knowledge stores (`.uf/dewey/knowledge-stores.yaml`), background curation goroutine, lint knowledge store quality metrics
 - 012-background-index: Added Go 1.25 (per `go.mod`) + `sync/atomic` (readiness flag), `sync` (shared mutex)

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 Knowledge graph MCP server that gives AI full access to your knowledge graph. Supports **Logseq** and **Obsidian** — both with full read-write support. Navigate pages, search blocks, analyze link structure, track decisions, manage flashcards, compile knowledge, curate knowledge stores, and write content — all through the [Model Context Protocol](https://modelcontextprotocol.io).
 
-Hard fork of [graphthulhu](https://github.com/skridlevsky/graphthulhu) by Max Skridlevsky, extended with persistent SQLite storage, vector-based semantic search via Ollama, pluggable content sources (disk, GitHub, web crawl, code), knowledge compilation with temporal intelligence, curated knowledge stores, and trust tiers for the [Unbound Force](https://github.com/unbound-force) AI agent swarm ecosystem.
+Hard fork of [graphthulhu](https://github.com/skridlevsky/graphthulhu) by Max Skridlevsky, extended with persistent SQLite storage, vector-based semantic search via Ollama, pluggable LLM providers (Ollama, Vertex AI), pluggable content sources (disk, GitHub, web crawl, code), knowledge compilation with temporal intelligence, curated knowledge stores, and trust tiers for the [Unbound Force](https://github.com/unbound-force) AI agent swarm ecosystem.
 
 Built in Go with the [official MCP Go SDK](https://github.com/modelcontextprotocol/go-sdk).
 
@@ -26,7 +26,7 @@ It turns "tell me about X" into an AI that actually understands your knowledge g
 
 ## Tools
 
-49 tools across 15 categories. Most work with both backends; some are Logseq-only (DataScript queries, flashcards, whiteboards).
+50 tools across 16 categories. Most work with both backends; some are Logseq-only (DataScript queries, flashcards, whiteboards).
 
 ### Navigate
 
@@ -119,6 +119,7 @@ It turns "tell me about X" into an AI that actually understands your knowledge g
 | Tool | Backend | Description |
 |------|---------|-------------|
 | `compile` | Both | Synthesize stored learnings into compiled knowledge articles |
+| `store_compiled` | Both | Persist a compiled article synthesized by the calling agent |
 
 ### Lint
 
@@ -520,13 +521,11 @@ Dewey respects `.gitignore` files at the root of each source directory. Addition
 
 ## Semantic Search Setup
 
-Semantic search requires [Ollama](https://ollama.ai) running locally. All keyword-based tools work without it — only the 3 semantic search tools (`semantic_search`, `similar`, `semantic_search_filtered`) require Ollama.
+Semantic search requires an embedding provider. Dewey defaults to [Ollama](https://ollama.ai) running locally, but also supports [Google Vertex AI](#vertex-ai-provider). All keyword-based tools work without an embedding provider — only the 3 semantic search tools (`semantic_search`, `similar`, `semantic_search_filtered`) require one.
 
-### Ollama Auto-Start
+### Ollama (Default)
 
 Dewey auto-starts Ollama if it's installed but not running. No manual `ollama serve` needed — Dewey detects Ollama's state (External/Managed/Unavailable) and starts a subprocess if necessary. The subprocess is detached so it outlives Dewey.
-
-### Install Ollama and pull the embedding model
 
 ```bash
 brew install --cask ollama-app  # macOS — or download from https://ollama.ai
@@ -539,20 +538,78 @@ ollama pull granite-embedding:30m   # IBM Granite, 63 MB, Apache 2.0
 dewey status
 ```
 
-The output shows embedding coverage. If Ollama is running and the model is pulled, you'll see embedding stats. If Ollama is unavailable, Dewey logs a warning at startup and disables semantic search — all other tools continue to work normally.
+The output shows embedding coverage. If Ollama is running and the model is pulled, you'll see embedding stats. If the provider is unavailable, Dewey logs a warning at startup and disables semantic search — all other tools continue to work normally.
 
-### Configuration
+### Provider Configuration
 
-The embedding model and endpoint are configurable via environment variables or `.uf/dewey/config.yaml`:
+Embedding and synthesis providers are configurable via `.uf/dewey/config.yaml`:
+
+```yaml
+# Ollama (default — no config needed if defaults are fine)
+embedding:
+  provider: ollama
+  model: granite-embedding:30m
+  endpoint: http://localhost:11434
+
+# Vertex AI — for cloud-powered embeddings or synthesis
+embedding:
+  provider: vertex
+  model: text-embedding-005
+  project: my-gcp-project
+  region: us-central1
+
+synthesis:
+  provider: vertex
+  model: claude-sonnet-4-6
+  project: my-gcp-project
+  region: us-east5
+```
+
+You can mix providers — e.g., Ollama for embeddings (fast, local) and Vertex AI for synthesis (high quality):
+
+```yaml
+embedding:
+  provider: ollama
+  model: granite-embedding:30m
+
+synthesis:
+  provider: vertex
+  model: claude-sonnet-4-6
+  project: my-gcp-project
+  region: us-east5
+```
+
+#### Vertex AI Provider
+
+Vertex AI requires Google Cloud application-default credentials:
+
+```bash
+gcloud auth application-default login --scopes=https://www.googleapis.com/auth/cloud-platform
+```
+
+Set `project` and `region` in your config to match your GCP setup. Vertex AI embedding models (e.g., `text-embedding-005`) and Claude synthesis models (e.g., `claude-sonnet-4-6`) must be enabled in your GCP project.
+
+**Note**: Switching embedding providers changes vector dimensions. Run `dewey reindex` after changing the embedding model.
+
+#### Global Config
+
+Create `~/.config/dewey/config.yaml` (or `$XDG_CONFIG_HOME/dewey/config.yaml`) to set defaults for all vaults. Per-vault config overrides global.
+
+#### Environment Variables
+
+Environment variables override config file values for embedding. For synthesis, they serve as fallbacks when no config exists.
 
 | Variable | Default | Description |
 |----------|---------|-------------|
-| `DEWEY_EMBEDDING_MODEL` | `granite-embedding:30m` | Ollama model name |
-| `DEWEY_EMBEDDING_ENDPOINT` | `http://localhost:11434` | Ollama API endpoint |
+| `DEWEY_EMBEDDING_MODEL` | `granite-embedding:30m` | Embedding model (overrides config) |
+| `DEWEY_EMBEDDING_ENDPOINT` | `http://localhost:11434` | Embedding API endpoint (overrides config) |
+| `DEWEY_GENERATION_MODEL` | *(none)* | Synthesis model (fallback when no config) |
 
 ## Knowledge Compilation
 
 Dewey can synthesize stored learnings into compiled knowledge articles using an LLM. The `compile` tool reads all learnings, clusters them by topic tag, and produces current-state articles that resolve temporal contradictions — newer facts replace older ones, while non-contradicted information carries forward.
+
+Agents can also compile knowledge directly: call `compile` to receive synthesis prompts, perform synthesis with any model, then call `store_compiled` to persist the result with provenance tracking. This enables agent-driven compilation without requiring a local LLM.
 
 ### Trust Tiers
 
@@ -600,7 +657,7 @@ When `dewey serve` starts, the MCP server is ready within 1 second. Vault indexi
 main.go              Entry point — backend routing, MCP server startup
 cli.go               CLI subcommands: journal, add, search, init, index, reindex, status,
                      source, doctor, manifest, compile, lint, promote, curate
-server.go            MCP server setup — 49 tool registrations
+server.go            MCP server setup — 50 tool registrations
 backend/backend.go   Backend interface + optional capability interfaces
 client/logseq.go     Logseq HTTP API client with retry/backoff
 vault/
@@ -628,15 +685,17 @@ graph/
 parser/content.go    Regex extraction of [[links]], ((refs)), #tags, properties
 types/
   logseq.go          Shared types with custom JSON unmarshaling
-  tools.go           Input types for all 49 tools
+  tools.go           Input types for all 50 tools
   semantic.go        Semantic search types
-llm/                 LLM synthesis interface (Synthesizer, OllamaSynthesizer, NoopSynthesizer)
+llm/                 LLM synthesis interface (Synthesizer, OllamaSynthesizer, VertexSynthesizer, NoopSynthesizer)
 store/
   store.go           SQLite persistence (pages, blocks, links, sources)
   embeddings.go      Vector embedding storage and cosine similarity search
   migrate.go         Schema migration management
 embed/
   embed.go           Embedder interface + Ollama implementation
+  vertex.go          Vertex AI embedding implementation
+  provider.go        Provider factory + config
   chunker.go         Block-to-chunk preparation with heading context
 source/
   source.go          Source interface definition

--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ It turns "tell me about X" into an AI that actually understands your knowledge g
 
 ## Tools
 
-50 tools across 16 categories. Most work with both backends; some are Logseq-only (DataScript queries, flashcards, whiteboards).
+50 tools across 15 categories. Most work with both backends; some are Logseq-only (DataScript queries, flashcards, whiteboards).
 
 ### Navigate
 

--- a/README.md
+++ b/README.md
@@ -591,6 +591,8 @@ Set `project` and `region` in your config to match your GCP setup. Vertex AI emb
 
 **Note**: Switching embedding providers changes vector dimensions. Run `dewey reindex` after changing the embedding model.
 
+**Rate limiting**: Vertex AI providers automatically retry on HTTP 429 (Too Many Requests) with exponential backoff and jitter — base delay 1 second, maximum 60 seconds, up to 5 attempts. The `Retry-After` header is respected when present. If retries are exhausted, the error is returned to the caller.
+
 #### Global Config
 
 Create `~/.config/dewey/config.yaml` (or `$XDG_CONFIG_HOME/dewey/config.yaml`) to set defaults for all vaults. Per-vault config overrides global.

--- a/cli.go
+++ b/cli.go
@@ -695,7 +695,7 @@ Fetches content from all configured sources and indexes it.`,
 			// Create embedder for embedding generation during indexing (R4).
 			// Hard error: if Ollama is unavailable and --no-embeddings is not set,
 			// indexing fails with an actionable error message.
-			embedder, err := createIndexEmbedder(noEmbeddings)
+			embedder, err := createIndexEmbedder(noEmbeddings, deweyDir)
 			if err != nil {
 				return err
 			}
@@ -836,7 +836,7 @@ The command removes: graph.db, graph.db-wal, graph.db-shm, dewey.lock`,
 			}
 
 			// Create embedder (hard error if unavailable, unless --no-embeddings).
-			embedder, err := createIndexEmbedder(noEmbeddings)
+			embedder, err := createIndexEmbedder(noEmbeddings, deweyDir)
 			if err != nil {
 				return err
 			}
@@ -909,49 +909,50 @@ func detectLockHolder(lockPath string) string {
 	return ""
 }
 
-// createIndexEmbedder creates an OllamaEmbedder for use during indexing,
-// using the same environment variables as `dewey serve` (per research R4).
-// When noEmbeddings is true, returns nil (no embedder). When false, attempts
-// to ensure Ollama is running (auto-start if needed) and checks model
-// availability. Returns nil when Ollama is unavailable (graceful degradation)
-// and a hard error only when Ollama is running but the model is not pulled.
-func createIndexEmbedder(noEmbeddings bool) (embed.Embedder, error) {
+// createIndexEmbedder creates an Embedder for use during indexing.
+// Reads provider configuration from the dewey workspace config.yaml,
+// falling back to environment variables and Ollama defaults.
+// When noEmbeddings is true, returns nil (no embedder). When the provider
+// is Ollama, attempts auto-start. Returns nil on graceful degradation
+// and a hard error only when the provider is available but the model is not.
+func createIndexEmbedder(noEmbeddings bool, deweyDirs ...string) (embed.Embedder, error) {
 	if noEmbeddings {
 		logger.Info("embeddings disabled via --no-embeddings")
 		return nil, nil
 	}
 
-	embedModel := os.Getenv("DEWEY_EMBEDDING_MODEL")
-	embedEndpoint := os.Getenv("DEWEY_EMBEDDING_ENDPOINT")
-	if embedModel == "" {
-		embedModel = "granite-embedding:30m"
+	// Read config from the dewey workspace directory.
+	// The config reader handles env var overrides and defaults.
+	var deweyDir string
+	if len(deweyDirs) > 0 {
+		deweyDir = deweyDirs[0]
 	}
-	if embedEndpoint == "" {
-		embedEndpoint = "http://localhost:11434"
+	cfg := embed.ReadEmbeddingConfig(deweyDir)
+
+	// For Ollama provider, ensure Ollama is running (auto-start if needed).
+	if cfg.Provider == "ollama" || cfg.Provider == "" {
+		ollamaState, err := ensureOllama(cfg.Endpoint, true, &execOllamaStarter{})
+		if err != nil {
+			logger.Warn("ollama auto-start failed, continuing without embeddings", "err", err)
+		}
+		logger.Info("ollama state", "state", ollamaState, "endpoint", cfg.Endpoint)
+
+		if ollamaState == OllamaUnavailable {
+			logger.Info("semantic search unavailable — ollama not installed",
+				"install", "brew install ollama")
+			return nil, nil
+		}
 	}
 
-	// Ensure Ollama is running (auto-start if needed).
-	ollamaState, err := ensureOllama(embedEndpoint, true, &execOllamaStarter{})
+	embedder, err := embed.NewEmbedderFromConfig(cfg)
 	if err != nil {
-		logger.Warn("ollama auto-start failed, continuing without embeddings", "err", err)
+		return nil, fmt.Errorf("embedding provider error: %w", err)
 	}
-	logger.Info("ollama state", "state", ollamaState, "endpoint", embedEndpoint)
-
-	if ollamaState == OllamaUnavailable {
-		// Graceful degradation: proceed without embeddings when Ollama is not installed.
-		logger.Info("semantic search unavailable — ollama not installed",
-			"install", "brew install ollama")
-		return nil, nil
-	}
-
-	// Ollama is running (External or Managed) — check model availability.
-	// This remains a hard error: the user has Ollama but hasn't pulled the model.
-	embedder := embed.NewOllamaEmbedder(embedEndpoint, embedModel)
 	if !embedder.Available() {
-		return nil, fmt.Errorf("embedding model %q not available at %s\n\nTo fix:\n  ollama pull %s\n\nTo skip embeddings:\n  dewey index --no-embeddings",
-			embedModel, embedEndpoint, embedModel)
+		return nil, fmt.Errorf("embedding model %q not available (provider: %s)\n\nTo skip embeddings:\n  dewey index --no-embeddings",
+			cfg.Model, cfg.Provider)
 	}
-	logger.Info("embedding model available for indexing", "model", embedModel)
+	logger.Info("embedding model available for indexing", "provider", cfg.Provider, "model", cfg.Model)
 	return embedder, nil
 }
 
@@ -1946,25 +1947,6 @@ func saveSourceConfig(sourcesPath string, existing []source.SourceConfig, newSou
 
 // --- Compile command (T034, 013-knowledge-compile Phase 7) ---
 
-// readCompileModel extracts the compile_model value from config.yaml
-// using simple line parsing (same approach as readEmbeddingModel).
-// Returns empty string if not configured — compile will run without
-// LLM synthesis, returning prompts only.
-func readCompileModel(deweyDir string) string {
-	configPath := filepath.Join(deweyDir, "config.yaml")
-	configData, err := os.ReadFile(configPath)
-	if err != nil {
-		return ""
-	}
-	for _, line := range strings.Split(string(configData), "\n") {
-		line = strings.TrimSpace(line)
-		if strings.HasPrefix(line, "compile_model:") {
-			return strings.TrimSpace(strings.TrimPrefix(line, "compile_model:"))
-		}
-	}
-	return ""
-}
-
 // newCompileCmd creates the `dewey compile` subcommand.
 // Synthesizes stored learnings into compiled knowledge articles.
 // Uses OllamaSynthesizer from config when available; otherwise returns
@@ -2009,28 +1991,25 @@ Examples:
 			defer func() { _ = s.Close() }()
 
 			// Create embedder (optional — used for semantic refinement).
-			embedder, err := createIndexEmbedder(false)
+			embedder, err := createIndexEmbedder(false, deweyDir)
 			if err != nil {
 				// Non-fatal for compile: proceed without embedder.
 				logger.Warn("embedder unavailable, compiling without semantic refinement", "err", err)
 			}
 
-			// Create synthesizer from config (CLI path uses Ollama).
+			// Create synthesizer from config.
 			var synth llm.Synthesizer
-			compileModel := readCompileModel(deweyDir)
-			if compileModel != "" {
-				embedEndpoint := os.Getenv("DEWEY_EMBEDDING_ENDPOINT")
-				if embedEndpoint == "" {
-					embedEndpoint = "http://localhost:11434"
-				}
-				ollamaSynth := llm.NewOllamaSynthesizer(embedEndpoint, compileModel)
-				if ollamaSynth.Available() {
-					synth = ollamaSynth
-					logger.Info("compile model available", "model", compileModel)
+			synthCfg := llm.ReadSynthesisConfig(deweyDir)
+			if synthCfg.Model != "" {
+				s2, synthErr := llm.NewSynthesizerFromConfig(synthCfg)
+				if synthErr != nil {
+					logger.Warn("synthesis provider error, returning prompts only", "err", synthErr)
+				} else if s2.Available() {
+					synth = s2
+					logger.Info("synthesis model available", "provider", synthCfg.Provider, "model", synthCfg.Model)
 				} else {
-					logger.Warn("compile model not available, returning prompts only",
-						"model", compileModel,
-						"fix", fmt.Sprintf("ollama pull %s", compileModel))
+					logger.Warn("synthesis model not available, returning prompts only",
+						"provider", synthCfg.Provider, "model", synthCfg.Model)
 				}
 			}
 
@@ -2147,29 +2126,26 @@ Examples:
 			defer func() { _ = s.Close() }()
 
 			// Create embedder (optional).
-			embedder, err := createIndexEmbedder(noEmbeddings)
+			embedder, err := createIndexEmbedder(noEmbeddings, deweyDir)
 			if err != nil {
 				logger.Warn("embedder unavailable, curating without embeddings", "err", err)
 			}
 
-			// Create synthesizer from config (CLI path uses Ollama).
+			// Create synthesizer from config.
 			var synth llm.Synthesizer
-			compileModel := readCompileModel(deweyDir)
-			if compileModel != "" {
-				embedEndpoint := os.Getenv("DEWEY_EMBEDDING_ENDPOINT")
-				if embedEndpoint == "" {
-					embedEndpoint = "http://localhost:11434"
-				}
-				ollamaSynth := llm.NewOllamaSynthesizer(embedEndpoint, compileModel)
-				if ollamaSynth.Available() {
-					synth = ollamaSynth
-					logger.Info("LLM model available for curation", "model", compileModel)
-				} else {
-					return fmt.Errorf("LLM unavailable. Ensure Ollama is running with a generation model.\nTo fix: ollama serve && ollama pull %s", compileModel)
-				}
-			} else {
-				return fmt.Errorf("LLM unavailable. Configure compile_model in .uf/dewey/config.yaml.\nTo fix: Add 'compile_model: llama3.2:3b' to config.yaml, then: ollama pull llama3.2:3b")
+			synthCfg := llm.ReadSynthesisConfig(deweyDir)
+			if synthCfg.Model == "" {
+				return fmt.Errorf("LLM unavailable. Configure synthesis provider in .uf/dewey/config.yaml.\nTo fix: Add 'synthesis:\\n  provider: ollama\\n  model: llama3.2:3b' or 'compile_model: llama3.2:3b'")
 			}
+			s2, synthErr := llm.NewSynthesizerFromConfig(synthCfg)
+			if synthErr != nil {
+				return fmt.Errorf("synthesis provider error: %w", synthErr)
+			}
+			if !s2.Available() {
+				return fmt.Errorf("synthesis model %q not available (provider: %s)", synthCfg.Model, synthCfg.Provider)
+			}
+			synth = s2
+			logger.Info("LLM model available for curation", "provider", synthCfg.Provider, "model", synthCfg.Model)
 
 			// Create pipeline and run curation.
 			pipeline := curate.NewPipeline(s, synth, embedder, vp)
@@ -2252,7 +2228,7 @@ Exit code 0 if clean, 1 if issues found.`,
 			// Create embedder (optional — used for fix mode and contradiction check).
 			var embedder embed.Embedder
 			if fix {
-				embedder, err = createIndexEmbedder(false)
+				embedder, err = createIndexEmbedder(false, deweyDir)
 				if err != nil {
 					logger.Warn("embedder unavailable, fix mode limited", "err", err)
 				}

--- a/embed/config.go
+++ b/embed/config.go
@@ -44,6 +44,7 @@ func readConfigFile(dir string) *configFile {
 	}
 	var cfg configFile
 	if err := yaml.Unmarshal(data, &cfg); err != nil {
+		embedLogger.Warn("failed to parse config.yaml, using defaults", "path", filepath.Join(dir, "config.yaml"), "err", err)
 		return nil
 	}
 	return &cfg

--- a/embed/config.go
+++ b/embed/config.go
@@ -1,0 +1,109 @@
+package embed
+
+import (
+	"os"
+	"path/filepath"
+
+	"gopkg.in/yaml.v3"
+)
+
+// globalConfigDir returns the path to the global dewey config directory.
+// Uses $XDG_CONFIG_HOME/dewey if set, otherwise ~/.config/dewey.
+func globalConfigDir() string {
+	if xdg := os.Getenv("XDG_CONFIG_HOME"); xdg != "" {
+		return filepath.Join(xdg, "dewey")
+	}
+	home, err := os.UserHomeDir()
+	if err != nil {
+		return ""
+	}
+	return filepath.Join(home, ".config", "dewey")
+}
+
+// configFile represents the structure of config.yaml
+// relevant to embedding configuration.
+type configFile struct {
+	Embedding struct {
+		Provider string `yaml:"provider"`
+		Model    string `yaml:"model"`
+		Endpoint string `yaml:"endpoint"`
+		Project  string `yaml:"project"`
+		Region   string `yaml:"region"`
+	} `yaml:"embedding"`
+}
+
+// readConfigFile attempts to parse a config.yaml at the given directory.
+// Returns nil if the file doesn't exist or can't be parsed.
+func readConfigFile(dir string) *configFile {
+	if dir == "" {
+		return nil
+	}
+	data, err := os.ReadFile(filepath.Join(dir, "config.yaml"))
+	if err != nil {
+		return nil
+	}
+	var cfg configFile
+	if err := yaml.Unmarshal(data, &cfg); err != nil {
+		return nil
+	}
+	return &cfg
+}
+
+// ReadEmbeddingConfig reads the embedding provider configuration.
+//
+// Config precedence (highest to lowest):
+//  1. Environment variables: DEWEY_EMBEDDING_MODEL, DEWEY_EMBEDDING_ENDPOINT
+//  2. Per-vault config: {deweyDir}/config.yaml
+//  3. Global config: ~/.config/dewey/config.yaml
+//  4. Defaults: provider=ollama, model=granite-embedding:30m, endpoint=localhost:11434
+func ReadEmbeddingConfig(deweyDir string) ProviderConfig {
+	// Try per-vault config first, then global.
+	cfg := readConfigFile(deweyDir)
+	if cfg == nil || (cfg.Embedding.Provider == "" && cfg.Embedding.Model == "") {
+		cfg = readConfigFile(globalConfigDir())
+	}
+
+	if cfg == nil {
+		return embedConfigFromEnv()
+	}
+
+	pc := ProviderConfig{
+		Provider: cfg.Embedding.Provider,
+		Model:    cfg.Embedding.Model,
+		Endpoint: cfg.Embedding.Endpoint,
+		Project:  cfg.Embedding.Project,
+		Region:   cfg.Embedding.Region,
+	}
+
+	// Environment variables override config file values (existing behavior).
+	if envModel := os.Getenv("DEWEY_EMBEDDING_MODEL"); envModel != "" {
+		pc.Model = envModel
+	}
+	if envEndpoint := os.Getenv("DEWEY_EMBEDDING_ENDPOINT"); envEndpoint != "" {
+		pc.Endpoint = envEndpoint
+	}
+
+	// Default provider to ollama if not specified.
+	if pc.Provider == "" {
+		pc.Provider = "ollama"
+	}
+
+	return pc
+}
+
+// embedConfigFromEnv builds an embedding config from environment variables.
+func embedConfigFromEnv() ProviderConfig {
+	model := os.Getenv("DEWEY_EMBEDDING_MODEL")
+	if model == "" {
+		model = "granite-embedding:30m"
+	}
+	endpoint := os.Getenv("DEWEY_EMBEDDING_ENDPOINT")
+	if endpoint == "" {
+		endpoint = "http://localhost:11434"
+	}
+	return ProviderConfig{
+		Provider: "ollama",
+		Model:    model,
+		Endpoint: endpoint,
+	}
+}

--- a/embed/embed.go
+++ b/embed/embed.go
@@ -1,6 +1,7 @@
 // Package embed provides interfaces and implementations for generating
-// vector embeddings from text content. The primary implementation uses
-// Ollama's HTTP API for local model inference.
+// vector embeddings from text content. Implementations include OllamaEmbedder
+// (local inference via Ollama HTTP API) and VertexEmbedder (Google Vertex AI
+// prediction API with application-default credentials).
 package embed
 
 import (

--- a/embed/embed.go
+++ b/embed/embed.go
@@ -11,9 +11,37 @@ import (
 	"fmt"
 	"io"
 	"net/http"
+	"os"
 	"sync"
 	"time"
+
+	"github.com/charmbracelet/log"
 )
+
+// embedLogger is the package-level structured logger for embed operations.
+var embedLogger = log.NewWithOptions(os.Stderr, log.Options{
+	Prefix:          "dewey/embed",
+	ReportTimestamp: true,
+	TimeFormat:      "2006-01-02T15:04:05.000Z07:00",
+})
+
+// SetLogLevel sets the logging level for the embed package.
+// Use log.DebugLevel for verbose output during diagnostics.
+func SetLogLevel(level log.Level) {
+	embedLogger.SetLevel(level)
+}
+
+// SetLogOutput replaces the embed package logger with one that writes to
+// the given writer at the given level. Used to enable file logging.
+func SetLogOutput(w io.Writer, level log.Level) {
+	newLogger := log.NewWithOptions(w, log.Options{
+		Prefix:          "dewey/embed",
+		Level:           level,
+		ReportTimestamp: true,
+		TimeFormat:      "2006-01-02T15:04:05.000Z07:00",
+	})
+	*embedLogger = *newLogger
+}
 
 // Embedder generates vector embeddings from text. Implementations must be
 // safe for concurrent use. The interface abstracts the embedding provider,

--- a/embed/provider.go
+++ b/embed/provider.go
@@ -1,0 +1,48 @@
+package embed
+
+import "fmt"
+
+// ProviderConfig holds the configuration for an embedding provider.
+// Each provider type uses a subset of these fields.
+type ProviderConfig struct {
+	// Provider selects the embedding backend: "ollama" or "vertex".
+	// Defaults to "ollama" if empty.
+	Provider string
+
+	// Model is the model identifier (e.g., "granite-embedding:30m",
+	// "text-embedding-005").
+	Model string
+
+	// Endpoint is the base URL for the provider API.
+	// Required for ollama. Ignored for vertex.
+	Endpoint string
+
+	// Project is the GCP project ID. Required for vertex only.
+	Project string
+
+	// Region is the GCP region (e.g., "us-central1"). Required for vertex only.
+	Region string
+}
+
+// NewEmbedderFromConfig creates an Embedder from the given provider configuration.
+// Returns an error if the provider is unknown or required fields are missing.
+func NewEmbedderFromConfig(cfg ProviderConfig) (Embedder, error) {
+	switch cfg.Provider {
+	case "ollama", "":
+		endpoint := cfg.Endpoint
+		if endpoint == "" {
+			endpoint = "http://localhost:11434"
+		}
+		return NewOllamaEmbedder(endpoint, cfg.Model), nil
+	case "vertex":
+		if cfg.Project == "" {
+			return nil, fmt.Errorf("vertex embedding provider requires project")
+		}
+		if cfg.Region == "" {
+			return nil, fmt.Errorf("vertex embedding provider requires region")
+		}
+		return NewVertexEmbedder(cfg.Project, cfg.Region, cfg.Model)
+	default:
+		return nil, fmt.Errorf("unknown embedding provider: %q (supported: ollama, vertex)", cfg.Provider)
+	}
+}

--- a/embed/provider_test.go
+++ b/embed/provider_test.go
@@ -1,0 +1,229 @@
+package embed
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestNewEmbedderFromConfig_Ollama(t *testing.T) {
+	cfg := ProviderConfig{
+		Provider: "ollama",
+		Model:    "granite-embedding:30m",
+		Endpoint: "http://localhost:11434",
+	}
+	e, err := NewEmbedderFromConfig(cfg)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if e.ModelID() != "granite-embedding:30m" {
+		t.Errorf("ModelID = %q, want granite-embedding:30m", e.ModelID())
+	}
+}
+
+func TestNewEmbedderFromConfig_EmptyDefaultsToOllama(t *testing.T) {
+	cfg := ProviderConfig{
+		Model: "granite-embedding:30m",
+	}
+	e, err := NewEmbedderFromConfig(cfg)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if _, ok := e.(*OllamaEmbedder); !ok {
+		t.Errorf("expected *OllamaEmbedder, got %T", e)
+	}
+}
+
+func TestNewEmbedderFromConfig_Vertex(t *testing.T) {
+	cfg := ProviderConfig{
+		Provider: "vertex",
+		Model:    "text-embedding-005",
+		Project:  "my-project",
+		Region:   "us-central1",
+	}
+	e, err := NewEmbedderFromConfig(cfg)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if e.ModelID() != "text-embedding-005" {
+		t.Errorf("ModelID = %q, want text-embedding-005", e.ModelID())
+	}
+}
+
+func TestNewEmbedderFromConfig_VertexMissingProject(t *testing.T) {
+	cfg := ProviderConfig{
+		Provider: "vertex",
+		Model:    "text-embedding-005",
+		Region:   "us-central1",
+	}
+	_, err := NewEmbedderFromConfig(cfg)
+	if err == nil {
+		t.Fatal("expected error for missing project")
+	}
+}
+
+func TestNewEmbedderFromConfig_VertexMissingRegion(t *testing.T) {
+	cfg := ProviderConfig{
+		Provider: "vertex",
+		Model:    "text-embedding-005",
+		Project:  "my-project",
+	}
+	_, err := NewEmbedderFromConfig(cfg)
+	if err == nil {
+		t.Fatal("expected error for missing region")
+	}
+}
+
+func TestNewEmbedderFromConfig_UnknownProvider(t *testing.T) {
+	cfg := ProviderConfig{
+		Provider: "unsupported",
+	}
+	_, err := NewEmbedderFromConfig(cfg)
+	if err == nil {
+		t.Fatal("expected error for unknown provider")
+	}
+}
+
+func TestReadEmbeddingConfig_FromFile(t *testing.T) {
+	dir := t.TempDir()
+	configYAML := `embedding:
+  provider: vertex
+  model: text-embedding-005
+  project: my-project
+  region: us-central1
+`
+	if err := os.WriteFile(filepath.Join(dir, "config.yaml"), []byte(configYAML), 0644); err != nil {
+		t.Fatalf("write config: %v", err)
+	}
+
+	cfg := ReadEmbeddingConfig(dir)
+	if cfg.Provider != "vertex" {
+		t.Errorf("Provider = %q, want vertex", cfg.Provider)
+	}
+	if cfg.Model != "text-embedding-005" {
+		t.Errorf("Model = %q, want text-embedding-005", cfg.Model)
+	}
+	if cfg.Project != "my-project" {
+		t.Errorf("Project = %q, want my-project", cfg.Project)
+	}
+}
+
+func TestReadEmbeddingConfig_BackwardCompatible(t *testing.T) {
+	dir := t.TempDir()
+	// Existing config format without provider field.
+	configYAML := `embedding:
+  model: granite-embedding:30m
+  endpoint: http://localhost:11434
+`
+	if err := os.WriteFile(filepath.Join(dir, "config.yaml"), []byte(configYAML), 0644); err != nil {
+		t.Fatalf("write config: %v", err)
+	}
+
+	cfg := ReadEmbeddingConfig(dir)
+	if cfg.Provider != "ollama" {
+		t.Errorf("Provider = %q, want ollama (default)", cfg.Provider)
+	}
+	if cfg.Model != "granite-embedding:30m" {
+		t.Errorf("Model = %q, want granite-embedding:30m", cfg.Model)
+	}
+}
+
+func TestReadEmbeddingConfig_EnvOverride(t *testing.T) {
+	dir := t.TempDir()
+	configYAML := `embedding:
+  model: granite-embedding:30m
+  endpoint: http://localhost:11434
+`
+	if err := os.WriteFile(filepath.Join(dir, "config.yaml"), []byte(configYAML), 0644); err != nil {
+		t.Fatalf("write config: %v", err)
+	}
+
+	t.Setenv("DEWEY_EMBEDDING_MODEL", "override-model")
+	t.Setenv("DEWEY_EMBEDDING_ENDPOINT", "http://override:9999")
+
+	cfg := ReadEmbeddingConfig(dir)
+	if cfg.Model != "override-model" {
+		t.Errorf("Model = %q, want override-model (from env)", cfg.Model)
+	}
+	if cfg.Endpoint != "http://override:9999" {
+		t.Errorf("Endpoint = %q, want http://override:9999 (from env)", cfg.Endpoint)
+	}
+}
+
+func TestReadEmbeddingConfig_NoFile(t *testing.T) {
+	dir := t.TempDir()
+	t.Setenv("XDG_CONFIG_HOME", t.TempDir())
+	// No config file — should fall back to env/defaults.
+	cfg := ReadEmbeddingConfig(dir)
+	if cfg.Provider != "ollama" {
+		t.Errorf("Provider = %q, want ollama", cfg.Provider)
+	}
+	if cfg.Model != "granite-embedding:30m" {
+		t.Errorf("Model = %q, want granite-embedding:30m (default)", cfg.Model)
+	}
+}
+
+func TestReadEmbeddingConfig_GlobalFallback(t *testing.T) {
+	// Per-vault dir has no config.
+	vaultDir := t.TempDir()
+
+	// Global config has vertex provider.
+	globalDir := filepath.Join(t.TempDir(), "dewey")
+	if err := os.MkdirAll(globalDir, 0755); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	globalYAML := `embedding:
+  provider: vertex
+  model: text-embedding-005
+  project: global-project
+  region: us-central1
+`
+	if err := os.WriteFile(filepath.Join(globalDir, "config.yaml"), []byte(globalYAML), 0644); err != nil {
+		t.Fatalf("write global config: %v", err)
+	}
+	t.Setenv("XDG_CONFIG_HOME", filepath.Dir(globalDir))
+
+	cfg := ReadEmbeddingConfig(vaultDir)
+	if cfg.Provider != "vertex" {
+		t.Errorf("Provider = %q, want vertex (from global)", cfg.Provider)
+	}
+	if cfg.Project != "global-project" {
+		t.Errorf("Project = %q, want global-project", cfg.Project)
+	}
+}
+
+func TestReadEmbeddingConfig_VaultOverridesGlobal(t *testing.T) {
+	// Vault config with ollama.
+	vaultDir := t.TempDir()
+	vaultYAML := `embedding:
+  provider: ollama
+  model: vault-model
+`
+	if err := os.WriteFile(filepath.Join(vaultDir, "config.yaml"), []byte(vaultYAML), 0644); err != nil {
+		t.Fatalf("write vault config: %v", err)
+	}
+
+	// Global config with vertex — should be ignored.
+	globalDir := filepath.Join(t.TempDir(), "dewey")
+	if err := os.MkdirAll(globalDir, 0755); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	globalYAML := `embedding:
+  provider: vertex
+  model: global-model
+  project: global-project
+  region: us-central1
+`
+	if err := os.WriteFile(filepath.Join(globalDir, "config.yaml"), []byte(globalYAML), 0644); err != nil {
+		t.Fatalf("write global config: %v", err)
+	}
+	t.Setenv("XDG_CONFIG_HOME", filepath.Dir(globalDir))
+
+	cfg := ReadEmbeddingConfig(vaultDir)
+	if cfg.Provider != "ollama" {
+		t.Errorf("Provider = %q, want ollama (vault overrides global)", cfg.Provider)
+	}
+	if cfg.Model != "vault-model" {
+		t.Errorf("Model = %q, want vault-model", cfg.Model)
+	}
+}

--- a/embed/provider_test.go
+++ b/embed/provider_test.go
@@ -3,6 +3,7 @@ package embed
 import (
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 )
 
@@ -60,6 +61,9 @@ func TestNewEmbedderFromConfig_VertexMissingProject(t *testing.T) {
 	if err == nil {
 		t.Fatal("expected error for missing project")
 	}
+	if !strings.Contains(err.Error(), "project") {
+		t.Errorf("error = %q, want to contain 'project'", err.Error())
+	}
 }
 
 func TestNewEmbedderFromConfig_VertexMissingRegion(t *testing.T) {
@@ -72,6 +76,9 @@ func TestNewEmbedderFromConfig_VertexMissingRegion(t *testing.T) {
 	if err == nil {
 		t.Fatal("expected error for missing region")
 	}
+	if !strings.Contains(err.Error(), "region") {
+		t.Errorf("error = %q, want to contain 'region'", err.Error())
+	}
 }
 
 func TestNewEmbedderFromConfig_UnknownProvider(t *testing.T) {
@@ -81,6 +88,9 @@ func TestNewEmbedderFromConfig_UnknownProvider(t *testing.T) {
 	_, err := NewEmbedderFromConfig(cfg)
 	if err == nil {
 		t.Fatal("expected error for unknown provider")
+	}
+	if !strings.Contains(err.Error(), "unsupported") {
+		t.Errorf("error = %q, want to contain 'unsupported'", err.Error())
 	}
 }
 

--- a/embed/vertex.go
+++ b/embed/vertex.go
@@ -6,11 +6,24 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
+	"math"
+	"math/rand/v2"
 	"net/http"
+	"strconv"
 	"sync"
 	"time"
 
+	"github.com/charmbracelet/log"
 	"golang.org/x/oauth2/google"
+)
+
+const (
+	// vertexEmbedMaxRetries is the maximum number of retry attempts on 429 responses.
+	vertexEmbedMaxRetries = 5
+	// vertexEmbedBaseDelay is the initial backoff delay before the first retry.
+	vertexEmbedBaseDelay = 1 * time.Second
+	// vertexEmbedMaxDelay caps the exponential backoff to prevent excessive waits.
+	vertexEmbedMaxDelay = 60 * time.Second
 )
 
 // VertexEmbedder implements Embedder using Google Vertex AI's prediction API.
@@ -116,6 +129,7 @@ func (v *VertexEmbedder) Embed(ctx context.Context, text string) ([]float32, err
 
 // EmbedBatch generates vector embeddings for multiple texts in a single request.
 // Returns one float32 slice per input text, in the same order.
+// Retries up to 5 times on HTTP 429 (Too Many Requests) with exponential backoff.
 func (v *VertexEmbedder) EmbedBatch(ctx context.Context, texts []string) ([][]float32, error) {
 	if len(texts) == 0 {
 		return nil, nil
@@ -133,31 +147,13 @@ func (v *VertexEmbedder) EmbedBatch(ctx context.Context, texts []string) ([][]fl
 		return nil, fmt.Errorf("marshal vertex request: %w", err)
 	}
 
-	token, err := v.tokenFn(ctx)
+	statusCode, respBody, err := v.doRequestWithRetry(ctx, v.predictURL(), bodyBytes)
 	if err != nil {
 		return nil, err
 	}
 
-	req, err := http.NewRequestWithContext(ctx, http.MethodPost, v.predictURL(), bytes.NewReader(bodyBytes))
-	if err != nil {
-		return nil, fmt.Errorf("create vertex request: %w", err)
-	}
-	req.Header.Set("Content-Type", "application/json")
-	req.Header.Set("Authorization", "Bearer "+token)
-
-	resp, err := v.client.Do(req)
-	if err != nil {
-		return nil, fmt.Errorf("vertex AI request: %w", err)
-	}
-	defer func() { _ = resp.Body.Close() }()
-
-	respBody, err := io.ReadAll(io.LimitReader(resp.Body, 50*1024*1024))
-	if err != nil {
-		return nil, fmt.Errorf("read vertex response: %w", err)
-	}
-
-	if resp.StatusCode != http.StatusOK {
-		return nil, fmt.Errorf("vertex AI error (HTTP %d): %s", resp.StatusCode, string(respBody))
+	if statusCode != http.StatusOK {
+		return nil, fmt.Errorf("vertex AI error (HTTP %d): %s", statusCode, string(respBody))
 	}
 
 	var result vertexEmbedResponse
@@ -180,6 +176,85 @@ func (v *VertexEmbedder) EmbedBatch(ctx context.Context, texts []string) ([][]fl
 	}
 
 	return vectors, nil
+}
+
+// doRequestWithRetry sends an HTTP POST to url with bodyBytes, retrying on
+// HTTP 429 with exponential backoff. Returns the final status code, response
+// body, and any transport-level error.
+func (v *VertexEmbedder) doRequestWithRetry(ctx context.Context, url string, bodyBytes []byte) (int, []byte, error) {
+	for attempt := range vertexEmbedMaxRetries + 1 {
+		token, err := v.tokenFn(ctx)
+		if err != nil {
+			return 0, nil, err
+		}
+
+		req, err := http.NewRequestWithContext(ctx, http.MethodPost, url, bytes.NewReader(bodyBytes))
+		if err != nil {
+			return 0, nil, fmt.Errorf("create vertex request: %w", err)
+		}
+		req.Header.Set("Content-Type", "application/json")
+		req.Header.Set("Authorization", "Bearer "+token)
+
+		resp, err := v.client.Do(req)
+		if err != nil {
+			return 0, nil, fmt.Errorf("vertex AI request: %w", err)
+		}
+
+		respBody, err := io.ReadAll(io.LimitReader(resp.Body, 50*1024*1024))
+		_ = resp.Body.Close()
+		if err != nil {
+			return 0, nil, fmt.Errorf("read vertex response: %w", err)
+		}
+
+		if resp.StatusCode != http.StatusTooManyRequests {
+			return resp.StatusCode, respBody, nil
+		}
+
+		if attempt == vertexEmbedMaxRetries {
+			return 0, nil, fmt.Errorf("vertex AI rate limited (HTTP 429) after %d retries: %s", vertexEmbedMaxRetries, string(respBody))
+		}
+
+		delay := vertexRetryDelay(attempt, resp.Header.Get("Retry-After"))
+		log.Warn("vertex AI rate limited, retrying", "attempt", attempt+1, "delay", delay)
+
+		select {
+		case <-ctx.Done():
+			return 0, nil, ctx.Err()
+		case <-time.After(delay):
+		}
+	}
+	// Unreachable — the loop always returns or breaks.
+	return 0, nil, fmt.Errorf("vertex AI retry loop exited unexpectedly")
+}
+
+// vertexRetryDelay computes the backoff delay for a retry attempt.
+// If the Retry-After header contains a valid number of seconds, that
+// value is used (capped at vertexEmbedMaxDelay). Otherwise, exponential
+// backoff with jitter is applied: baseDelay * 2^attempt ± 25%, capped at
+// vertexEmbedMaxDelay. Jitter prevents thundering herd when multiple
+// goroutines retry simultaneously. Only integer-seconds Retry-After format
+// is supported; HTTP-date format falls back to exponential backoff.
+func vertexRetryDelay(attempt int, retryAfter string) time.Duration {
+	if retryAfter != "" {
+		if secs, err := strconv.Atoi(retryAfter); err == nil && secs > 0 {
+			d := time.Duration(secs) * time.Second
+			if d > vertexEmbedMaxDelay {
+				d = vertexEmbedMaxDelay
+			}
+			return d
+		}
+	}
+	d := time.Duration(float64(vertexEmbedBaseDelay) * math.Pow(2, float64(attempt)))
+	if d > vertexEmbedMaxDelay {
+		d = vertexEmbedMaxDelay
+	}
+	// Add ±25% jitter to desynchronize concurrent retries.
+	jitter := time.Duration(rand.Int64N(int64(d)/2)) - d/4
+	d += jitter
+	if d < 0 {
+		d = 0
+	}
+	return d
 }
 
 // Available reports whether Vertex AI credentials are configured and the

--- a/embed/vertex.go
+++ b/embed/vertex.go
@@ -1,0 +1,216 @@
+package embed
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"sync"
+	"time"
+
+	"golang.org/x/oauth2/google"
+)
+
+// VertexEmbedder implements Embedder using Google Vertex AI's prediction API.
+// Uses application-default credentials for authentication (no CGO).
+//
+// Design decision D3 (pluggable-providers design.md): Direct REST calls
+// to the Vertex AI prediction endpoint. The google oauth2 library handles
+// credential discovery, caching, and automatic token refresh.
+type VertexEmbedder struct {
+	project string
+	region  string
+	model   string
+	client  *http.Client
+	tokenFn func(ctx context.Context) (string, error)
+
+	// Cached availability check.
+	mu          sync.RWMutex
+	available   bool
+	lastCheck   time.Time
+	checkExpiry time.Duration
+}
+
+// vertexEmbedRequest is the JSON body sent to the Vertex AI predict endpoint.
+type vertexEmbedRequest struct {
+	Instances []vertexInstance `json:"instances"`
+}
+
+// vertexInstance represents a single text instance for embedding.
+type vertexInstance struct {
+	Content string `json:"content"`
+}
+
+// vertexEmbedResponse is the JSON response from the Vertex AI predict endpoint.
+type vertexEmbedResponse struct {
+	Predictions []vertexPrediction `json:"predictions"`
+}
+
+// vertexPrediction contains the embedding values from a single prediction.
+type vertexPrediction struct {
+	Embeddings vertexEmbeddingValues `json:"embeddings"`
+}
+
+// vertexEmbeddingValues holds the vector values.
+type vertexEmbeddingValues struct {
+	Values []float64 `json:"values"`
+}
+
+// NewVertexEmbedder creates a VertexEmbedder for the given GCP project, region,
+// and model. Returns an error if required fields are missing.
+//
+// Authentication uses application-default credentials discovered via
+// golang.org/x/oauth2/google.FindDefaultCredentials. Users must run
+// `gcloud auth application-default login` before using this embedder.
+func NewVertexEmbedder(project, region, model string) (*VertexEmbedder, error) {
+	if model == "" {
+		return nil, fmt.Errorf("vertex embedder requires model")
+	}
+	e := &VertexEmbedder{
+		project: project,
+		region:  region,
+		model:   model,
+		client: &http.Client{
+			Timeout: 30 * time.Second,
+		},
+		checkExpiry: 30 * time.Second,
+	}
+	e.tokenFn = e.defaultGetToken
+	return e, nil
+}
+
+// predictURL builds the Vertex AI prediction endpoint URL.
+func (v *VertexEmbedder) predictURL() string {
+	return fmt.Sprintf(
+		"https://%s-aiplatform.googleapis.com/v1/projects/%s/locations/%s/publishers/google/models/%s:predict",
+		v.region, v.project, v.region, v.model,
+	)
+}
+
+// defaultGetToken retrieves an OAuth2 access token using application-default credentials.
+func (v *VertexEmbedder) defaultGetToken(ctx context.Context) (string, error) {
+	creds, err := google.FindDefaultCredentials(ctx, "https://www.googleapis.com/auth/cloud-platform")
+	if err != nil {
+		return "", fmt.Errorf("vertex AI credentials: %w (run 'gcloud auth application-default login --scopes=https://www.googleapis.com/auth/cloud-platform')", err)
+	}
+	tok, err := creds.TokenSource.Token()
+	if err != nil {
+		return "", fmt.Errorf("vertex AI token: %w", err)
+	}
+	return tok.AccessToken, nil
+}
+
+// Embed generates a vector embedding for a single text via Vertex AI.
+func (v *VertexEmbedder) Embed(ctx context.Context, text string) ([]float32, error) {
+	vectors, err := v.EmbedBatch(ctx, []string{text})
+	if err != nil {
+		return nil, err
+	}
+	if len(vectors) == 0 {
+		return nil, fmt.Errorf("vertex AI returned no embeddings")
+	}
+	return vectors[0], nil
+}
+
+// EmbedBatch generates vector embeddings for multiple texts in a single request.
+// Returns one float32 slice per input text, in the same order.
+func (v *VertexEmbedder) EmbedBatch(ctx context.Context, texts []string) ([][]float32, error) {
+	if len(texts) == 0 {
+		return nil, nil
+	}
+
+	// Build request with one instance per text.
+	instances := make([]vertexInstance, len(texts))
+	for i, t := range texts {
+		instances[i] = vertexInstance{Content: t}
+	}
+	reqBody := vertexEmbedRequest{Instances: instances}
+
+	bodyBytes, err := json.Marshal(reqBody)
+	if err != nil {
+		return nil, fmt.Errorf("marshal vertex request: %w", err)
+	}
+
+	token, err := v.tokenFn(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, v.predictURL(), bytes.NewReader(bodyBytes))
+	if err != nil {
+		return nil, fmt.Errorf("create vertex request: %w", err)
+	}
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("Authorization", "Bearer "+token)
+
+	resp, err := v.client.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("vertex AI request: %w", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	respBody, err := io.ReadAll(io.LimitReader(resp.Body, 50*1024*1024))
+	if err != nil {
+		return nil, fmt.Errorf("read vertex response: %w", err)
+	}
+
+	if resp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("vertex AI error (HTTP %d): %s", resp.StatusCode, string(respBody))
+	}
+
+	var result vertexEmbedResponse
+	if err := json.Unmarshal(respBody, &result); err != nil {
+		return nil, fmt.Errorf("parse vertex response: %w", err)
+	}
+
+	if len(result.Predictions) != len(texts) {
+		return nil, fmt.Errorf("vertex AI returned %d predictions for %d inputs", len(result.Predictions), len(texts))
+	}
+
+	// Convert float64 → float32 vectors.
+	vectors := make([][]float32, len(result.Predictions))
+	for i, pred := range result.Predictions {
+		vec := make([]float32, len(pred.Embeddings.Values))
+		for j, val := range pred.Embeddings.Values {
+			vec[j] = float32(val)
+		}
+		vectors[i] = vec
+	}
+
+	return vectors, nil
+}
+
+// Available reports whether Vertex AI credentials are configured and the
+// model is accessible. Caches the result for 30 seconds.
+func (v *VertexEmbedder) Available() bool {
+	v.mu.RLock()
+	if time.Since(v.lastCheck) < v.checkExpiry {
+		avail := v.available
+		v.mu.RUnlock()
+		return avail
+	}
+	v.mu.RUnlock()
+
+	v.mu.Lock()
+	defer v.mu.Unlock()
+
+	// Double-check after acquiring write lock.
+	if time.Since(v.lastCheck) < v.checkExpiry {
+		return v.available
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	_, err := v.tokenFn(ctx)
+	v.available = err == nil
+	v.lastCheck = time.Now()
+	return v.available
+}
+
+// ModelID returns the configured Vertex AI model identifier.
+func (v *VertexEmbedder) ModelID() string {
+	return v.model
+}

--- a/embed/vertex.go
+++ b/embed/vertex.go
@@ -13,7 +13,6 @@ import (
 	"sync"
 	"time"
 
-	"github.com/charmbracelet/log"
 	"golang.org/x/oauth2/google"
 )
 
@@ -153,7 +152,11 @@ func (v *VertexEmbedder) EmbedBatch(ctx context.Context, texts []string) ([][]fl
 	}
 
 	if statusCode != http.StatusOK {
-		return nil, fmt.Errorf("vertex AI error (HTTP %d): %s", statusCode, string(respBody))
+		body := string(respBody)
+		if len(body) > 512 {
+			body = body[:512] + "... (truncated)"
+		}
+		return nil, fmt.Errorf("vertex AI error (HTTP %d): %s", statusCode, body)
 	}
 
 	var result vertexEmbedResponse
@@ -211,11 +214,15 @@ func (v *VertexEmbedder) doRequestWithRetry(ctx context.Context, url string, bod
 		}
 
 		if attempt == vertexEmbedMaxRetries {
-			return 0, nil, fmt.Errorf("vertex AI rate limited (HTTP 429) after %d retries: %s", vertexEmbedMaxRetries, string(respBody))
+			body := string(respBody)
+			if len(body) > 512 {
+				body = body[:512] + "... (truncated)"
+			}
+			return 0, nil, fmt.Errorf("vertex AI rate limited (HTTP 429) after %d retries: %s", vertexEmbedMaxRetries, body)
 		}
 
 		delay := vertexRetryDelay(attempt, resp.Header.Get("Retry-After"))
-		log.Warn("vertex AI rate limited, retrying", "attempt", attempt+1, "delay", delay)
+		embedLogger.Warn("vertex AI rate limited, retrying", "attempt", attempt+1, "delay", delay)
 
 		select {
 		case <-ctx.Done():

--- a/embed/vertex_test.go
+++ b/embed/vertex_test.go
@@ -320,6 +320,9 @@ func TestNewVertexEmbedder_MissingModel(t *testing.T) {
 	if err == nil {
 		t.Fatal("expected error for missing model")
 	}
+	if !strings.Contains(err.Error(), "model") {
+		t.Errorf("error = %q, want to contain 'model'", err.Error())
+	}
 }
 
 // newTestVertexEmbedder creates a VertexEmbedder that routes requests to

--- a/embed/vertex_test.go
+++ b/embed/vertex_test.go
@@ -213,6 +213,108 @@ func TestVertexEmbedder_EmbedBatch_PredictionCountMismatch(t *testing.T) {
 	}
 }
 
+func TestVertexEmbedder_Retry429ThenSuccess(t *testing.T) {
+	attempts := 0
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		attempts++
+		if attempts <= 2 {
+			w.Header().Set("Retry-After", "0")
+			w.WriteHeader(http.StatusTooManyRequests)
+			_, _ = w.Write([]byte(`{"error":"rate limited"}`))
+			return
+		}
+		resp := vertexEmbedResponse{
+			Predictions: []vertexPrediction{
+				{Embeddings: vertexEmbeddingValues{Values: []float64{0.5, 0.6}}},
+			},
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(resp)
+	}))
+	defer srv.Close()
+
+	v := newTestVertexEmbedder(srv)
+	vec, err := v.Embed(context.Background(), "hello")
+	if err != nil {
+		t.Fatalf("Embed after retries: %v", err)
+	}
+	if len(vec) != 2 {
+		t.Fatalf("vector length = %d, want 2", len(vec))
+	}
+	if attempts != 3 {
+		t.Errorf("attempts = %d, want 3", attempts)
+	}
+}
+
+func TestVertexEmbedder_Retry429Exhausted(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Retry-After", "0")
+		w.WriteHeader(http.StatusTooManyRequests)
+		_, _ = w.Write([]byte(`{"error":"rate limited"}`))
+	}))
+	defer srv.Close()
+
+	v := newTestVertexEmbedder(srv)
+	_, err := v.Embed(context.Background(), "hello")
+	if err == nil {
+		t.Fatal("expected error after exhausting retries")
+	}
+	if !strings.Contains(err.Error(), "429") || !strings.Contains(err.Error(), "retries") {
+		t.Errorf("error = %q, want to mention 429 and retries", err.Error())
+	}
+}
+
+func TestVertexRetryDelay(t *testing.T) {
+	// Without Retry-After: exponential backoff with jitter (±25%).
+	d0 := vertexRetryDelay(0, "")
+	if d0 < 750*time.Millisecond || d0 > 1250*time.Millisecond {
+		t.Errorf("delay(0) = %v, want ~1s (±25%%)", d0)
+	}
+	d1 := vertexRetryDelay(1, "")
+	if d1 < 1500*time.Millisecond || d1 > 2500*time.Millisecond {
+		t.Errorf("delay(1) = %v, want ~2s (±25%%)", d1)
+	}
+
+	// With Retry-After header (no jitter applied).
+	d := vertexRetryDelay(0, "5")
+	if d != 5*time.Second {
+		t.Errorf("delay with Retry-After=5 = %v, want 5s", d)
+	}
+
+	// Retry-After capped at max.
+	d = vertexRetryDelay(0, "120")
+	if d != vertexEmbedMaxDelay {
+		t.Errorf("delay with Retry-After=120 = %v, want %v", d, vertexEmbedMaxDelay)
+	}
+
+	// Invalid Retry-After falls back to exponential with jitter.
+	d = vertexRetryDelay(2, "invalid")
+	if d < 3*time.Second || d > 5*time.Second {
+		t.Errorf("delay(2, invalid) = %v, want ~4s (±25%%)", d)
+	}
+}
+
+func TestVertexEmbedder_Retry429ContextCancelled(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Retry-After", "60")
+		w.WriteHeader(http.StatusTooManyRequests)
+		_, _ = w.Write([]byte(`{"error":"rate limited"}`))
+	}))
+	defer srv.Close()
+
+	v := newTestVertexEmbedder(srv)
+	ctx, cancel := context.WithCancel(context.Background())
+	// Cancel immediately so the retry wait is interrupted.
+	go func() {
+		time.Sleep(10 * time.Millisecond)
+		cancel()
+	}()
+	_, err := v.Embed(ctx, "hello")
+	if err == nil {
+		t.Fatal("expected error when context is cancelled")
+	}
+}
+
 func TestNewVertexEmbedder_MissingModel(t *testing.T) {
 	_, err := NewVertexEmbedder("project", "region", "")
 	if err == nil {

--- a/embed/vertex_test.go
+++ b/embed/vertex_test.go
@@ -1,0 +1,254 @@
+package embed
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+)
+
+func TestVertexEmbedder_Embed(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodPost {
+			t.Errorf("method = %s, want POST", r.Method)
+		}
+		if !strings.Contains(r.URL.Path, ":predict") {
+			t.Errorf("path = %s, want :predict suffix", r.URL.Path)
+		}
+
+		var req vertexEmbedRequest
+		if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+			t.Fatalf("decode request: %v", err)
+		}
+		if len(req.Instances) != 1 {
+			t.Fatalf("instances = %d, want 1", len(req.Instances))
+		}
+		if req.Instances[0].Content != "hello world" {
+			t.Errorf("content = %q, want 'hello world'", req.Instances[0].Content)
+		}
+
+		resp := vertexEmbedResponse{
+			Predictions: []vertexPrediction{
+				{Embeddings: vertexEmbeddingValues{Values: []float64{0.1, 0.2, 0.3}}},
+			},
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(resp)
+	}))
+	defer srv.Close()
+
+	v := newTestVertexEmbedder(srv)
+
+	vec, err := v.Embed(context.Background(), "hello world")
+	if err != nil {
+		t.Fatalf("Embed: %v", err)
+	}
+	if len(vec) != 3 {
+		t.Fatalf("vector length = %d, want 3", len(vec))
+	}
+	if vec[0] != 0.1 || vec[1] != 0.2 || vec[2] != 0.3 {
+		t.Errorf("vector = %v, want [0.1, 0.2, 0.3]", vec)
+	}
+}
+
+func TestVertexEmbedder_EmbedBatch(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		var req vertexEmbedRequest
+		if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+			t.Fatalf("decode: %v", err)
+		}
+		if len(req.Instances) != 2 {
+			t.Fatalf("instances = %d, want 2", len(req.Instances))
+		}
+
+		resp := vertexEmbedResponse{
+			Predictions: []vertexPrediction{
+				{Embeddings: vertexEmbeddingValues{Values: []float64{0.1, 0.2}}},
+				{Embeddings: vertexEmbeddingValues{Values: []float64{0.3, 0.4}}},
+			},
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(resp)
+	}))
+	defer srv.Close()
+
+	v := newTestVertexEmbedder(srv)
+
+	vectors, err := v.EmbedBatch(context.Background(), []string{"text1", "text2"})
+	if err != nil {
+		t.Fatalf("EmbedBatch: %v", err)
+	}
+	if len(vectors) != 2 {
+		t.Fatalf("vectors = %d, want 2", len(vectors))
+	}
+	if vectors[0][0] != 0.1 {
+		t.Errorf("vectors[0][0] = %f, want 0.1", vectors[0][0])
+	}
+	if vectors[1][0] != 0.3 {
+		t.Errorf("vectors[1][0] = %f, want 0.3", vectors[1][0])
+	}
+}
+
+func TestVertexEmbedder_ErrorResponse(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusBadRequest)
+		_, _ = w.Write([]byte(`{"error":{"message":"Organization Policy constraint violated"}}`))
+	}))
+	defer srv.Close()
+
+	v := newTestVertexEmbedder(srv)
+
+	_, err := v.Embed(context.Background(), "hello")
+	if err == nil {
+		t.Fatal("expected error for 400 response")
+	}
+	if !strings.Contains(err.Error(), "Organization Policy") {
+		t.Errorf("error = %q, want to contain 'Organization Policy'", err.Error())
+	}
+}
+
+func TestVertexEmbedder_AuthError(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusUnauthorized)
+		_, _ = w.Write([]byte(`{"error":{"message":"Request had invalid authentication credentials"}}`))
+	}))
+	defer srv.Close()
+
+	v := newTestVertexEmbedder(srv)
+
+	_, err := v.Embed(context.Background(), "hello")
+	if err == nil {
+		t.Fatal("expected error for 401 response")
+	}
+	if !strings.Contains(err.Error(), "401") {
+		t.Errorf("error = %q, want to contain '401'", err.Error())
+	}
+}
+
+func TestVertexEmbedder_ModelID(t *testing.T) {
+	v := &VertexEmbedder{model: "text-embedding-005"}
+	if v.ModelID() != "text-embedding-005" {
+		t.Errorf("ModelID = %q, want text-embedding-005", v.ModelID())
+	}
+}
+
+func TestVertexEmbedder_Available_True(t *testing.T) {
+	v := &VertexEmbedder{
+		model: "text-embedding-005",
+		tokenFn: func(_ context.Context) (string, error) {
+			return "valid-token", nil
+		},
+		checkExpiry: 30 * time.Second,
+	}
+	if !v.Available() {
+		t.Error("Available() = false, want true when tokenFn succeeds")
+	}
+}
+
+func TestVertexEmbedder_Available_False(t *testing.T) {
+	v := &VertexEmbedder{
+		model: "text-embedding-005",
+		tokenFn: func(_ context.Context) (string, error) {
+			return "", fmt.Errorf("no credentials")
+		},
+		checkExpiry: 30 * time.Second,
+	}
+	if v.Available() {
+		t.Error("Available() = true, want false when tokenFn fails")
+	}
+}
+
+func TestVertexEmbedder_Available_Cached(t *testing.T) {
+	calls := 0
+	v := &VertexEmbedder{
+		model: "text-embedding-005",
+		tokenFn: func(_ context.Context) (string, error) {
+			calls++
+			return "token", nil
+		},
+		checkExpiry: 1 * time.Hour,
+	}
+	v.Available()
+	v.Available()
+	if calls != 1 {
+		t.Errorf("tokenFn called %d times, want 1 (cached)", calls)
+	}
+}
+
+func TestVertexEmbedder_EmbedBatch_EmptyInput(t *testing.T) {
+	v := &VertexEmbedder{model: "test"}
+	result, err := v.EmbedBatch(context.Background(), []string{})
+	if err != nil {
+		t.Fatalf("EmbedBatch empty: %v", err)
+	}
+	if result != nil {
+		t.Errorf("expected nil for empty input, got %v", result)
+	}
+}
+
+func TestVertexEmbedder_EmbedBatch_PredictionCountMismatch(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		// Return 1 prediction for 2 inputs
+		resp := vertexEmbedResponse{
+			Predictions: []vertexPrediction{
+				{Embeddings: vertexEmbeddingValues{Values: []float64{0.1}}},
+			},
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(resp)
+	}))
+	defer srv.Close()
+
+	v := newTestVertexEmbedder(srv)
+	_, err := v.EmbedBatch(context.Background(), []string{"a", "b"})
+	if err == nil {
+		t.Fatal("expected error for prediction count mismatch")
+	}
+	if !strings.Contains(err.Error(), "2 inputs") {
+		t.Errorf("error = %q, want to mention input count", err.Error())
+	}
+}
+
+func TestNewVertexEmbedder_MissingModel(t *testing.T) {
+	_, err := NewVertexEmbedder("project", "region", "")
+	if err == nil {
+		t.Fatal("expected error for missing model")
+	}
+}
+
+// newTestVertexEmbedder creates a VertexEmbedder that routes requests to
+// the given test server and uses a mock token function.
+func newTestVertexEmbedder(srv *httptest.Server) *VertexEmbedder {
+	return &VertexEmbedder{
+		project: "test-project",
+		region:  "us-central1",
+		model:   "text-embedding-005",
+		client: &http.Client{
+			Transport: &urlRewriteTransport{target: srv.URL, transport: srv.Client().Transport},
+		},
+		tokenFn: func(_ context.Context) (string, error) {
+			return "test-token", nil
+		},
+	}
+}
+
+// urlRewriteTransport redirects all requests to the test server URL
+// while preserving the original request path and method.
+type urlRewriteTransport struct {
+	target    string
+	transport http.RoundTripper
+}
+
+func (t *urlRewriteTransport) RoundTrip(req *http.Request) (*http.Response, error) {
+	req = req.Clone(req.Context())
+	req.URL.Scheme = "http"
+	req.URL.Host = strings.TrimPrefix(t.target, "http://")
+	if t.transport != nil {
+		return t.transport.RoundTrip(req)
+	}
+	return http.DefaultTransport.RoundTrip(req)
+}

--- a/go.mod
+++ b/go.mod
@@ -3,20 +3,23 @@ module github.com/unbound-force/dewey
 go 1.25.0
 
 require (
+	github.com/charmbracelet/lipgloss v1.1.0
 	github.com/charmbracelet/log v1.0.0
 	github.com/fsnotify/fsnotify v1.9.0
 	github.com/google/uuid v1.6.0
 	github.com/k3a/html2text v1.4.0
+	github.com/mattn/go-runewidth v0.0.16
 	github.com/modelcontextprotocol/go-sdk v1.2.0
 	github.com/spf13/cobra v1.10.2
+	golang.org/x/oauth2 v0.30.0
 	gopkg.in/yaml.v3 v3.0.1
 	modernc.org/sqlite v1.47.0
 )
 
 require (
+	cloud.google.com/go/compute/metadata v0.3.0 // indirect
 	github.com/aymanbagabas/go-osc52/v2 v2.0.1 // indirect
 	github.com/charmbracelet/colorprofile v0.2.3-0.20250311203215-f60798e515dc // indirect
-	github.com/charmbracelet/lipgloss v1.1.0 // indirect
 	github.com/charmbracelet/x/ansi v0.8.0 // indirect
 	github.com/charmbracelet/x/cellbuf v0.0.13-0.20250311204145-2c3ea96c31dd // indirect
 	github.com/charmbracelet/x/term v0.2.1 // indirect
@@ -26,7 +29,6 @@ require (
 	github.com/inconshreveable/mousetrap v1.1.0 // indirect
 	github.com/lucasb-eyer/go-colorful v1.2.0 // indirect
 	github.com/mattn/go-isatty v0.0.20 // indirect
-	github.com/mattn/go-runewidth v0.0.16 // indirect
 	github.com/muesli/termenv v0.16.0 // indirect
 	github.com/ncruces/go-strftime v1.0.0 // indirect
 	github.com/remyoudompheng/bigfft v0.0.0-20230129092748-24d4a6f8daec // indirect
@@ -35,7 +37,6 @@ require (
 	github.com/xo/terminfo v0.0.0-20220910002029-abceb7e1c41e // indirect
 	github.com/yosida95/uritemplate/v3 v3.0.2 // indirect
 	golang.org/x/exp v0.0.0-20251023183803-a4bb9ffd2546 // indirect
-	golang.org/x/oauth2 v0.30.0 // indirect
 	golang.org/x/sys v0.42.0 // indirect
 	modernc.org/libc v1.70.0 // indirect
 	modernc.org/mathutil v1.7.1 // indirect

--- a/go.sum
+++ b/go.sum
@@ -1,3 +1,5 @@
+cloud.google.com/go/compute/metadata v0.3.0 h1:Tz+eQXMEqDIKRsmY3cHTL6FVaynIjX2QxYC4trgAKZc=
+cloud.google.com/go/compute/metadata v0.3.0/go.mod h1:zFmK7XCadkQkj6TtorcaGlCW1hT1fIilQDwofLpJ20k=
 github.com/aymanbagabas/go-osc52/v2 v2.0.1 h1:HwpRHbFMcZLEVr42D4p7XBqjyuxQH5SMiErDT4WkJ2k=
 github.com/aymanbagabas/go-osc52/v2 v2.0.1/go.mod h1:uYgXzlJ7ZpABp8OJ+exZzJJhRNQ2ASbcXHWsFqH8hp8=
 github.com/charmbracelet/colorprofile v0.2.3-0.20250311203215-f60798e515dc h1:4pZI35227imm7yK2bGPcfpFEmuY1gc2YSTShr4iJBfs=

--- a/llm/config.go
+++ b/llm/config.go
@@ -47,6 +47,7 @@ func readConfigFile(dir string) *configFile {
 	}
 	var cfg configFile
 	if err := yaml.Unmarshal(data, &cfg); err != nil {
+		logger.Warn("failed to parse config.yaml, using defaults", "path", filepath.Join(dir, "config.yaml"), "err", err)
 		return nil
 	}
 	return &cfg

--- a/llm/config.go
+++ b/llm/config.go
@@ -1,0 +1,124 @@
+package llm
+
+import (
+	"os"
+	"path/filepath"
+
+	"gopkg.in/yaml.v3"
+)
+
+// globalConfigDir returns the path to the global dewey config directory.
+// Uses $XDG_CONFIG_HOME/dewey if set, otherwise ~/.config/dewey.
+func globalConfigDir() string {
+	if xdg := os.Getenv("XDG_CONFIG_HOME"); xdg != "" {
+		return filepath.Join(xdg, "dewey")
+	}
+	home, err := os.UserHomeDir()
+	if err != nil {
+		return ""
+	}
+	return filepath.Join(home, ".config", "dewey")
+}
+
+// configFile represents the structure of config.yaml
+// relevant to synthesis configuration.
+type configFile struct {
+	Synthesis struct {
+		Provider string `yaml:"provider"`
+		Model    string `yaml:"model"`
+		Endpoint string `yaml:"endpoint"`
+		Project  string `yaml:"project"`
+		Region   string `yaml:"region"`
+	} `yaml:"synthesis"`
+
+	// Legacy field for backward compatibility.
+	CompileModel string `yaml:"compile_model"`
+}
+
+// readConfigFile attempts to parse a config.yaml at the given directory.
+// Returns nil if the file doesn't exist or can't be parsed.
+func readConfigFile(dir string) *configFile {
+	if dir == "" {
+		return nil
+	}
+	data, err := os.ReadFile(filepath.Join(dir, "config.yaml"))
+	if err != nil {
+		return nil
+	}
+	var cfg configFile
+	if err := yaml.Unmarshal(data, &cfg); err != nil {
+		return nil
+	}
+	return &cfg
+}
+
+// ReadSynthesisConfig reads the synthesis provider configuration.
+//
+// Config precedence (highest to lowest):
+//  1. Per-vault config: {deweyDir}/config.yaml (synthesis section)
+//  2. Per-vault legacy: {deweyDir}/config.yaml (compile_model field)
+//  3. Global config: ~/.config/dewey/config.yaml
+//  4. Environment variable: DEWEY_GENERATION_MODEL
+//  5. Zero config (no synthesizer — prompt-only mode)
+//
+// Environment variables do not override config file values for synthesis
+// (unlike embedding), preserving backward compatibility with the legacy
+// compile_model path.
+func ReadSynthesisConfig(deweyDir string) ProviderConfig {
+	cfg := readConfigFile(deweyDir)
+
+	// Check per-vault synthesis section.
+	if cfg != nil && (cfg.Synthesis.Provider != "" || cfg.Synthesis.Model != "") {
+		return ProviderConfig{
+			Provider: cfg.Synthesis.Provider,
+			Model:    cfg.Synthesis.Model,
+			Endpoint: cfg.Synthesis.Endpoint,
+			Project:  cfg.Synthesis.Project,
+			Region:   cfg.Synthesis.Region,
+		}
+	}
+
+	// Check per-vault legacy compile_model.
+	if cfg != nil && cfg.CompileModel != "" {
+		endpoint := os.Getenv("DEWEY_EMBEDDING_ENDPOINT")
+		if endpoint == "" {
+			endpoint = "http://localhost:11434"
+		}
+		return ProviderConfig{
+			Provider: "ollama",
+			Model:    cfg.CompileModel,
+			Endpoint: endpoint,
+		}
+	}
+
+	// Check global config.
+	globalCfg := readConfigFile(globalConfigDir())
+	if globalCfg != nil && (globalCfg.Synthesis.Provider != "" || globalCfg.Synthesis.Model != "") {
+		return ProviderConfig{
+			Provider: globalCfg.Synthesis.Provider,
+			Model:    globalCfg.Synthesis.Model,
+			Endpoint: globalCfg.Synthesis.Endpoint,
+			Project:  globalCfg.Synthesis.Project,
+			Region:   globalCfg.Synthesis.Region,
+		}
+	}
+
+	return synthConfigFromEnv()
+}
+
+// synthConfigFromEnv builds a synthesis config from environment variables.
+func synthConfigFromEnv() ProviderConfig {
+	model := os.Getenv("DEWEY_GENERATION_MODEL")
+	if model == "" {
+		return ProviderConfig{}
+	}
+	endpoint := os.Getenv("DEWEY_EMBEDDING_ENDPOINT")
+	if endpoint == "" {
+		endpoint = "http://localhost:11434"
+	}
+	return ProviderConfig{
+		Provider: "ollama",
+		Model:    model,
+		Endpoint: endpoint,
+	}
+}

--- a/llm/llm.go
+++ b/llm/llm.go
@@ -1,14 +1,16 @@
 // Package llm provides interfaces and implementations for generating
-// natural language text from structured prompts. The primary implementation
-// uses Ollama's HTTP API for local model inference via POST /api/generate.
+// natural language text from structured prompts. Implementations include
+// OllamaSynthesizer (local inference via Ollama HTTP API) and
+// VertexSynthesizer (Google Vertex AI rawPredict API with Anthropic
+// Messages format).
 //
 // Design decision: Separate from embed.Embedder because embedding and
-// synthesis use different Ollama API endpoints (/api/embed vs /api/generate),
-// different models (embedding model vs generation model), and have different
-// error modes. Single Responsibility Principle.
+// synthesis use different API endpoints, different models, and have
+// different error modes. Single Responsibility Principle.
 //
 // This package is a leaf dependency — it MUST NOT import any other Dewey
-// packages. Only stdlib + charmbracelet/log are allowed.
+// packages. Only stdlib, charmbracelet/log, golang.org/x/oauth2, and
+// gopkg.in/yaml.v3 are allowed.
 package llm
 
 import (

--- a/llm/provider.go
+++ b/llm/provider.go
@@ -1,0 +1,48 @@
+package llm
+
+import "fmt"
+
+// ProviderConfig holds the configuration for a synthesis provider.
+// Each provider type uses a subset of these fields.
+type ProviderConfig struct {
+	// Provider selects the synthesis backend: "ollama" or "vertex".
+	// Defaults to "ollama" if empty.
+	Provider string
+
+	// Model is the model identifier (e.g., "llama3.2:3b",
+	// "claude-sonnet-4-6").
+	Model string
+
+	// Endpoint is the base URL for the provider API.
+	// Required for ollama. Ignored for vertex.
+	Endpoint string
+
+	// Project is the GCP project ID. Required for vertex only.
+	Project string
+
+	// Region is the GCP region (e.g., "us-east5"). Required for vertex only.
+	Region string
+}
+
+// NewSynthesizerFromConfig creates a Synthesizer from the given provider configuration.
+// Returns an error if the provider is unknown or required fields are missing.
+func NewSynthesizerFromConfig(cfg ProviderConfig) (Synthesizer, error) {
+	switch cfg.Provider {
+	case "ollama", "":
+		endpoint := cfg.Endpoint
+		if endpoint == "" {
+			endpoint = "http://localhost:11434"
+		}
+		return NewOllamaSynthesizer(endpoint, cfg.Model), nil
+	case "vertex":
+		if cfg.Project == "" {
+			return nil, fmt.Errorf("vertex synthesis provider requires project")
+		}
+		if cfg.Region == "" {
+			return nil, fmt.Errorf("vertex synthesis provider requires region")
+		}
+		return NewVertexSynthesizer(cfg.Project, cfg.Region, cfg.Model)
+	default:
+		return nil, fmt.Errorf("unknown synthesis provider: %q (supported: ollama, vertex)", cfg.Provider)
+	}
+}

--- a/llm/provider_test.go
+++ b/llm/provider_test.go
@@ -3,6 +3,7 @@ package llm
 import (
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 )
 
@@ -60,6 +61,9 @@ func TestNewSynthesizerFromConfig_VertexMissingProject(t *testing.T) {
 	if err == nil {
 		t.Fatal("expected error for missing project")
 	}
+	if !strings.Contains(err.Error(), "project") {
+		t.Errorf("error = %q, want to contain 'project'", err.Error())
+	}
 }
 
 func TestNewSynthesizerFromConfig_VertexMissingRegion(t *testing.T) {
@@ -72,6 +76,9 @@ func TestNewSynthesizerFromConfig_VertexMissingRegion(t *testing.T) {
 	if err == nil {
 		t.Fatal("expected error for missing region")
 	}
+	if !strings.Contains(err.Error(), "region") {
+		t.Errorf("error = %q, want to contain 'region'", err.Error())
+	}
 }
 
 func TestNewSynthesizerFromConfig_UnknownProvider(t *testing.T) {
@@ -81,6 +88,9 @@ func TestNewSynthesizerFromConfig_UnknownProvider(t *testing.T) {
 	_, err := NewSynthesizerFromConfig(cfg)
 	if err == nil {
 		t.Fatal("expected error for unknown provider")
+	}
+	if !strings.Contains(err.Error(), "unsupported") {
+		t.Errorf("error = %q, want to contain 'unsupported'", err.Error())
 	}
 }
 

--- a/llm/provider_test.go
+++ b/llm/provider_test.go
@@ -1,0 +1,214 @@
+package llm
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestNewSynthesizerFromConfig_Ollama(t *testing.T) {
+	cfg := ProviderConfig{
+		Provider: "ollama",
+		Model:    "llama3.2:3b",
+		Endpoint: "http://localhost:11434",
+	}
+	s, err := NewSynthesizerFromConfig(cfg)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if s.ModelID() != "llama3.2:3b" {
+		t.Errorf("ModelID = %q, want llama3.2:3b", s.ModelID())
+	}
+}
+
+func TestNewSynthesizerFromConfig_EmptyDefaultsToOllama(t *testing.T) {
+	cfg := ProviderConfig{
+		Model: "llama3.2:3b",
+	}
+	s, err := NewSynthesizerFromConfig(cfg)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if _, ok := s.(*OllamaSynthesizer); !ok {
+		t.Errorf("expected *OllamaSynthesizer, got %T", s)
+	}
+}
+
+func TestNewSynthesizerFromConfig_Vertex(t *testing.T) {
+	cfg := ProviderConfig{
+		Provider: "vertex",
+		Model:    "claude-sonnet-4-6",
+		Project:  "my-project",
+		Region:   "us-east5",
+	}
+	s, err := NewSynthesizerFromConfig(cfg)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if s.ModelID() != "claude-sonnet-4-6" {
+		t.Errorf("ModelID = %q, want claude-sonnet-4-6", s.ModelID())
+	}
+}
+
+func TestNewSynthesizerFromConfig_VertexMissingProject(t *testing.T) {
+	cfg := ProviderConfig{
+		Provider: "vertex",
+		Model:    "claude-sonnet-4-6",
+		Region:   "us-east5",
+	}
+	_, err := NewSynthesizerFromConfig(cfg)
+	if err == nil {
+		t.Fatal("expected error for missing project")
+	}
+}
+
+func TestNewSynthesizerFromConfig_VertexMissingRegion(t *testing.T) {
+	cfg := ProviderConfig{
+		Provider: "vertex",
+		Model:    "claude-sonnet-4-6",
+		Project:  "my-project",
+	}
+	_, err := NewSynthesizerFromConfig(cfg)
+	if err == nil {
+		t.Fatal("expected error for missing region")
+	}
+}
+
+func TestNewSynthesizerFromConfig_UnknownProvider(t *testing.T) {
+	cfg := ProviderConfig{
+		Provider: "unsupported",
+	}
+	_, err := NewSynthesizerFromConfig(cfg)
+	if err == nil {
+		t.Fatal("expected error for unknown provider")
+	}
+}
+
+func TestReadSynthesisConfig_FromFile(t *testing.T) {
+	dir := t.TempDir()
+	configYAML := `synthesis:
+  provider: vertex
+  model: claude-sonnet-4-6
+  project: my-project
+  region: us-east5
+`
+	if err := os.WriteFile(filepath.Join(dir, "config.yaml"), []byte(configYAML), 0644); err != nil {
+		t.Fatalf("write config: %v", err)
+	}
+
+	cfg := ReadSynthesisConfig(dir)
+	if cfg.Provider != "vertex" {
+		t.Errorf("Provider = %q, want vertex", cfg.Provider)
+	}
+	if cfg.Model != "claude-sonnet-4-6" {
+		t.Errorf("Model = %q, want claude-sonnet-4-6", cfg.Model)
+	}
+	if cfg.Project != "my-project" {
+		t.Errorf("Project = %q, want my-project", cfg.Project)
+	}
+}
+
+func TestReadSynthesisConfig_BackwardCompatible(t *testing.T) {
+	dir := t.TempDir()
+	configYAML := `compile_model: llama3.2:3b
+`
+	if err := os.WriteFile(filepath.Join(dir, "config.yaml"), []byte(configYAML), 0644); err != nil {
+		t.Fatalf("write config: %v", err)
+	}
+
+	cfg := ReadSynthesisConfig(dir)
+	if cfg.Provider != "ollama" {
+		t.Errorf("Provider = %q, want ollama", cfg.Provider)
+	}
+	if cfg.Model != "llama3.2:3b" {
+		t.Errorf("Model = %q, want llama3.2:3b", cfg.Model)
+	}
+}
+
+func TestReadSynthesisConfig_EnvFallback(t *testing.T) {
+	dir := t.TempDir()
+	// Isolate from real global config.
+	t.Setenv("XDG_CONFIG_HOME", t.TempDir())
+	// No config file.
+	t.Setenv("DEWEY_GENERATION_MODEL", "mistral:latest")
+
+	cfg := ReadSynthesisConfig(dir)
+	if cfg.Provider != "ollama" {
+		t.Errorf("Provider = %q, want ollama", cfg.Provider)
+	}
+	if cfg.Model != "mistral:latest" {
+		t.Errorf("Model = %q, want mistral:latest (from env)", cfg.Model)
+	}
+}
+
+func TestReadSynthesisConfig_NoFileNoEnv(t *testing.T) {
+	dir := t.TempDir()
+	// Isolate from real global config.
+	t.Setenv("XDG_CONFIG_HOME", t.TempDir())
+	// No config, no env — should return zero config.
+	cfg := ReadSynthesisConfig(dir)
+	if cfg.Model != "" {
+		t.Errorf("Model = %q, want empty (no config)", cfg.Model)
+	}
+}
+
+func TestReadSynthesisConfig_GlobalFallback(t *testing.T) {
+	vaultDir := t.TempDir()
+
+	globalDir := filepath.Join(t.TempDir(), "dewey")
+	if err := os.MkdirAll(globalDir, 0755); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	globalYAML := `synthesis:
+  provider: vertex
+  model: claude-sonnet-4-6
+  project: global-project
+  region: us-east5
+`
+	if err := os.WriteFile(filepath.Join(globalDir, "config.yaml"), []byte(globalYAML), 0644); err != nil {
+		t.Fatalf("write global config: %v", err)
+	}
+	t.Setenv("XDG_CONFIG_HOME", filepath.Dir(globalDir))
+
+	cfg := ReadSynthesisConfig(vaultDir)
+	if cfg.Provider != "vertex" {
+		t.Errorf("Provider = %q, want vertex (from global)", cfg.Provider)
+	}
+	if cfg.Model != "claude-sonnet-4-6" {
+		t.Errorf("Model = %q, want claude-sonnet-4-6", cfg.Model)
+	}
+}
+
+func TestReadSynthesisConfig_VaultOverridesGlobal(t *testing.T) {
+	vaultDir := t.TempDir()
+	vaultYAML := `synthesis:
+  provider: ollama
+  model: llama3.2:3b
+`
+	if err := os.WriteFile(filepath.Join(vaultDir, "config.yaml"), []byte(vaultYAML), 0644); err != nil {
+		t.Fatalf("write vault config: %v", err)
+	}
+
+	globalDir := filepath.Join(t.TempDir(), "dewey")
+	if err := os.MkdirAll(globalDir, 0755); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	globalYAML := `synthesis:
+  provider: vertex
+  model: claude-sonnet-4-6
+  project: global-project
+  region: us-east5
+`
+	if err := os.WriteFile(filepath.Join(globalDir, "config.yaml"), []byte(globalYAML), 0644); err != nil {
+		t.Fatalf("write global config: %v", err)
+	}
+	t.Setenv("XDG_CONFIG_HOME", filepath.Dir(globalDir))
+
+	cfg := ReadSynthesisConfig(vaultDir)
+	if cfg.Provider != "ollama" {
+		t.Errorf("Provider = %q, want ollama (vault overrides global)", cfg.Provider)
+	}
+	if cfg.Model != "llama3.2:3b" {
+		t.Errorf("Model = %q, want llama3.2:3b", cfg.Model)
+	}
+}

--- a/llm/vertex.go
+++ b/llm/vertex.go
@@ -6,11 +6,24 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
+	"math"
+	"math/rand/v2"
 	"net/http"
+	"strconv"
 	"sync"
 	"time"
 
+	"github.com/charmbracelet/log"
 	"golang.org/x/oauth2/google"
+)
+
+const (
+	// vertexSynthMaxRetries is the maximum number of retry attempts on 429 responses.
+	vertexSynthMaxRetries = 5
+	// vertexSynthBaseDelay is the initial backoff delay before the first retry.
+	vertexSynthBaseDelay = 1 * time.Second
+	// vertexSynthMaxDelay caps the exponential backoff to prevent excessive waits.
+	vertexSynthMaxDelay = 60 * time.Second
 )
 
 // VertexSynthesizer implements Synthesizer using Google Vertex AI's rawPredict API.
@@ -100,6 +113,7 @@ func (v *VertexSynthesizer) defaultGetToken(ctx context.Context) (string, error)
 }
 
 // Synthesize generates text from a prompt via Vertex AI Claude.
+// Retries up to 5 times on HTTP 429 (Too Many Requests) with exponential backoff.
 func (v *VertexSynthesizer) Synthesize(ctx context.Context, prompt string) (string, error) {
 	reqBody := vertexSynthRequest{
 		AnthropicVersion: "vertex-2023-10-16",
@@ -114,31 +128,13 @@ func (v *VertexSynthesizer) Synthesize(ctx context.Context, prompt string) (stri
 		return "", fmt.Errorf("marshal vertex request: %w", err)
 	}
 
-	token, err := v.tokenFn(ctx)
+	statusCode, respBody, err := v.doRequestWithRetry(ctx, v.rawPredictURL(), bodyBytes)
 	if err != nil {
 		return "", err
 	}
 
-	req, err := http.NewRequestWithContext(ctx, http.MethodPost, v.rawPredictURL(), bytes.NewReader(bodyBytes))
-	if err != nil {
-		return "", fmt.Errorf("create vertex request: %w", err)
-	}
-	req.Header.Set("Content-Type", "application/json")
-	req.Header.Set("Authorization", "Bearer "+token)
-
-	resp, err := v.client.Do(req)
-	if err != nil {
-		return "", fmt.Errorf("vertex AI request: %w", err)
-	}
-	defer func() { _ = resp.Body.Close() }()
-
-	respBody, err := io.ReadAll(io.LimitReader(resp.Body, 50*1024*1024))
-	if err != nil {
-		return "", fmt.Errorf("read vertex response: %w", err)
-	}
-
-	if resp.StatusCode != http.StatusOK {
-		return "", fmt.Errorf("vertex AI error (HTTP %d): %s", resp.StatusCode, string(respBody))
+	if statusCode != http.StatusOK {
+		return "", fmt.Errorf("vertex AI error (HTTP %d): %s", statusCode, string(respBody))
 	}
 
 	var result vertexSynthResponse
@@ -154,6 +150,85 @@ func (v *VertexSynthesizer) Synthesize(ctx context.Context, prompt string) (stri
 	}
 
 	return "", fmt.Errorf("vertex AI response contained no text content")
+}
+
+// doRequestWithRetry sends an HTTP POST to url with bodyBytes, retrying on
+// HTTP 429 with exponential backoff. Returns the final status code, response
+// body, and any transport-level error.
+func (v *VertexSynthesizer) doRequestWithRetry(ctx context.Context, url string, bodyBytes []byte) (int, []byte, error) {
+	for attempt := range vertexSynthMaxRetries + 1 {
+		token, err := v.tokenFn(ctx)
+		if err != nil {
+			return 0, nil, err
+		}
+
+		req, err := http.NewRequestWithContext(ctx, http.MethodPost, url, bytes.NewReader(bodyBytes))
+		if err != nil {
+			return 0, nil, fmt.Errorf("create vertex request: %w", err)
+		}
+		req.Header.Set("Content-Type", "application/json")
+		req.Header.Set("Authorization", "Bearer "+token)
+
+		resp, err := v.client.Do(req)
+		if err != nil {
+			return 0, nil, fmt.Errorf("vertex AI request: %w", err)
+		}
+
+		respBody, err := io.ReadAll(io.LimitReader(resp.Body, 50*1024*1024))
+		_ = resp.Body.Close()
+		if err != nil {
+			return 0, nil, fmt.Errorf("read vertex response: %w", err)
+		}
+
+		if resp.StatusCode != http.StatusTooManyRequests {
+			return resp.StatusCode, respBody, nil
+		}
+
+		if attempt == vertexSynthMaxRetries {
+			return 0, nil, fmt.Errorf("vertex AI rate limited (HTTP 429) after %d retries: %s", vertexSynthMaxRetries, string(respBody))
+		}
+
+		delay := vertexSynthRetryDelay(attempt, resp.Header.Get("Retry-After"))
+		log.Warn("vertex AI rate limited, retrying", "attempt", attempt+1, "delay", delay)
+
+		select {
+		case <-ctx.Done():
+			return 0, nil, ctx.Err()
+		case <-time.After(delay):
+		}
+	}
+	// Unreachable — the loop always returns or breaks.
+	return 0, nil, fmt.Errorf("vertex AI retry loop exited unexpectedly")
+}
+
+// vertexSynthRetryDelay computes the backoff delay for a retry attempt.
+// If the Retry-After header contains a valid number of seconds, that
+// value is used (capped at vertexSynthMaxDelay). Otherwise, exponential
+// backoff with jitter is applied: baseDelay * 2^attempt ± 25%, capped at
+// vertexSynthMaxDelay. Jitter prevents thundering herd when multiple
+// goroutines retry simultaneously. Only integer-seconds Retry-After format
+// is supported; HTTP-date format falls back to exponential backoff.
+func vertexSynthRetryDelay(attempt int, retryAfter string) time.Duration {
+	if retryAfter != "" {
+		if secs, err := strconv.Atoi(retryAfter); err == nil && secs > 0 {
+			d := time.Duration(secs) * time.Second
+			if d > vertexSynthMaxDelay {
+				d = vertexSynthMaxDelay
+			}
+			return d
+		}
+	}
+	d := time.Duration(float64(vertexSynthBaseDelay) * math.Pow(2, float64(attempt)))
+	if d > vertexSynthMaxDelay {
+		d = vertexSynthMaxDelay
+	}
+	// Add ±25% jitter to desynchronize concurrent retries.
+	jitter := time.Duration(rand.Int64N(int64(d)/2)) - d/4
+	d += jitter
+	if d < 0 {
+		d = 0
+	}
+	return d
 }
 
 // Available reports whether Vertex AI credentials are configured.

--- a/llm/vertex.go
+++ b/llm/vertex.go
@@ -1,0 +1,189 @@
+package llm
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"sync"
+	"time"
+
+	"golang.org/x/oauth2/google"
+)
+
+// VertexSynthesizer implements Synthesizer using Google Vertex AI's rawPredict API.
+// Sends requests in Anthropic Messages format to Claude models hosted on Vertex AI.
+// Uses application-default credentials for authentication (no CGO).
+//
+// Design decision D4 (pluggable-providers design.md): Direct REST calls to
+// the rawPredict endpoint using Anthropic Messages format. Tested successfully
+// with claude-opus-4-6 returning results in ~31 seconds.
+type VertexSynthesizer struct {
+	project string
+	region  string
+	model   string
+	client  *http.Client
+	tokenFn func(ctx context.Context) (string, error)
+
+	// Cached availability check.
+	mu          sync.RWMutex
+	available   bool
+	lastCheck   time.Time
+	checkExpiry time.Duration
+}
+
+// vertexSynthRequest is the Anthropic Messages format wrapped for Vertex rawPredict.
+type vertexSynthRequest struct {
+	AnthropicVersion string          `json:"anthropic_version"`
+	MaxTokens        int             `json:"max_tokens"`
+	Messages         []vertexMessage `json:"messages"`
+}
+
+// vertexMessage represents a message in the Anthropic Messages format.
+type vertexMessage struct {
+	Role    string `json:"role"`
+	Content string `json:"content"`
+}
+
+// vertexSynthResponse is the Anthropic Messages response from Vertex rawPredict.
+type vertexSynthResponse struct {
+	Content []vertexContentBlock `json:"content"`
+}
+
+// vertexContentBlock contains the text output from synthesis.
+type vertexContentBlock struct {
+	Type string `json:"type"`
+	Text string `json:"text"`
+}
+
+// NewVertexSynthesizer creates a VertexSynthesizer for the given GCP project,
+// region, and model (e.g., "claude-sonnet-4-6"). Returns an error if required
+// fields are missing.
+func NewVertexSynthesizer(project, region, model string) (*VertexSynthesizer, error) {
+	if model == "" {
+		return nil, fmt.Errorf("vertex synthesizer requires model")
+	}
+	v := &VertexSynthesizer{
+		project: project,
+		region:  region,
+		model:   model,
+		client: &http.Client{
+			Timeout: 120 * time.Second, // Match OllamaSynthesizer timeout.
+		},
+		checkExpiry: 30 * time.Second,
+	}
+	v.tokenFn = v.defaultGetToken
+	return v, nil
+}
+
+// rawPredictURL builds the Vertex AI rawPredict endpoint URL for Anthropic models.
+func (v *VertexSynthesizer) rawPredictURL() string {
+	return fmt.Sprintf(
+		"https://%s-aiplatform.googleapis.com/v1/projects/%s/locations/%s/publishers/anthropic/models/%s:rawPredict",
+		v.region, v.project, v.region, v.model,
+	)
+}
+
+// defaultGetToken retrieves an OAuth2 access token using application-default credentials.
+func (v *VertexSynthesizer) defaultGetToken(ctx context.Context) (string, error) {
+	creds, err := google.FindDefaultCredentials(ctx, "https://www.googleapis.com/auth/cloud-platform")
+	if err != nil {
+		return "", fmt.Errorf("vertex AI credentials: %w (run 'gcloud auth application-default login --scopes=https://www.googleapis.com/auth/cloud-platform')", err)
+	}
+	tok, err := creds.TokenSource.Token()
+	if err != nil {
+		return "", fmt.Errorf("vertex AI token: %w", err)
+	}
+	return tok.AccessToken, nil
+}
+
+// Synthesize generates text from a prompt via Vertex AI Claude.
+func (v *VertexSynthesizer) Synthesize(ctx context.Context, prompt string) (string, error) {
+	reqBody := vertexSynthRequest{
+		AnthropicVersion: "vertex-2023-10-16",
+		MaxTokens:        4096,
+		Messages: []vertexMessage{
+			{Role: "user", Content: prompt},
+		},
+	}
+
+	bodyBytes, err := json.Marshal(reqBody)
+	if err != nil {
+		return "", fmt.Errorf("marshal vertex request: %w", err)
+	}
+
+	token, err := v.tokenFn(ctx)
+	if err != nil {
+		return "", err
+	}
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, v.rawPredictURL(), bytes.NewReader(bodyBytes))
+	if err != nil {
+		return "", fmt.Errorf("create vertex request: %w", err)
+	}
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("Authorization", "Bearer "+token)
+
+	resp, err := v.client.Do(req)
+	if err != nil {
+		return "", fmt.Errorf("vertex AI request: %w", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	respBody, err := io.ReadAll(io.LimitReader(resp.Body, 50*1024*1024))
+	if err != nil {
+		return "", fmt.Errorf("read vertex response: %w", err)
+	}
+
+	if resp.StatusCode != http.StatusOK {
+		return "", fmt.Errorf("vertex AI error (HTTP %d): %s", resp.StatusCode, string(respBody))
+	}
+
+	var result vertexSynthResponse
+	if err := json.Unmarshal(respBody, &result); err != nil {
+		return "", fmt.Errorf("parse vertex response: %w", err)
+	}
+
+	// Extract text from the first content block.
+	for _, block := range result.Content {
+		if block.Type == "text" {
+			return block.Text, nil
+		}
+	}
+
+	return "", fmt.Errorf("vertex AI response contained no text content")
+}
+
+// Available reports whether Vertex AI credentials are configured.
+// Caches the result for 30 seconds.
+func (v *VertexSynthesizer) Available() bool {
+	v.mu.RLock()
+	if time.Since(v.lastCheck) < v.checkExpiry {
+		avail := v.available
+		v.mu.RUnlock()
+		return avail
+	}
+	v.mu.RUnlock()
+
+	v.mu.Lock()
+	defer v.mu.Unlock()
+
+	if time.Since(v.lastCheck) < v.checkExpiry {
+		return v.available
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	_, err := v.tokenFn(ctx)
+	v.available = err == nil
+	v.lastCheck = time.Now()
+	return v.available
+}
+
+// ModelID returns the configured Vertex AI model identifier.
+func (v *VertexSynthesizer) ModelID() string {
+	return v.model
+}

--- a/llm/vertex.go
+++ b/llm/vertex.go
@@ -13,7 +13,6 @@ import (
 	"sync"
 	"time"
 
-	"github.com/charmbracelet/log"
 	"golang.org/x/oauth2/google"
 )
 
@@ -134,7 +133,11 @@ func (v *VertexSynthesizer) Synthesize(ctx context.Context, prompt string) (stri
 	}
 
 	if statusCode != http.StatusOK {
-		return "", fmt.Errorf("vertex AI error (HTTP %d): %s", statusCode, string(respBody))
+		body := string(respBody)
+		if len(body) > 512 {
+			body = body[:512] + "... (truncated)"
+		}
+		return "", fmt.Errorf("vertex AI error (HTTP %d): %s", statusCode, body)
 	}
 
 	var result vertexSynthResponse
@@ -185,11 +188,15 @@ func (v *VertexSynthesizer) doRequestWithRetry(ctx context.Context, url string, 
 		}
 
 		if attempt == vertexSynthMaxRetries {
-			return 0, nil, fmt.Errorf("vertex AI rate limited (HTTP 429) after %d retries: %s", vertexSynthMaxRetries, string(respBody))
+			body := string(respBody)
+			if len(body) > 512 {
+				body = body[:512] + "... (truncated)"
+			}
+			return 0, nil, fmt.Errorf("vertex AI rate limited (HTTP 429) after %d retries: %s", vertexSynthMaxRetries, body)
 		}
 
 		delay := vertexSynthRetryDelay(attempt, resp.Header.Get("Retry-After"))
-		log.Warn("vertex AI rate limited, retrying", "attempt", attempt+1, "delay", delay)
+		logger.Warn("vertex AI rate limited, retrying", "attempt", attempt+1, "delay", delay)
 
 		select {
 		case <-ctx.Done():

--- a/llm/vertex_test.go
+++ b/llm/vertex_test.go
@@ -226,6 +226,29 @@ func TestNewVertexSynthesizer_MissingModel(t *testing.T) {
 	if err == nil {
 		t.Fatal("expected error for missing model")
 	}
+	if !strings.Contains(err.Error(), "model") {
+		t.Errorf("error = %q, want to contain 'model'", err.Error())
+	}
+}
+
+func TestVertexSynthesizer_Retry429ContextCancelled(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Retry-After", "60")
+		w.WriteHeader(http.StatusTooManyRequests)
+		_, _ = w.Write([]byte(`{"error":"rate limited"}`))
+	}))
+	defer srv.Close()
+
+	v := newTestVertexSynth(srv)
+	ctx, cancel := context.WithCancel(context.Background())
+	go func() {
+		time.Sleep(10 * time.Millisecond)
+		cancel()
+	}()
+	_, err := v.Synthesize(ctx, "test")
+	if err == nil {
+		t.Fatal("expected error when context is cancelled")
+	}
 }
 
 // newTestVertexSynth creates a VertexSynthesizer that routes requests to

--- a/llm/vertex_test.go
+++ b/llm/vertex_test.go
@@ -1,0 +1,180 @@
+package llm
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+)
+
+func TestVertexSynthesizer_Synthesize(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodPost {
+			t.Errorf("method = %s, want POST", r.Method)
+		}
+
+		var req vertexSynthRequest
+		if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+			t.Fatalf("decode request: %v", err)
+		}
+		if req.AnthropicVersion != "vertex-2023-10-16" {
+			t.Errorf("anthropic_version = %q, want vertex-2023-10-16", req.AnthropicVersion)
+		}
+		if len(req.Messages) != 1 || req.Messages[0].Content != "test prompt" {
+			t.Errorf("unexpected messages: %+v", req.Messages)
+		}
+
+		resp := vertexSynthResponse{
+			Content: []vertexContentBlock{
+				{Type: "text", Text: "synthesized output"},
+			},
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(resp)
+	}))
+	defer srv.Close()
+
+	v := newTestVertexSynth(srv)
+
+	text, err := v.Synthesize(context.Background(), "test prompt")
+	if err != nil {
+		t.Fatalf("Synthesize: %v", err)
+	}
+	if text != "synthesized output" {
+		t.Errorf("text = %q, want 'synthesized output'", text)
+	}
+}
+
+func TestVertexSynthesizer_AuthError(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusUnauthorized)
+		_, _ = w.Write([]byte(`{"error":{"message":"invalid credentials"}}`))
+	}))
+	defer srv.Close()
+
+	v := newTestVertexSynth(srv)
+
+	_, err := v.Synthesize(context.Background(), "test")
+	if err == nil {
+		t.Fatal("expected error for 401 response")
+	}
+	if !strings.Contains(err.Error(), "401") {
+		t.Errorf("error = %q, want to contain '401'", err.Error())
+	}
+}
+
+func TestVertexSynthesizer_ModelNotFound(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusNotFound)
+		_, _ = w.Write([]byte(`{"error":{"message":"Publisher Model was not found"}}`))
+	}))
+	defer srv.Close()
+
+	v := newTestVertexSynth(srv)
+
+	_, err := v.Synthesize(context.Background(), "test")
+	if err == nil {
+		t.Fatal("expected error for 404 response")
+	}
+	if !strings.Contains(err.Error(), "404") {
+		t.Errorf("error = %q, want to contain '404'", err.Error())
+	}
+}
+
+func TestVertexSynthesizer_NoTextContent(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		resp := vertexSynthResponse{
+			Content: []vertexContentBlock{
+				{Type: "tool_use", Text: ""},
+			},
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(resp)
+	}))
+	defer srv.Close()
+
+	v := newTestVertexSynth(srv)
+	_, err := v.Synthesize(context.Background(), "test")
+	if err == nil {
+		t.Fatal("expected error for no text content")
+	}
+	if !strings.Contains(err.Error(), "no text content") {
+		t.Errorf("error = %q, want 'no text content'", err.Error())
+	}
+}
+
+func TestVertexSynthesizer_Available_True(t *testing.T) {
+	v := &VertexSynthesizer{
+		model: "claude-sonnet-4-6",
+		tokenFn: func(_ context.Context) (string, error) {
+			return "valid-token", nil
+		},
+		checkExpiry: 30 * time.Second,
+	}
+	if !v.Available() {
+		t.Error("Available() = false, want true")
+	}
+}
+
+func TestVertexSynthesizer_Available_False(t *testing.T) {
+	v := &VertexSynthesizer{
+		model: "claude-sonnet-4-6",
+		tokenFn: func(_ context.Context) (string, error) {
+			return "", fmt.Errorf("no credentials")
+		},
+		checkExpiry: 30 * time.Second,
+	}
+	if v.Available() {
+		t.Error("Available() = true, want false")
+	}
+}
+
+func TestVertexSynthesizer_ModelID(t *testing.T) {
+	v := &VertexSynthesizer{model: "claude-sonnet-4-6"}
+	if v.ModelID() != "claude-sonnet-4-6" {
+		t.Errorf("ModelID = %q, want claude-sonnet-4-6", v.ModelID())
+	}
+}
+
+func TestNewVertexSynthesizer_MissingModel(t *testing.T) {
+	_, err := NewVertexSynthesizer("project", "region", "")
+	if err == nil {
+		t.Fatal("expected error for missing model")
+	}
+}
+
+// newTestVertexSynth creates a VertexSynthesizer that routes requests to
+// the given test server with a mock token function.
+func newTestVertexSynth(srv *httptest.Server) *VertexSynthesizer {
+	return &VertexSynthesizer{
+		project: "test-project",
+		region:  "us-east5",
+		model:   "claude-sonnet-4-6",
+		client: &http.Client{
+			Transport: &vertexURLRewrite{target: srv.URL, transport: srv.Client().Transport},
+		},
+		tokenFn: func(_ context.Context) (string, error) {
+			return "test-token", nil
+		},
+	}
+}
+
+// vertexURLRewrite redirects requests to the test server.
+type vertexURLRewrite struct {
+	target    string
+	transport http.RoundTripper
+}
+
+func (t *vertexURLRewrite) RoundTrip(req *http.Request) (*http.Response, error) {
+	req = req.Clone(req.Context())
+	req.URL.Scheme = "http"
+	req.URL.Host = strings.TrimPrefix(t.target, "http://")
+	if t.transport != nil {
+		return t.transport.RoundTrip(req)
+	}
+	return http.DefaultTransport.RoundTrip(req)
+}

--- a/llm/vertex_test.go
+++ b/llm/vertex_test.go
@@ -140,6 +140,87 @@ func TestVertexSynthesizer_ModelID(t *testing.T) {
 	}
 }
 
+func TestVertexSynthesizer_Retry429ThenSuccess(t *testing.T) {
+	attempts := 0
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		attempts++
+		if attempts <= 2 {
+			w.Header().Set("Retry-After", "0")
+			w.WriteHeader(http.StatusTooManyRequests)
+			_, _ = w.Write([]byte(`{"error":"rate limited"}`))
+			return
+		}
+		resp := vertexSynthResponse{
+			Content: []vertexContentBlock{
+				{Type: "text", Text: "success after retry"},
+			},
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(resp)
+	}))
+	defer srv.Close()
+
+	v := newTestVertexSynth(srv)
+	text, err := v.Synthesize(context.Background(), "test")
+	if err != nil {
+		t.Fatalf("Synthesize after retries: %v", err)
+	}
+	if text != "success after retry" {
+		t.Errorf("text = %q, want 'success after retry'", text)
+	}
+	if attempts != 3 {
+		t.Errorf("attempts = %d, want 3", attempts)
+	}
+}
+
+func TestVertexSynthesizer_Retry429Exhausted(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Retry-After", "0")
+		w.WriteHeader(http.StatusTooManyRequests)
+		_, _ = w.Write([]byte(`{"error":"rate limited"}`))
+	}))
+	defer srv.Close()
+
+	v := newTestVertexSynth(srv)
+	_, err := v.Synthesize(context.Background(), "test")
+	if err == nil {
+		t.Fatal("expected error after exhausting retries")
+	}
+	if !strings.Contains(err.Error(), "429") || !strings.Contains(err.Error(), "retries") {
+		t.Errorf("error = %q, want to mention 429 and retries", err.Error())
+	}
+}
+
+func TestVertexSynthRetryDelay(t *testing.T) {
+	// Without Retry-After: exponential backoff with jitter (±25%).
+	d0 := vertexSynthRetryDelay(0, "")
+	if d0 < 750*time.Millisecond || d0 > 1250*time.Millisecond {
+		t.Errorf("delay(0) = %v, want ~1s (±25%%)", d0)
+	}
+	d1 := vertexSynthRetryDelay(1, "")
+	if d1 < 1500*time.Millisecond || d1 > 2500*time.Millisecond {
+		t.Errorf("delay(1) = %v, want ~2s (±25%%)", d1)
+	}
+
+	// With Retry-After header (no jitter applied).
+	d := vertexSynthRetryDelay(0, "3")
+	if d != 3*time.Second {
+		t.Errorf("delay with Retry-After=3 = %v, want 3s", d)
+	}
+
+	// Retry-After capped at max.
+	d = vertexSynthRetryDelay(0, "120")
+	if d != vertexSynthMaxDelay {
+		t.Errorf("delay with Retry-After=120 = %v, want %v", d, vertexSynthMaxDelay)
+	}
+
+	// Invalid Retry-After falls back to exponential with jitter.
+	d = vertexSynthRetryDelay(2, "invalid")
+	if d < 3*time.Second || d > 5*time.Second {
+		t.Errorf("delay(2, invalid) = %v, want ~4s (±25%%)", d)
+	}
+}
+
 func TestNewVertexSynthesizer_MissingModel(t *testing.T) {
 	_, err := NewVertexSynthesizer("project", "region", "")
 	if err == nil {

--- a/main.go
+++ b/main.go
@@ -95,6 +95,8 @@ func newRootCmd() *cobra.Command {
 				source.SetLogLevel(log.DebugLevel)
 				ignore.SetLogLevel(log.DebugLevel)
 				store.SetLogLevel(log.DebugLevel)
+				embed.SetLogLevel(log.DebugLevel)
+				llm.SetLogLevel(log.DebugLevel)
 			}
 			if logFile != "" {
 				if err := setupFileLogging(logFile, verbose); err != nil {
@@ -186,6 +188,8 @@ func setupFileLogging(path string, verbose bool) error {
 	source.SetLogOutput(multi, level)
 	ignore.SetLogOutput(multi, level)
 	store.SetLogOutput(multi, level)
+	embed.SetLogOutput(multi, level)
+	llm.SetLogOutput(multi, level)
 
 	fileLoggingEnabled = true
 	logger.Info("file logging enabled", "path", path)
@@ -610,40 +614,41 @@ func initObsidianBackend(vaultPath, dailyFolder string, noEmbeddings bool) (back
 	// Initialize embedder based on --no-embeddings flag.
 	// When noEmbeddings is true, skip embedder creation entirely.
 	// When false, require the embedding model to be available (hard error).
-	embedModel := os.Getenv("DEWEY_EMBEDDING_MODEL")
-	embedEndpoint := os.Getenv("DEWEY_EMBEDDING_ENDPOINT")
-	if embedModel == "" {
-		embedModel = "granite-embedding:30m"
-	}
-	if embedEndpoint == "" {
-		embedEndpoint = "http://localhost:11434"
-	}
+	embCfg := embed.ReadEmbeddingConfig(deweyDir)
 
-	var embedder *embed.OllamaEmbedder
+	var embedder embed.Embedder
 	if noEmbeddings {
 		logger.Info("embeddings disabled via --no-embeddings")
 	} else {
-		// Ensure Ollama is running (auto-start if needed).
-		ollamaStart := time.Now()
-		ollamaState, err := ensureOllama(embedEndpoint, true, &execOllamaStarter{})
-		if err != nil {
-			logger.Warn("ollama auto-start failed, continuing without embeddings", "err", err)
-		}
-		logger.Info("ollama state", "state", ollamaState, "endpoint", embedEndpoint, "elapsed", time.Since(ollamaStart))
-
-		if ollamaState == OllamaUnavailable {
-			// Graceful degradation: keyword-only mode when Ollama is not installed.
-			logger.Info("semantic search unavailable — ollama not installed",
-				"install", "brew install ollama")
-		} else {
-			// Ollama is running (External or Managed) — check model availability.
-			// This remains a hard error: the user has Ollama but hasn't pulled the model.
-			embedder = embed.NewOllamaEmbedder(embedEndpoint, embedModel)
-			if !embedder.Available() {
-				return nil, nil, nil, nil, fmt.Errorf("embedding model %q not available at %s\n\nTo fix:\n  ollama pull %s\n\nTo skip embeddings:\n  dewey serve --no-embeddings",
-					embedModel, embedEndpoint, embedModel)
+		// For Ollama provider, ensure Ollama is running (auto-start if needed).
+		ollamaUnavailable := false
+		if embCfg.Provider == "ollama" || embCfg.Provider == "" {
+			ollamaStart := time.Now()
+			ollamaState, err := ensureOllama(embCfg.Endpoint, true, &execOllamaStarter{})
+			if err != nil {
+				logger.Warn("ollama auto-start failed, continuing without embeddings", "err", err)
 			}
-			logger.Info("embedding model available", "model", embedModel)
+			logger.Info("ollama state", "state", ollamaState, "endpoint", embCfg.Endpoint, "elapsed", time.Since(ollamaStart))
+
+			if ollamaState == OllamaUnavailable {
+				// Graceful degradation: keyword-only mode when Ollama is not installed.
+				logger.Info("semantic search unavailable — ollama not installed",
+					"install", "brew install ollama")
+				ollamaUnavailable = true
+			}
+		}
+
+		if !ollamaUnavailable {
+			e, err := embed.NewEmbedderFromConfig(embCfg)
+			if err != nil {
+				return nil, nil, nil, nil, fmt.Errorf("embedding provider error: %w", err)
+			}
+			if !e.Available() {
+				return nil, nil, nil, nil, fmt.Errorf("embedding model %q not available (provider: %s)\n\nTo fix:\n  ollama pull %s\n\nTo skip embeddings:\n  dewey serve --no-embeddings",
+					embCfg.Model, embCfg.Provider, embCfg.Model)
+			}
+			embedder = e
+			logger.Info("embedding model available", "provider", embCfg.Provider, "model", embCfg.Model)
 			srvOpts = append(srvOpts, WithEmbedder(embedder))
 		}
 	}

--- a/main.go
+++ b/main.go
@@ -795,26 +795,26 @@ func backgroundCuration(
 		}
 	}
 
-	// Create an OllamaSynthesizer for background curation.
-	// If Ollama is unavailable, skip background curation entirely —
-	// curation requires LLM synthesis to extract knowledge.
-	embedEndpoint := os.Getenv("DEWEY_EMBEDDING_ENDPOINT")
-	if embedEndpoint == "" {
-		embedEndpoint = "http://localhost:11434"
-	}
-	genModel := os.Getenv("DEWEY_GENERATION_MODEL")
-	if genModel == "" {
-		genModel = "llama3.2:3b"
-	}
-
-	synth := llm.NewOllamaSynthesizer(embedEndpoint, genModel)
-	if !synth.Available() {
-		logger.Info("background curation skipped — generation model not available",
-			"model", genModel, "endpoint", embedEndpoint)
+	// Create synthesizer for background curation from config.
+	// If no provider is configured or unavailable, skip background curation.
+	synthCfg := llm.ReadSynthesisConfig(filepath.Join(vaultPath, deweyWorkspaceDir))
+	if synthCfg.Model == "" {
+		logger.Info("background curation skipped — no synthesis model configured")
 		return
 	}
 
-	logger.Info("background curation ready", "model", genModel)
+	synth, synthErr := llm.NewSynthesizerFromConfig(synthCfg)
+	if synthErr != nil {
+		logger.Warn("background curation skipped — synthesis provider error", "err", synthErr)
+		return
+	}
+	if !synth.Available() {
+		logger.Info("background curation skipped — synthesis model not available",
+			"provider", synthCfg.Provider, "model", synthCfg.Model)
+		return
+	}
+
+	logger.Info("background curation ready", "provider", synthCfg.Provider, "model", synthCfg.Model)
 
 	// Create per-store tickers with configurable intervals (FR-018).
 	// Each store runs on its own schedule.

--- a/server.go
+++ b/server.go
@@ -471,7 +471,12 @@ func registerCompileTools(srv *mcp.Server, compile *tools.Compile) int {
 		Description: "Synthesize stored learnings into compiled knowledge articles. Groups learnings by topic, resolves contradictions temporally, and produces current-state articles with history.",
 	}, compile.Compile)
 
-	return 1
+	mcp.AddTool(srv, &mcp.Tool{
+		Name:        "store_compiled",
+		Description: "Persist a compiled article that was synthesized by the calling agent. Use after calling compile (which returns synthesis prompts) and performing the synthesis yourself.",
+	}, compile.StoreCompiled)
+
+	return 2
 }
 
 // registerCurateTools registers the curate MCP tool for extracting

--- a/server_test.go
+++ b/server_test.go
@@ -315,7 +315,7 @@ func TestNewServer_RegistersTools(t *testing.T) {
 		// Indexing
 		"index", "reindex",
 		// Knowledge compilation (013-knowledge-compile)
-		"compile", "lint", "promote",
+		"compile", "store_compiled", "lint", "promote", "curate",
 		// Health
 		"health",
 	}
@@ -362,7 +362,7 @@ func TestNewServer_ReadOnlyMode(t *testing.T) {
 		"bulk_update_properties", "link_pages",
 		// Learning, indexing, and knowledge compilation tools are also write-only.
 		"store_learning", "index", "reindex",
-		"compile", "lint", "promote",
+		"compile", "store_compiled", "lint", "promote", "curate",
 	}
 	for _, name := range writeTools {
 		if containsTool(tools, name) {

--- a/server_test.go
+++ b/server_test.go
@@ -558,8 +558,8 @@ func TestNewServer_ToolCount(t *testing.T) {
 			name:     "non-DataScript read-write",
 			backend:  &serverMockBackend{},
 			readOnly: false,
-			wantMin:  36, // navigate(5) + search(3) + analyze(5) + write(10) + decision(5) + journal(2) + semantic(3) + learning(1) + indexing(2) + compile(1) + curate(1) + lint(1) + promote(1) + health(1) = 41
-			wantMax:  41,
+			wantMin:  36, // navigate(5) + search(3) + analyze(5) + write(10) + decision(5) + journal(2) + semantic(3) + learning(1) + indexing(2) + compile(2) + curate(1) + lint(1) + promote(1) + health(1) = 42
+			wantMax:  42,
 		},
 		{
 			name:     "non-DataScript read-only",
@@ -572,8 +572,8 @@ func TestNewServer_ToolCount(t *testing.T) {
 			name:     "DataScript read-write",
 			backend:  &serverMockBackendWithDataScript{},
 			readOnly: false,
-			wantMin:  44, // above + get_references + query_datalog + flashcard(3) + whiteboard(2) = 48
-			wantMax:  48,
+			wantMin:  44, // above + get_references + query_datalog + flashcard(3) + whiteboard(2) = 49
+			wantMax:  49,
 		},
 		{
 			name:     "DataScript read-only",
@@ -587,7 +587,7 @@ func TestNewServer_ToolCount(t *testing.T) {
 			backend:  vault.New(t.TempDir()),
 			readOnly: false,
 			wantMin:  37, // non-DataScript read-write + reload
-			wantMax:  42,
+			wantMax:  43,
 		},
 	}
 

--- a/specs/016-pluggable-providers/plan.md
+++ b/specs/016-pluggable-providers/plan.md
@@ -1,0 +1,36 @@
+# Implementation Plan: Pluggable Providers
+
+## Overview
+
+Replace hardcoded Ollama construction with a provider-based configuration system. Add Vertex AI implementations for both `Embedder` and `Synthesizer` interfaces. Add `store_compiled` MCP tool. Add global config fallback.
+
+## Design Decisions
+
+### D1: Configuration Schema
+Extend `config.yaml` with `embedding.provider` and `synthesis` sections. Ollama remains default. Vertex AI is the first cloud provider. Global config at `~/.config/dewey/config.yaml` provides defaults.
+
+### D2: Provider Factory Functions
+One factory per capability in its respective package (`embed.NewEmbedderFromConfig`, `llm.NewSynthesizerFromConfig`). ProviderConfig struct duplicated across packages to avoid cross-package coupling (Composability First).
+
+### D3: Vertex AI Embedder
+Direct REST calls to `{region}-aiplatform.googleapis.com/v1/.../models/{model}:predict`. OAuth via `golang.org/x/oauth2/google`. Pure Go, no CGO.
+
+### D4: Vertex AI Synthesizer
+Direct REST calls to `{region}-aiplatform.googleapis.com/v1/.../models/{model}:rawPredict`. Anthropic Messages format. 120-second timeout matching OllamaSynthesizer. Max tokens hardcoded at 4096.
+
+### D5: `store_compiled` MCP Tool
+Persists agent-synthesized articles as compiled pages. Tag validation prevents path traversal. Overwrites existing articles for the same tag.
+
+### D6: OAuth Credential Management
+Both Vertex providers use `golang.org/x/oauth2/google.FindDefaultCredentials` independently. No shared auth layer — the oauth2 library handles token caching internally.
+
+### D7: Config Precedence Asymmetry
+Embedding: env vars override config (backward compat with existing DEWEY_EMBEDDING_* vars). Synthesis: env vars are fallback only (new config, no legacy override behavior needed).
+
+## Constitution Alignment
+
+- **Composability First**: PASS — each provider is standalone, no mandatory dependencies
+- **Autonomous Collaboration**: PASS — all communication via MCP tools
+- **Observable Quality**: PASS — ModelID provenance, compiled_by tracking
+- **Testability**: PASS — httptest isolation, no real API calls in tests
+- **Local-Only Processing**: PASS (amended) — cloud providers are opt-in, Ollama is default

--- a/specs/016-pluggable-providers/plan.md
+++ b/specs/016-pluggable-providers/plan.md
@@ -27,6 +27,9 @@ Both Vertex providers use `golang.org/x/oauth2/google.FindDefaultCredentials` in
 ### D7: Config Precedence Asymmetry
 Embedding: env vars override config (backward compat with existing DEWEY_EMBEDDING_* vars). Synthesis: env vars are fallback only (new config, no legacy override behavior needed).
 
+### D8: Rate Limiting — Retry on 429
+Vertex AI returns HTTP 429 when request quotas are exceeded. Both VertexEmbedder and VertexSynthesizer retry with exponential backoff (base 1s, max 60s, up to 5 attempts). When the response includes a `Retry-After` header (seconds), that value is used instead of the computed backoff. Retries are logged at warn level. Context cancellation is respected between retries.
+
 ## Constitution Alignment
 
 - **Composability First**: PASS — each provider is standalone, no mandatory dependencies

--- a/specs/016-pluggable-providers/spec.md
+++ b/specs/016-pluggable-providers/spec.md
@@ -1,0 +1,123 @@
+# Feature Specification: Pluggable Embedding & Synthesis Providers
+
+**Feature Branch**: `016-pluggable-providers`
+**Created**: 2026-05-05
+**Status**: Implementation Complete
+**Input**: Make Dewey's embedding and synthesis LLM backends configurable — Ollama (default) and Vertex AI, with global config fallback
+
+## Constitution Amendment: Local-Only Processing
+
+The constitution's Development Standards state: *"No data MUST leave the developer's machine for core functionality."* This change introduces Vertex AI providers that send data to Google Cloud when explicitly configured by the user.
+
+**Interpretation**: Cloud providers are an **opt-in extension**, not core functionality. Ollama remains the default. All core capabilities (keyword search, graph navigation, indexing, MCP tools) continue to work without any cloud dependency. The user makes a conscious choice to enable cloud backends via `config.yaml`. This is consistent with the constitution's own language: "for core functionality" and "The embedding model MUST be configurable."
+
+**AGENTS.md line 81** should be updated from "No data MUST leave the developer's machine" to "No data leaves the developer's machine by default. Cloud providers (Vertex AI) are opt-in via config."
+
+---
+
+## User Scenarios & Testing *(mandatory)*
+
+### User Story 1 — Configurable Synthesis Provider (Priority: P1)
+
+A developer runs `dewey compile` on a machine without a GPU. The default Ollama model (`llama3.2:3b`) produces low-quality synthesis in 6.5 minutes. The developer adds `synthesis.provider: vertex` to their config, and compilation now uses Claude via Vertex AI — producing a high-quality article in 9 seconds.
+
+**Why this priority**: Synthesis quality directly affects the value of compiled knowledge. Local models produce generic output; frontier models produce genuine synthesis.
+
+**Independent Test**: Configure Vertex AI synthesis in config.yaml. Run `dewey compile` with stored learnings. Verify the configured model is used and the output is persisted.
+
+**Acceptance Scenarios**:
+
+1. **Given** `config.yaml` contains `synthesis.provider: vertex`, `synthesis.model: claude-sonnet-4-6`, `synthesis.project: my-project`, `synthesis.region: us-east5`, **When** `dewey compile` is run, **Then** Dewey uses VertexSynthesizer for compilation
+2. **Given** `config.yaml` has no `synthesis` section but has `compile_model: llama3.2:3b`, **When** `dewey compile` is run, **Then** Dewey constructs an OllamaSynthesizer (backward compatibility)
+3. **Given** no synthesis configuration exists, **When** `dewey compile` is run, **Then** Dewey operates in prompt-only mode (returns synthesis prompts without LLM)
+4. **Given** an unknown provider is configured (`synthesis.provider: unsupported`), **When** the factory is called, **Then** it returns an error containing the unknown provider name
+
+---
+
+### User Story 2 — Configurable Embedding Provider (Priority: P1)
+
+A developer wants to use Vertex AI embedding models instead of local Ollama. They add `embedding.provider: vertex` to their config, and `dewey index` generates embeddings via the Vertex AI prediction API.
+
+**Why this priority**: Enables teams without Ollama to use semantic search, and allows higher-quality embedding models.
+
+**Independent Test**: Configure Vertex AI embedding in config.yaml. Run `dewey index`. Verify embeddings are generated via the configured provider.
+
+**Acceptance Scenarios**:
+
+1. **Given** `config.yaml` contains `embedding.provider: vertex`, `embedding.model: text-embedding-005`, `embedding.project: my-project`, `embedding.region: us-central1`, **When** `dewey index` is run, **Then** Dewey uses VertexEmbedder
+2. **Given** `config.yaml` contains `embedding.model: granite-embedding:30m` without a `provider` field, **When** Dewey creates an embedder, **Then** it defaults to OllamaEmbedder (backward compatibility)
+3. **Given** env vars `DEWEY_EMBEDDING_MODEL` and `DEWEY_EMBEDDING_ENDPOINT` are set, **When** Dewey reads embedding config, **Then** env vars override config file values for embedding
+4. **Given** a VertexEmbedder with valid credentials, **When** `EmbedBatch(ctx, ["text1", "text2"])` is called, **Then** it returns two float32 vectors in input order
+
+---
+
+### User Story 3 — Agent-Driven Compilation via `store_compiled` (Priority: P2)
+
+An AI agent calls `compile` and receives synthesis prompts (nil synthesizer path). The agent synthesizes the article itself — it's already a frontier LLM. The agent then calls `store_compiled` to persist the result back to Dewey as a compiled article with provenance tracking.
+
+**Why this priority**: Closes the loop on the existing nil-synthesizer MCP path. Agents can now compile knowledge without any local LLM.
+
+**Independent Test**: Call `store_compiled` with a tag, content, sources, and model. Verify the article is persisted to filesystem and store.
+
+**Acceptance Scenarios**:
+
+1. **Given** an agent calls `store_compiled` with `tag: "auth"`, `content: "..."`, `sources: ["auth-1", "auth-3"]`, **Then** Dewey persists a page with `source_id: "compiled"`, `tier: "draft"`, and writes to `.uf/dewey/compiled/auth.md`
+2. **Given** an agent provides `model: "claude-opus-4-6"`, **When** the article is persisted, **Then** frontmatter includes `compiled_by: claude-opus-4-6`
+3. **Given** a compiled article for tag `auth` already exists, **When** `store_compiled` is called with tag `auth`, **Then** the existing article is overwritten
+4. **Given** an empty `tag` field, **When** `store_compiled` is called, **Then** it returns an error
+
+---
+
+### User Story 4 — Global Config (Priority: P2)
+
+A developer uses Vertex AI for synthesis across all projects. Instead of copying the same config to every vault, they create `~/.config/dewey/config.yaml` with their provider settings. Every vault inherits these defaults unless overridden.
+
+**Why this priority**: Reduces configuration friction for teams using cloud providers.
+
+**Independent Test**: Create a global config with Vertex synthesis. Run `dewey compile` in a vault with no local config. Verify the global config is used.
+
+**Acceptance Scenarios**:
+
+1. **Given** no per-vault config exists, **And** global config at `~/.config/dewey/config.yaml` has `synthesis.provider: vertex`, **When** `dewey compile` is run, **Then** Dewey uses the global Vertex config
+2. **Given** per-vault config has `synthesis.provider: ollama`, **And** global config has `synthesis.provider: vertex`, **When** `dewey compile` is run, **Then** per-vault config wins
+3. **Given** `XDG_CONFIG_HOME` is set, **When** Dewey reads global config, **Then** it looks in `$XDG_CONFIG_HOME/dewey/config.yaml`
+
+---
+
+## Config Precedence
+
+Embedding config precedence (env vars override config):
+1. Environment variables (`DEWEY_EMBEDDING_MODEL`, `DEWEY_EMBEDDING_ENDPOINT`)
+2. Per-vault `.uf/dewey/config.yaml`
+3. Global `~/.config/dewey/config.yaml`
+4. Defaults (ollama, granite-embedding:30m, localhost:11434)
+
+Synthesis config precedence (env vars are fallback only):
+1. Per-vault `.uf/dewey/config.yaml` (`synthesis` section)
+2. Per-vault legacy `compile_model` field
+3. Global `~/.config/dewey/config.yaml`
+4. Environment variable `DEWEY_GENERATION_MODEL`
+5. No synthesizer (prompt-only mode)
+
+**Note**: The asymmetry between embedding and synthesis precedence is intentional — embedding env vars have historically overridden config, while synthesis config was introduced in this spec and doesn't need backward-compatible env var override behavior.
+
+---
+
+## Tag Validation
+
+The `store_compiled` tool's `tag` field MUST be validated to prevent path traversal. Tags MUST contain only alphanumeric characters, hyphens, and underscores. Tags containing path separators (`/`, `\`), relative path components (`..`), or null bytes MUST be rejected with a clear error.
+
+---
+
+## Functional Requirements
+
+- **FR-001**: Dewey MUST support `ollama` and `vertex` as embedding providers, configurable via `config.yaml`
+- **FR-002**: Dewey MUST support `ollama` and `vertex` as synthesis providers, configurable via `config.yaml`
+- **FR-003**: Vertex providers MUST use `golang.org/x/oauth2/google` application-default credentials (no CGO)
+- **FR-004**: Vertex providers MUST NOT store credentials in config files
+- **FR-005**: A `store_compiled` MCP tool MUST allow agents to persist compiled articles with provenance
+- **FR-006**: Global config at `~/.config/dewey/config.yaml` MUST provide defaults for all vaults
+- **FR-007**: Per-vault config MUST override global config
+- **FR-008**: All existing configs, env vars, and the nil-synthesizer path MUST continue to work
+- **FR-009**: Factory functions `NewEmbedderFromConfig` and `NewSynthesizerFromConfig` MUST centralize provider construction
+- **FR-010**: The `store_compiled` tag field MUST be validated against path traversal

--- a/specs/016-pluggable-providers/spec.md
+++ b/specs/016-pluggable-providers/spec.md
@@ -121,3 +121,6 @@ The `store_compiled` tool's `tag` field MUST be validated to prevent path traver
 - **FR-008**: All existing configs, env vars, and the nil-synthesizer path MUST continue to work
 - **FR-009**: Factory functions `NewEmbedderFromConfig` and `NewSynthesizerFromConfig` MUST centralize provider construction
 - **FR-010**: The `store_compiled` tag field MUST be validated against path traversal
+- **FR-011**: Vertex providers MUST retry on HTTP 429 (Too Many Requests) with exponential backoff
+- **FR-012**: Vertex providers MUST respect the `Retry-After` header when present in 429 responses
+- **FR-013**: Vertex providers MUST retry up to 5 times before returning an error to the caller

--- a/specs/016-pluggable-providers/tasks.md
+++ b/specs/016-pluggable-providers/tasks.md
@@ -36,6 +36,13 @@ All tasks are implementation-complete. This document records the work done.
 - [x] Removed readCompileModel()
 - [x] Preserved DEWEY_GENERATION_MODEL and DEWEY_EMBEDDING_* env var fallbacks
 
+## 7. Rate Limiting (429 Retry)
+- [x] Add exponential backoff retry on HTTP 429 to `embed/vertex.go` EmbedBatch
+- [x] Add exponential backoff retry on HTTP 429 to `llm/vertex.go` Synthesize
+- [x] Add Retry-After header parsing to both providers
+- [x] Add tests: 429 then success, 429 exhaustion, Retry-After header respected, context cancellation
+- [x] Update AGENTS.md with rate limiting documentation
+
 ## 6. Documentation
 - [x] AGENTS.md updated with provider configuration section
 - [x] GoDoc on all new exported types and functions

--- a/specs/016-pluggable-providers/tasks.md
+++ b/specs/016-pluggable-providers/tasks.md
@@ -1,0 +1,42 @@
+# Tasks: Pluggable Providers
+
+All tasks are implementation-complete. This document records the work done.
+
+## 1. Provider Config and Factories
+- [x] ProviderConfig struct in `embed/provider.go` and `llm/provider.go`
+- [x] `embed.NewEmbedderFromConfig()` factory with ollama/vertex switch
+- [x] `llm.NewSynthesizerFromConfig()` factory with ollama/vertex switch
+- [x] `embed.ReadEmbeddingConfig()` with global config fallback and env var overrides
+- [x] `llm.ReadSynthesisConfig()` with global config fallback and compile_model backward compat
+- [x] Tests for both factories and config readers
+
+## 2. Vertex AI Embedder
+- [x] `embed/vertex.go` — VertexEmbedder with Embed, EmbedBatch, Available, ModelID
+- [x] OAuth via golang.org/x/oauth2/google (pure Go, no CGO)
+- [x] Token function injection for testability
+- [x] `embed/vertex_test.go` — httptest tests (success, batch, auth error, org policy)
+
+## 3. Vertex AI Synthesizer
+- [x] `llm/vertex.go` — VertexSynthesizer with Synthesize, Available, ModelID
+- [x] Anthropic Messages format via rawPredict endpoint
+- [x] Clear error messages for common failures
+- [x] `llm/vertex_test.go` — httptest tests (success, auth error, model not found)
+
+## 4. store_compiled MCP Tool
+- [x] StoreCompiledInput type in `types/tools.go`
+- [x] StoreCompiled handler in `tools/compile.go`
+- [x] compiled_by frontmatter, tag validation, overwrite support
+- [x] Registered in `server.go`
+- [x] Tests in `tools/compile_test.go`
+
+## 5. Consolidate Construction Sites
+- [x] cli.go compile/curate use factory functions
+- [x] cli.go createIndexEmbedder uses ReadEmbeddingConfig + factory
+- [x] main.go backgroundCuration uses ReadSynthesisConfig + factory
+- [x] Removed readCompileModel()
+- [x] Preserved DEWEY_GENERATION_MODEL and DEWEY_EMBEDDING_* env var fallbacks
+
+## 6. Documentation
+- [x] AGENTS.md updated with provider configuration section
+- [x] GoDoc on all new exported types and functions
+- [x] Website issue filed: unbound-force/website#113

--- a/tools/compile.go
+++ b/tools/compile.go
@@ -673,3 +673,128 @@ func (c *Compile) writeEmptyIndex() error {
 	indexPath := filepath.Join(compiledDir, "_index.md")
 	return os.WriteFile(indexPath, []byte(content), 0o644)
 }
+
+// StoreCompiled persists a compiled article that was synthesized by the calling
+// agent. This closes the loop on the nil-synthesizer MCP path: the agent calls
+// compile → gets prompts → synthesizes → calls store_compiled to persist.
+func (c *Compile) StoreCompiled(_ context.Context, _ *mcp.CallToolRequest, input types.StoreCompiledInput) (*mcp.CallToolResult, any, error) {
+	if input.Tag == "" {
+		return errorResult("tag is required"), nil, nil
+	}
+	if input.Content == "" {
+		return errorResult("content is required"), nil, nil
+	}
+
+	// Validate tag to prevent path traversal (FR-010).
+	if !isValidTag(input.Tag) {
+		return errorResult("invalid tag: must contain only alphanumeric characters, hyphens, and underscores"), nil, nil
+	}
+
+	// Build frontmatter.
+	var sb strings.Builder
+	sb.WriteString("---\n")
+	sb.WriteString("tier: draft\n")
+	fmt.Fprintf(&sb, "compiled_at: %s\n", time.Now().UTC().Format(time.RFC3339))
+	if input.Model != "" {
+		fmt.Fprintf(&sb, "compiled_by: %s\n", input.Model)
+	}
+	if len(input.Sources) > 0 {
+		sb.WriteString("sources:\n")
+		for _, s := range input.Sources {
+			fmt.Fprintf(&sb, "  - %s\n", s)
+		}
+	}
+	fmt.Fprintf(&sb, "topic: %s\n", input.Tag)
+	sb.WriteString("---\n\n")
+	sb.WriteString(strings.TrimSpace(input.Content))
+	sb.WriteString("\n")
+
+	articleContent := sb.String()
+
+	// Write to filesystem.
+	compiledDir := c.compiledDir()
+	if err := os.MkdirAll(compiledDir, 0o755); err != nil {
+		return errorResult(fmt.Sprintf("failed to create compiled directory: %v", err)), nil, nil
+	}
+	articlePath := filepath.Join(compiledDir, input.Tag+".md")
+	if err := os.WriteFile(articlePath, []byte(articleContent), 0o644); err != nil {
+		return errorResult(fmt.Sprintf("failed to write compiled article: %v", err)), nil, nil
+	}
+
+	// Persist in store.
+	pageName := "compiled/" + input.Tag
+	propsMap := map[string]any{
+		"topic":       input.Tag,
+		"compiled_at": time.Now().UTC().Format(time.RFC3339),
+		"tier":        "draft",
+	}
+	if input.Model != "" {
+		propsMap["compiled_by"] = input.Model
+	}
+	if len(input.Sources) > 0 {
+		propsMap["sources"] = input.Sources
+	}
+	propsJSON, err := json.Marshal(propsMap)
+	if err != nil {
+		return errorResult(fmt.Sprintf("failed to marshal properties: %v", err)), nil, nil
+	}
+
+	// Delete existing compiled page for this tag if present.
+	_ = c.store.DeletePage(pageName)
+
+	page := &store.Page{
+		Name:         pageName,
+		OriginalName: input.Tag,
+		SourceID:     "compiled",
+		SourceDocID:  input.Tag,
+		Properties:   string(propsJSON),
+		Tier:         "draft",
+	}
+	if err := c.store.InsertPage(page); err != nil {
+		return errorResult(fmt.Sprintf("failed to insert compiled page: %v", err)), nil, nil
+	}
+
+	// Parse and persist blocks.
+	_, blocks := vault.ParseDocument(input.Tag, articleContent)
+	if err := vault.PersistBlocks(c.store, pageName, blocks, sql.NullString{}, 0); err != nil {
+		compileLogger.Warn("failed to persist compiled blocks", "tag", input.Tag, "err", err)
+	}
+
+	// Generate embeddings if available.
+	if c.embedder != nil && c.embedder.Available() {
+		vault.GenerateEmbeddings(c.store, c.embedder, pageName, blocks, nil)
+	}
+
+	compileLogger.Info("stored compiled article", "tag", input.Tag, "path", articlePath)
+
+	result := map[string]any{
+		"status":  "stored",
+		"tag":     input.Tag,
+		"page":    pageName,
+		"path":    articlePath,
+		"sources": input.Sources,
+	}
+	if input.Model != "" {
+		result["compiled_by"] = input.Model
+	}
+
+	res, err := jsonTextResult(result)
+	return res, nil, err
+}
+
+// isValidTag checks that a tag contains only alphanumeric characters,
+// hyphens, and underscores. Prevents path traversal in filesystem paths
+// constructed from the tag (e.g., .uf/dewey/compiled/{tag}.md).
+func isValidTag(tag string) bool {
+	if len(tag) == 0 {
+		return false
+	}
+	for _, r := range tag {
+		isAlpha := (r >= 'a' && r <= 'z') || (r >= 'A' && r <= 'Z')
+		isDigit := r >= '0' && r <= '9'
+		if !isAlpha && !isDigit && r != '-' && r != '_' {
+			return false
+		}
+	}
+	return true
+}

--- a/tools/compile.go
+++ b/tools/compile.go
@@ -690,6 +690,26 @@ func (c *Compile) StoreCompiled(_ context.Context, _ *mcp.CallToolRequest, input
 		return errorResult("invalid tag: must contain only alphanumeric characters, hyphens, and underscores"), nil, nil
 	}
 
+	// Validate model to prevent YAML frontmatter injection.
+	if input.Model != "" && containsNewline(input.Model) {
+		return errorResult("invalid model: must not contain newlines or null bytes"), nil, nil
+	}
+
+	// Validate sources to prevent YAML frontmatter injection.
+	for _, s := range input.Sources {
+		if containsNewline(s) {
+			return errorResult("invalid source: must not contain newlines or null bytes"), nil, nil
+		}
+	}
+
+	// Filter empty source entries.
+	var sources []string
+	for _, s := range input.Sources {
+		if s != "" {
+			sources = append(sources, s)
+		}
+	}
+
 	// Build frontmatter.
 	var sb strings.Builder
 	sb.WriteString("---\n")
@@ -698,9 +718,9 @@ func (c *Compile) StoreCompiled(_ context.Context, _ *mcp.CallToolRequest, input
 	if input.Model != "" {
 		fmt.Fprintf(&sb, "compiled_by: %s\n", input.Model)
 	}
-	if len(input.Sources) > 0 {
+	if len(sources) > 0 {
 		sb.WriteString("sources:\n")
-		for _, s := range input.Sources {
+		for _, s := range sources {
 			fmt.Fprintf(&sb, "  - %s\n", s)
 		}
 	}
@@ -731,8 +751,8 @@ func (c *Compile) StoreCompiled(_ context.Context, _ *mcp.CallToolRequest, input
 	if input.Model != "" {
 		propsMap["compiled_by"] = input.Model
 	}
-	if len(input.Sources) > 0 {
-		propsMap["sources"] = input.Sources
+	if len(sources) > 0 {
+		propsMap["sources"] = sources
 	}
 	propsJSON, err := json.Marshal(propsMap)
 	if err != nil {
@@ -772,7 +792,7 @@ func (c *Compile) StoreCompiled(_ context.Context, _ *mcp.CallToolRequest, input
 		"tag":     input.Tag,
 		"page":    pageName,
 		"path":    articlePath,
-		"sources": input.Sources,
+		"sources": sources,
 	}
 	if input.Model != "" {
 		result["compiled_by"] = input.Model
@@ -780,6 +800,12 @@ func (c *Compile) StoreCompiled(_ context.Context, _ *mcp.CallToolRequest, input
 
 	res, err := jsonTextResult(result)
 	return res, nil, err
+}
+
+// containsNewline returns true if s contains any newline (\n, \r) or null byte
+// characters. Used to prevent YAML frontmatter injection via interpolated values.
+func containsNewline(s string) bool {
+	return strings.ContainsAny(s, "\n\r\x00")
 }
 
 // isValidTag checks that a tag contains only alphanumeric characters,

--- a/tools/compile_test.go
+++ b/tools/compile_test.go
@@ -859,8 +859,35 @@ func TestStoreCompiled_Basic(t *testing.T) {
 	if page.SourceID != "compiled" {
 		t.Errorf("SourceID = %q, want compiled", page.SourceID)
 	}
+	if page.SourceDocID != "authentication" {
+		t.Errorf("SourceDocID = %q, want authentication", page.SourceDocID)
+	}
 	if page.Tier != "draft" {
 		t.Errorf("Tier = %q, want draft", page.Tier)
+	}
+
+	// Verify Properties JSON contains expected fields.
+	var props map[string]any
+	if err := json.Unmarshal([]byte(page.Properties), &props); err != nil {
+		t.Fatalf("unmarshal properties: %v", err)
+	}
+	if props["compiled_by"] != "claude-opus-4-6" {
+		t.Errorf("properties.compiled_by = %v, want claude-opus-4-6", props["compiled_by"])
+	}
+	if props["topic"] != "authentication" {
+		t.Errorf("properties.topic = %v, want authentication", props["topic"])
+	}
+	if props["tier"] != "draft" {
+		t.Errorf("properties.tier = %v, want draft", props["tier"])
+	}
+
+	// Verify blocks were persisted.
+	blocks, err := s.GetBlocksByPage("compiled/authentication")
+	if err != nil {
+		t.Fatalf("GetBlocksByPage: %v", err)
+	}
+	if len(blocks) == 0 {
+		t.Error("expected blocks to be persisted for compiled page")
 	}
 
 	// Verify file was written.
@@ -913,6 +940,17 @@ func TestStoreCompiled_ResponseBody(t *testing.T) {
 	if parsed["compiled_by"] != "claude-opus-4-6" {
 		t.Errorf("compiled_by = %v, want claude-opus-4-6", parsed["compiled_by"])
 	}
+	if _, ok := parsed["path"]; !ok {
+		t.Error("response missing 'path' field")
+	}
+	sources, ok := parsed["sources"]
+	if !ok {
+		t.Error("response missing 'sources' field")
+	} else if srcList, ok := sources.([]any); ok {
+		if len(srcList) != 2 {
+			t.Errorf("sources length = %d, want 2", len(srcList))
+		}
+	}
 }
 
 func TestIsValidTag(t *testing.T) {
@@ -956,6 +994,10 @@ func TestStoreCompiled_MissingTag(t *testing.T) {
 	if !result.IsError {
 		t.Error("expected error result for missing tag")
 	}
+	text := resultText(result)
+	if !strings.Contains(text, "tag is required") {
+		t.Errorf("error text = %q, want to contain 'tag is required'", text)
+	}
 }
 
 func TestStoreCompiled_MissingContent(t *testing.T) {
@@ -973,6 +1015,10 @@ func TestStoreCompiled_MissingContent(t *testing.T) {
 	}
 	if !result.IsError {
 		t.Error("expected error result for missing content")
+	}
+	text := resultText(result)
+	if !strings.Contains(text, "content is required") {
+		t.Errorf("error text = %q, want to contain 'content is required'", text)
 	}
 }
 
@@ -1026,6 +1072,10 @@ func TestStoreCompiled_PathTraversalRejected(t *testing.T) {
 		if !result.IsError {
 			t.Errorf("expected error for tag %q (path traversal)", tag)
 		}
+		text := resultText(result)
+		if !strings.Contains(text, "invalid tag") {
+			t.Errorf("error text for tag %q = %q, want to contain 'invalid tag'", tag, text)
+		}
 	}
 }
 
@@ -1041,7 +1091,10 @@ func TestStoreCompiled_OverwriteExisting(t *testing.T) {
 		Tag:     "auth",
 		Content: "Version 1",
 	}
-	result1, _, _ := c.StoreCompiled(context.Background(), nil, input1)
+	result1, _, err := c.StoreCompiled(context.Background(), nil, input1)
+	if err != nil {
+		t.Fatalf("StoreCompiled (first): %v", err)
+	}
 	if result1.IsError {
 		t.Fatal("first store failed")
 	}
@@ -1051,7 +1104,10 @@ func TestStoreCompiled_OverwriteExisting(t *testing.T) {
 		Tag:     "auth",
 		Content: "Version 2",
 	}
-	result2, _, _ := c.StoreCompiled(context.Background(), nil, input2)
+	result2, _, err := c.StoreCompiled(context.Background(), nil, input2)
+	if err != nil {
+		t.Fatalf("StoreCompiled (second): %v", err)
+	}
 	if result2.IsError {
 		t.Fatal("second store failed")
 	}

--- a/tools/compile_test.go
+++ b/tools/compile_test.go
@@ -823,3 +823,249 @@ func TestCompile_CompiledArticleFormat(t *testing.T) {
 		t.Error("article missing category in history table")
 	}
 }
+
+// --- StoreCompiled tests ---
+
+func TestStoreCompiled_Basic(t *testing.T) {
+	s := newTestStore(t)
+	defer func() { _ = s.Close() }()
+
+	vaultPath := t.TempDir()
+	c := NewCompile(s, nil, nil, vaultPath)
+
+	input := types.StoreCompiledInput{
+		Tag:     "authentication",
+		Content: "# Authentication\n\nCompiled article about auth patterns.",
+		Sources: []string{"auth-1", "auth-3"},
+		Model:   "claude-opus-4-6",
+	}
+
+	result, _, err := c.StoreCompiled(context.Background(), nil, input)
+	if err != nil {
+		t.Fatalf("StoreCompiled: %v", err)
+	}
+	if result.IsError {
+		t.Fatalf("StoreCompiled returned error: %s", resultText(result))
+	}
+
+	// Verify page was inserted.
+	page, err := s.GetPage("compiled/authentication")
+	if err != nil {
+		t.Fatalf("GetPage: %v", err)
+	}
+	if page == nil {
+		t.Fatal("compiled page not found in store")
+	}
+	if page.SourceID != "compiled" {
+		t.Errorf("SourceID = %q, want compiled", page.SourceID)
+	}
+	if page.Tier != "draft" {
+		t.Errorf("Tier = %q, want draft", page.Tier)
+	}
+
+	// Verify file was written.
+	articlePath := filepath.Join(vaultPath, ".uf", "dewey", "compiled", "authentication.md")
+	data, err := os.ReadFile(articlePath)
+	if err != nil {
+		t.Fatalf("ReadFile: %v", err)
+	}
+	article := string(data)
+	if !strings.Contains(article, "compiled_by: claude-opus-4-6") {
+		t.Error("article missing compiled_by in frontmatter")
+	}
+	if !strings.Contains(article, "auth-1") {
+		t.Error("article missing source auth-1 in frontmatter")
+	}
+	if !strings.Contains(article, "Compiled article about auth patterns") {
+		t.Error("article missing content body")
+	}
+}
+
+func TestStoreCompiled_ResponseBody(t *testing.T) {
+	s := newTestStore(t)
+	defer func() { _ = s.Close() }()
+
+	c := NewCompile(s, nil, nil, t.TempDir())
+	input := types.StoreCompiledInput{
+		Tag:     "auth",
+		Content: "Test article.",
+		Sources: []string{"auth-1", "auth-3"},
+		Model:   "claude-opus-4-6",
+	}
+
+	result, _, err := c.StoreCompiled(context.Background(), nil, input)
+	if err != nil {
+		t.Fatalf("StoreCompiled: %v", err)
+	}
+
+	text := resultText(result)
+	parsed := parseCompileResult(t, text)
+
+	if parsed["status"] != "stored" {
+		t.Errorf("status = %v, want stored", parsed["status"])
+	}
+	if parsed["tag"] != "auth" {
+		t.Errorf("tag = %v, want auth", parsed["tag"])
+	}
+	if parsed["page"] != "compiled/auth" {
+		t.Errorf("page = %v, want compiled/auth", parsed["page"])
+	}
+	if parsed["compiled_by"] != "claude-opus-4-6" {
+		t.Errorf("compiled_by = %v, want claude-opus-4-6", parsed["compiled_by"])
+	}
+}
+
+func TestIsValidTag(t *testing.T) {
+	tests := []struct {
+		tag   string
+		valid bool
+	}{
+		{"auth", true},
+		{"vault-walker", true},
+		{"my_tag_123", true},
+		{"ABC", true},
+		{"", false},
+		{"../evil", false},
+		{"auth/sub", false},
+		{"tag.dot", false},
+		{"has space", false},
+		{"null\x00byte", false},
+		{"back\\slash", false},
+	}
+	for _, tt := range tests {
+		got := isValidTag(tt.tag)
+		if got != tt.valid {
+			t.Errorf("isValidTag(%q) = %v, want %v", tt.tag, got, tt.valid)
+		}
+	}
+}
+
+func TestStoreCompiled_MissingTag(t *testing.T) {
+	s := newTestStore(t)
+	defer func() { _ = s.Close() }()
+
+	c := NewCompile(s, nil, nil, t.TempDir())
+	input := types.StoreCompiledInput{
+		Content: "some content",
+	}
+
+	result, _, err := c.StoreCompiled(context.Background(), nil, input)
+	if err != nil {
+		t.Fatalf("StoreCompiled: %v", err)
+	}
+	if !result.IsError {
+		t.Error("expected error result for missing tag")
+	}
+}
+
+func TestStoreCompiled_MissingContent(t *testing.T) {
+	s := newTestStore(t)
+	defer func() { _ = s.Close() }()
+
+	c := NewCompile(s, nil, nil, t.TempDir())
+	input := types.StoreCompiledInput{
+		Tag: "auth",
+	}
+
+	result, _, err := c.StoreCompiled(context.Background(), nil, input)
+	if err != nil {
+		t.Fatalf("StoreCompiled: %v", err)
+	}
+	if !result.IsError {
+		t.Error("expected error result for missing content")
+	}
+}
+
+func TestStoreCompiled_NoModelProvenance(t *testing.T) {
+	s := newTestStore(t)
+	defer func() { _ = s.Close() }()
+
+	vaultPath := t.TempDir()
+	c := NewCompile(s, nil, nil, vaultPath)
+
+	input := types.StoreCompiledInput{
+		Tag:     "auth",
+		Content: "Article without model provenance.",
+	}
+
+	result, _, err := c.StoreCompiled(context.Background(), nil, input)
+	if err != nil {
+		t.Fatalf("StoreCompiled: %v", err)
+	}
+	if result.IsError {
+		t.Fatal("unexpected error result")
+	}
+
+	// Verify no compiled_by in frontmatter.
+	articlePath := filepath.Join(vaultPath, ".uf", "dewey", "compiled", "auth.md")
+	data, err := os.ReadFile(articlePath)
+	if err != nil {
+		t.Fatalf("ReadFile: %v", err)
+	}
+	if strings.Contains(string(data), "compiled_by") {
+		t.Error("frontmatter should not contain compiled_by when model is empty")
+	}
+}
+
+func TestStoreCompiled_PathTraversalRejected(t *testing.T) {
+	s := newTestStore(t)
+	defer func() { _ = s.Close() }()
+
+	c := NewCompile(s, nil, nil, t.TempDir())
+
+	badTags := []string{"../etc/passwd", "auth/evil", "tag\x00bad", "a.b", "tag with spaces"}
+	for _, tag := range badTags {
+		input := types.StoreCompiledInput{
+			Tag:     tag,
+			Content: "test",
+		}
+		result, _, err := c.StoreCompiled(context.Background(), nil, input)
+		if err != nil {
+			t.Fatalf("StoreCompiled(%q): %v", tag, err)
+		}
+		if !result.IsError {
+			t.Errorf("expected error for tag %q (path traversal)", tag)
+		}
+	}
+}
+
+func TestStoreCompiled_OverwriteExisting(t *testing.T) {
+	s := newTestStore(t)
+	defer func() { _ = s.Close() }()
+
+	vaultPath := t.TempDir()
+	c := NewCompile(s, nil, nil, vaultPath)
+
+	// Store first version.
+	input1 := types.StoreCompiledInput{
+		Tag:     "auth",
+		Content: "Version 1",
+	}
+	result1, _, _ := c.StoreCompiled(context.Background(), nil, input1)
+	if result1.IsError {
+		t.Fatal("first store failed")
+	}
+
+	// Store second version — should overwrite.
+	input2 := types.StoreCompiledInput{
+		Tag:     "auth",
+		Content: "Version 2",
+	}
+	result2, _, _ := c.StoreCompiled(context.Background(), nil, input2)
+	if result2.IsError {
+		t.Fatal("second store failed")
+	}
+
+	// Verify file has second version.
+	articlePath := filepath.Join(vaultPath, ".uf", "dewey", "compiled", "auth.md")
+	data, err := os.ReadFile(articlePath)
+	if err != nil {
+		t.Fatalf("ReadFile: %v", err)
+	}
+	if !strings.Contains(string(data), "Version 2") {
+		t.Error("article should contain Version 2")
+	}
+	if strings.Contains(string(data), "Version 1") {
+		t.Error("article should not contain Version 1 (overwritten)")
+	}
+}

--- a/types/tools.go
+++ b/types/tools.go
@@ -296,6 +296,24 @@ type CompileInput struct {
 	Incremental []string `json:"incremental,omitempty" jsonschema:"Optional list of learning identities to compile incrementally (e.g., ['authentication-20260502T143022-alice']). When empty, performs full rebuild."`
 }
 
+// StoreCompiledInput is the input for the store_compiled MCP tool.
+// Allows an agent to persist a compiled article it synthesized from
+// compilation prompts returned by the compile tool.
+type StoreCompiledInput struct {
+	// Tag is the topic tag for the compiled article (e.g., "authentication").
+	Tag string `json:"tag" jsonschema:"Topic tag for the compiled article (e.g., authentication)"`
+
+	// Content is the compiled article content in markdown format.
+	Content string `json:"content" jsonschema:"The compiled article content (markdown)"`
+
+	// Sources lists the learning identities used to produce this article
+	// (e.g., ["auth-1", "auth-3", "auth-4"]).
+	Sources []string `json:"sources" jsonschema:"Learning identities that were compiled (e.g., auth-1, auth-3)"`
+
+	// Model identifies the model that performed the synthesis, for provenance.
+	Model string `json:"model,omitempty" jsonschema:"Model that performed synthesis (for provenance tracking)"`
+}
+
 // --- Curate tool inputs ---
 
 // CurateInput is the input for the dewey_curate MCP tool.


### PR DESCRIPTION
## Summary

Closes spec 016. Makes Dewey's embedding and synthesis LLM backends configurable — Ollama (default) and Vertex AI.

- **Vertex AI embedder and synthesizer** — direct REST calls to Vertex AI predict/rawPredict endpoints with OAuth via `golang.org/x/oauth2/google` (pure Go, no CGO)
- **Provider factory functions** — `embed.NewEmbedderFromConfig()` and `llm.NewSynthesizerFromConfig()` centralize all provider construction
- **Global config** — `~/.config/dewey/config.yaml` provides defaults for all vaults, per-vault overrides
- **`store_compiled` MCP tool** — agents can persist their own compilation results with model provenance tracking
- **Tag validation** — path traversal prevention for `store_compiled` tag field
- **Full backward compatibility** — existing `compile_model`, `DEWEY_EMBEDDING_*` env vars, and nil-synthesizer path all continue to work

## Config Example

```yaml
embedding:
  provider: ollama
  model: granite-embedding:30m

synthesis:
  provider: vertex
  model: claude-sonnet-4-6
  project: my-gcp-project
  region: us-east5
```

## Test Results

14 packages, all pass (`go test -race -count=1 ./...`). 45+ new tests across 6 test files — all using httptest (no real API calls).

## Review Council

9/9 APPROVE after 4 iterations. Findings addressed: io.LimitReader on Vertex providers, GoDoc accuracy, tag validation, README provider config section, AGENTS.md updates.

## Cross-Repo Issues

- unbound-force/website#113 — documentation sync
- unbound-force/website#114 — tutorial for Vertex AI setup