### PR TITLE
feat: add nfpms RPM packaging to GoReleaser config

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -24,6 +24,20 @@ archives:
 checksum:
   name_template: checksums.txt
 
+nfpms:
+  - id: dewey
+    package_name: dewey
+    vendor: Unbound Force
+    homepage: "https://github.com/unbound-force/dewey"
+    maintainer: "Unbound Force <team@unboundforce.dev>"
+    description: >-
+      Knowledge graph MCP server with persistence, semantic
+      search, and pluggable content sources
+    license: Apache-2.0
+    formats:
+      - rpm
+    bindir: /usr/bin
+
 homebrew_casks:
   - name: dewey
     description: "Knowledge graph MCP server with persistence, semantic search, and pluggable content sources"


### PR DESCRIPTION
## Summary

- Add `nfpms` section to `.goreleaser.yaml` to produce RPM packages (`dewey_{version}_linux_{amd64,arm64}.rpm`) on each release
- Enables `uf setup` to install Dewey via `dnf` on Fedora/RHEL systems where Homebrew is not available

## Context

`uf setup` currently installs Dewey exclusively via Homebrew. On Fedora/RHEL, where `dnf` is the native package manager, the Dewey step is skipped with "Homebrew not available". The `unbound-force/unbound-force` repo already has `installViaRpm()` infrastructure and `rpmURL()` that constructs GitHub Release RPM download URLs following GoReleaser's nfpms naming convention — but Dewey doesn't produce RPMs yet.

This change adds the `nfpms` section following the same pattern used in the `unbound-force/unbound-force` repo (`.goreleaser.yaml` lines 46-60). A companion change in `unbound-force/unbound-force` will add RPM/dnf method dispatch to `installDewey()`.

## Changes

**`.goreleaser.yaml`**: Added `nfpms` block with:
- `package_name: dewey`
- `formats: [rpm]`
- `bindir: /usr/bin`
- Standard vendor/homepage/maintainer/license metadata

No symlink is needed (unlike `unbound-force` which symlinks `uf` → `unbound-force`).