### PR TITLE
chore: add CI preflight gate to release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,20 +1,161 @@
 name: Release
 
 on:
-  push:
-    tags:
-      - "v*"
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: 'Release tag (e.g., v0.15.0)'
+        required: true
+        type: string
 
-permissions:
-  contents: write
+permissions: {}
+
+concurrency:
+  group: release-${{ github.ref }}
+  cancel-in-progress: false
 
 jobs:
-  release:
+  preflight:
     runs-on: ubuntu-latest
-    timeout-minutes: 45
+    permissions:
+      contents: write
+      checks: read
+    timeout-minutes: 10
+    env:
+      RELEASE_TAG: ${{ inputs.tag }}
     outputs:
       has_signing_secrets: ${{ steps.check-secrets.outputs.has_secrets }}
     steps:
+      - name: Checkout
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        with:
+          fetch-depth: 0
+
+      - name: Validate branch
+        env:
+          BRANCH_REF: ${{ github.ref }}
+        run: |
+          if [ "$BRANCH_REF" != "refs/heads/main" ]; then
+            echo "::error::Releases MUST be triggered from the main branch. Current branch: $BRANCH_REF. Use the GitHub Actions UI branch dropdown to select 'main'."
+            exit 1
+          fi
+          echo "Branch validation passed: releasing from main"
+
+      - name: Validate tag format
+        run: |
+          if ! echo "$RELEASE_TAG" | grep -qE '^v[0-9]+\.[0-9]+\.[0-9]+$'; then
+            echo "::error::Invalid tag format: '$RELEASE_TAG'. Must match vMAJOR.MINOR.PATCH (e.g., v0.15.0)."
+            exit 1
+          fi
+          echo "Tag format valid: $RELEASE_TAG"
+
+      - name: Check tag uniqueness
+        run: |
+          EXISTING_SHA=$(git ls-remote --tags origin "refs/tags/${RELEASE_TAG}" | awk '{print $1}')
+          if [ -n "$EXISTING_SHA" ]; then
+            HEAD_SHA=$(git rev-parse HEAD)
+            # Resolve annotated tag to its commit (dereference ^{})
+            EXISTING_COMMIT=$(git ls-remote --tags origin "refs/tags/${RELEASE_TAG}^{}" | awk '{print $1}')
+            # If no dereferenced entry, it's a lightweight tag — use EXISTING_SHA directly
+            [ -z "$EXISTING_COMMIT" ] && EXISTING_COMMIT="$EXISTING_SHA"
+            if [ "$EXISTING_COMMIT" = "$HEAD_SHA" ]; then
+              echo "Tag '$RELEASE_TAG' already exists and points to HEAD (idempotent re-run). Skipping uniqueness check."
+            else
+              echo "::error::Tag '$RELEASE_TAG' already exists and points to commit $EXISTING_COMMIT, not HEAD ($HEAD_SHA). Choose a different version or delete the existing tag."
+              exit 1
+            fi
+          else
+            echo "Tag '$RELEASE_TAG' does not exist yet."
+          fi
+
+      - name: Verify semver ordering
+        # sort -V is a GNU coreutils extension, available on ubuntu-latest runners
+        run: |
+          # Exclude RELEASE_TAG from the list to support idempotent re-runs
+          # (tag may already exist from a previous preflight that succeeded
+          # before GoReleaser failed).
+          LATEST=$(git tag -l 'v[0-9]*' --sort=-v:refname | grep -v "^${RELEASE_TAG}$" | head -1)
+          if [ -z "$LATEST" ]; then
+            echo "No existing tags found. First release."
+            exit 0
+          fi
+          echo "Latest existing tag: $LATEST"
+          # Compare using sort -V: if TAG sorts after LATEST, it is greater
+          HIGHER=$(printf '%s\n%s' "$LATEST" "$RELEASE_TAG" | sort -V | tail -1)
+          if [ "$HIGHER" = "$LATEST" ]; then
+            echo "::error::Tag '$RELEASE_TAG' is not greater than latest release '$LATEST'."
+            exit 1
+          fi
+          echo "Version ordering valid: $RELEASE_TAG > $LATEST"
+
+      - name: Verify CI passed on HEAD
+        # Check names must match job IDs/names in ci.yml and mega-linter.yml
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_REPO: ${{ github.repository }}
+        run: |
+          HEAD_SHA=$(git rev-parse HEAD)
+          echo "Checking CI status for commit $HEAD_SHA"
+
+          FAILED=false
+
+          REQUIRED_CHECKS=(
+            "build-and-test"
+            "MegaLinter"
+          )
+
+          for CHECK_NAME in "${REQUIRED_CHECKS[@]}"; do
+            STATUS=$(gh api "repos/${GH_REPO}/commits/${HEAD_SHA}/check-runs" \
+              --jq ".check_runs | map(select(.name == \"${CHECK_NAME}\")) | sort_by(.started_at) | last | .conclusion" \
+              2>/dev/null)
+            if [ -z "$STATUS" ] || [ "$STATUS" = "null" ]; then
+              echo "::error::Required check '${CHECK_NAME}' not found on commit $HEAD_SHA. Verify CI ran on this commit before releasing."
+              FAILED=true
+            elif [ "$STATUS" != "success" ]; then
+              echo "::error::Required check '${CHECK_NAME}' has not passed (status: ${STATUS}). Push to main and wait for CI before releasing."
+              FAILED=true
+            else
+              echo "  ✓ ${CHECK_NAME}: success"
+            fi
+          done
+
+          if [ "$FAILED" = "true" ]; then
+            exit 1
+          fi
+
+          echo "All required CI checks passed."
+
+      - name: Verify unreleased commits
+        run: |
+          # Exclude RELEASE_TAG from the list to support idempotent re-runs
+          LATEST=$(git tag -l 'v[0-9]*' --sort=-v:refname | grep -v "^${RELEASE_TAG}$" | head -1)
+          if [ -z "$LATEST" ]; then
+            COUNT=$(git rev-list --count HEAD)
+          else
+            COUNT=$(git rev-list --count "${LATEST}..HEAD")
+          fi
+          if [ "$COUNT" -eq 0 ]; then
+            echo "::error::No unreleased commits since ${LATEST:-initial commit}. Nothing to release."
+            exit 1
+          fi
+          echo "$COUNT commit(s) since ${LATEST:-initial commit}."
+
+      - name: Create and push tag
+        run: |
+          # Skip if tag was already created (e.g., re-run after
+          # partial failure or manual tag via GitHub API).
+          if git ls-remote --tags origin | grep -q "refs/tags/${RELEASE_TAG}$"; then
+            echo "Tag $RELEASE_TAG already exists, skipping creation."
+            exit 0
+          fi
+          # Annotated tags require a committer identity on the
+          # CI runner (git tag -a uses GIT_COMMITTER_NAME/EMAIL).
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git tag -a "$RELEASE_TAG" -m "$RELEASE_TAG"
+          git push origin "$RELEASE_TAG"
+          echo "Created and pushed tag: $RELEASE_TAG"
+
       - name: Check signing secrets
         id: check-secrets
         run: |
@@ -26,9 +167,21 @@ jobs:
         env:
           MACOS_SIGN_P12: ${{ secrets.MACOS_SIGN_P12 }}
 
+  release:
+    runs-on: ubuntu-latest
+    needs: preflight
+    permissions:
+      contents: write
+    timeout-minutes: 45
+    env:
+      RELEASE_TAG: ${{ inputs.tag }}
+    outputs:
+      has_signing_secrets: ${{ needs.preflight.outputs.has_signing_secrets }}
+    steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
           fetch-depth: 0
+          ref: ${{ inputs.tag }}
 
       - uses: actions/setup-go@f111f3307d8850f501ac008e886eec1fd1932a34 # v5.3.0
         with:
@@ -45,7 +198,7 @@ jobs:
         # GoReleaser writes dist/homebrew/Casks/dewey.rb with skip_upload: true.
         # Upload it so the sign-macos job can download and patch darwin checksums.
         run: |
-          gh release upload "${GITHUB_REF_NAME}" \
+          gh release upload "$RELEASE_TAG" \
             --repo "$GITHUB_REPOSITORY" \
             dist/homebrew/Casks/dewey.rb \
             --clobber
@@ -56,7 +209,11 @@ jobs:
     runs-on: macos-latest
     needs: release
     if: ${{ needs.release.outputs.has_signing_secrets == 'true' }}
+    permissions:
+      contents: write
     timeout-minutes: 30
+    env:
+      RELEASE_TAG: ${{ inputs.tag }}
     steps:
       - name: Import certificate into Keychain
         run: |
@@ -85,10 +242,10 @@ jobs:
       - name: Download darwin archives
         run: |
           set -euo pipefail
-          gh release download "${GITHUB_REF_NAME}" --repo "$GITHUB_REPOSITORY" --pattern "dewey_*_darwin_*.tar.gz" --dir ./artifacts
+          gh release download "$RELEASE_TAG" --repo "$GITHUB_REPOSITORY" --pattern "dewey_*_darwin_*.tar.gz" --dir ./artifacts
 
           # Verify both expected archives were downloaded
-          VERSION="${GITHUB_REF_NAME#v}"
+          VERSION="${RELEASE_TAG#v}"
           for arch in amd64 arm64; do
             if [ ! -f "./artifacts/dewey_${VERSION}_darwin_${arch}.tar.gz" ]; then
               echo "::error::Expected darwin_${arch} archive not found after download"
@@ -142,10 +299,10 @@ jobs:
         run: |
           set -euo pipefail
           # Upload signed darwin archives (replaces unsigned)
-          gh release upload "${GITHUB_REF_NAME}" --repo "$GITHUB_REPOSITORY" ./signed/*.tar.gz --clobber
+          gh release upload "$RELEASE_TAG" --repo "$GITHUB_REPOSITORY" ./signed/*.tar.gz --clobber
 
           # Download existing checksums
-          gh release download "${GITHUB_REF_NAME}" --repo "$GITHUB_REPOSITORY" --pattern "checksums.txt" --dir ./
+          gh release download "$RELEASE_TAG" --repo "$GITHUB_REPOSITORY" --pattern "checksums.txt" --dir ./
 
           # Remove darwin lines from checksums (keep linux and other lines)
           grep -v darwin checksums.txt > checksums_updated.txt || true
@@ -157,14 +314,14 @@ jobs:
 
           # Replace checksums file
           mv checksums_updated.txt checksums.txt
-          gh release upload "${GITHUB_REF_NAME}" --repo "$GITHUB_REPOSITORY" checksums.txt --clobber
+          gh release upload "$RELEASE_TAG" --repo "$GITHUB_REPOSITORY" checksums.txt --clobber
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Update Homebrew cask
         run: |
           set -euo pipefail
-          VERSION="${GITHUB_REF_NAME#v}"
+          VERSION="${RELEASE_TAG#v}"
 
           # Verify signed archives exist before computing checksums
           for arch in arm64 amd64; do
@@ -182,7 +339,7 @@ jobs:
           echo "darwin_amd64 SHA256: $AMD64_SHA"
 
           # Download the GoReleaser-generated cask (uploaded by the release job)
-          gh release download "${GITHUB_REF_NAME}" --repo "$GITHUB_REPOSITORY" --pattern "dewey.rb" --dir ./cask-staging
+          gh release download "$RELEASE_TAG" --repo "$GITHUB_REPOSITORY" --pattern "dewey.rb" --dir ./cask-staging
           CASK_FILE="./cask-staging/dewey.rb"
 
           # Extract original unsigned darwin checksums by section context.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -533,7 +533,7 @@ Three GitHub Actions workflows:
 
 1. **CI** (`.github/workflows/ci.yml`): Build + vet + test with `-race -count=1` + Gaze quality report with threshold enforcement on push/PR.
 2. **MegaLinter** (`.github/workflows/mega-linter.yml`): Runs golangci-lint, markdownlint, yamllint, and gitleaks on push/PR to `main`. Auto-commits lint fixes to PR branches.
-3. **Release** (`.github/workflows/release.yml`): Triggered on `v*` tag push. Runs GoReleaser to build cross-platform binaries (darwin/linux x amd64/arm64), create GitHub Releases, and update the Homebrew formula in `unbound-force/homebrew-tap`.
+3. **Release** (`.github/workflows/release.yml`): Triggered via `workflow_dispatch` with a `tag` input (e.g., `gh workflow run release.yml -f tag=v1.2.3`). Runs a `preflight` job that validates branch (main-only), tag format, tag uniqueness, semver ordering, CI status via Checks API (`build-and-test` + `MegaLinter`), and unreleased commits before creating the tag. Then runs GoReleaser to build cross-platform binaries (darwin/linux x amd64/arm64), create GitHub Releases, and update the Homebrew formula in `unbound-force/homebrew-tap`.
 
 ## Sibling Repositories
 

--- a/openspec/changes/release-ci-gate/.openspec.yaml
+++ b/openspec/changes/release-ci-gate/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: unbound-force
+created: 2026-06-16

--- a/openspec/changes/release-ci-gate/design.md
+++ b/openspec/changes/release-ci-gate/design.md
@@ -1,0 +1,106 @@
+## Context
+
+Dewey's `release.yml` triggers on `push.tags: v*` and immediately runs GoReleaser. There is no verification that the tagged commit passed CI. The `unbound-force/unbound-force` repository has a battle-tested `preflight` job pattern that validates CI status, tag format, semver ordering, and unreleased commits before creating the tag and proceeding to artifact publishing.
+
+This design adapts that proven pattern for dewey's simpler CI setup (two workflows: CI and MegaLinter, no security scanners).
+
+## Goals / Non-Goals
+
+### Goals
+- Prevent release of binaries from commits that haven't passed CI
+- Validate tag format, uniqueness, and semver ordering before creating the tag
+- Verify unreleased commits exist to prevent empty releases
+- Enforce releases only from the `main` branch
+- Adopt `workflow_dispatch` trigger so the tag is created by the workflow, not pushed manually
+- Match the reference implementation from `unbound-force/unbound-force` for consistency across the org
+
+### Non-Goals
+- Adding SBOM generation (Syft) or binary signing (Cosign) -- separate concern, separate issue
+- Adding security scanners (OSV-Scanner, Trivy) -- dewey doesn't have these configured yet
+- Changing the GoReleaser configuration or build matrix
+- Modifying the macOS signing/notarization flow beyond updating tag references and permissions
+
+## Decisions
+
+### D1: Use `workflow_dispatch` instead of `push.tags`
+
+**Decision**: Replace the `push.tags: v*` trigger with `workflow_dispatch` with a `tag` string input.
+
+**Rationale**: With `push.tags`, the tag must exist before the workflow runs, so there's no opportunity to validate it first. With `workflow_dispatch`, the workflow validates everything and then creates the tag itself -- ensuring only verified releases get tagged. This matches the org-wide pattern.
+
+**Trade-off**: Releases now require using the GitHub Actions UI ("Run workflow") or `gh workflow run release.yml -f tag=v1.2.3` instead of simply `git tag v1.2.3 && git push --tags`. This is a minor ceremony increase for a significant safety gain.
+
+### D2: Verify specific CI check names via Checks API
+
+**Decision**: Query the GitHub Checks API (`GET /repos/{owner}/{repo}/commits/{sha}/check-runs`) for check runs on the dispatched commit (`github.sha`). Require `build-and-test` and `MegaLinter` to have `conclusion: "success"`. Check all required checks and report all failures (not fail-fast).
+
+**Check name derivation**:
+- `build-and-test`: This is the job key in `ci.yml` (line 19). The job has no explicit `name:` field, so the Checks API uses the job key as the check name.
+- `MegaLinter`: This is the `name:` field on the `megalinter` job in `mega-linter.yml` (line 23). Note the job key is `megalinter` (lowercase) but the display name is `MegaLinter` (PascalCase). The Checks API uses the `name:` field when present.
+
+**When a check name returns multiple check runs** (e.g., from workflow re-runs), the most recent run's conclusion is used.
+
+**Rationale**: These are the two CI workflows that run on push to main. The check names are stable identifiers. Using the API provides granular per-check verification.
+
+**Note on MegaLinter scope**: MegaLinter only runs on pushes to `main` and PRs to `main` (per `mega-linter.yml` triggers). Combined with the branch validation (D6), this ensures releases come from commits that both CI pipelines have verified.
+
+### D3: Skip security scan verification
+
+**Decision**: Do not require security scan checks in the preflight. The reference implementation checks for OSV-Scanner/Trivy, but dewey doesn't have these configured.
+
+**Rationale**: Adding a requirement for checks that don't exist would block all releases. Security scanning can be added later as a separate enhancement, and the preflight can be updated to include it at that time.
+
+### D4: Use per-job permissions
+
+**Decision**: Set `permissions: {}` at the workflow level and declare specific permissions per job.
+
+**Per-job permissions**:
+- `preflight`: `contents: write` (tag creation), `checks: read` (Checks API query)
+- `release`: `contents: write` (GoReleaser uploads, cask upload)
+- `sign-macos`: `contents: write` (release asset download/upload, Homebrew tap push)
+
+**Rationale**: Follows the principle of least privilege and matches the reference implementation. Each job gets only the permissions it needs.
+
+### D5: Add concurrency control
+
+**Decision**: Add a `concurrency` group (`release-${{ github.ref }}`) with `cancel-in-progress: false` to prevent parallel release runs.
+
+**Rationale**: Two concurrent releases could create conflicting tags or overwrite each other's artifacts. Using `cancel-in-progress: false` lets the first release finish rather than canceling it. The second run queues.
+
+### D6: Enforce main-branch-only releases
+
+**Decision**: Add a branch validation step in preflight that verifies `github.ref == 'refs/heads/main'`.
+
+**Rationale**: `workflow_dispatch` can be triggered from any branch via the GitHub Actions UI or CLI. Without this check, an operator could accidentally release from a feature branch, creating a tag pointing to unmerged code. The branch validation provides an explicit guard rather than relying on the implicit protection of MegaLinter only running on main.
+
+### D7: Use `RELEASE_TAG` env var for tag references
+
+**Decision**: Add `RELEASE_TAG: ${{ inputs.tag }}` as a job-level env var in all three jobs. Shell steps use `$RELEASE_TAG` instead of `${{ inputs.tag }}` or `${GITHUB_REF_NAME}`.
+
+**Rationale**: `GITHUB_REF_NAME` under `workflow_dispatch` resolves to the branch name (e.g., `main`), not the tag. Using it would cause asset download/upload failures. A dedicated env var avoids this gotcha and provides a single point of change if the input name ever changes. All existing `${GITHUB_REF_NAME}` references in the `release` and `sign-macos` jobs must be replaced.
+
+## Risks / Trade-offs
+
+### Risk: CI check names change
+
+If the CI workflow job names are renamed (e.g., `build-and-test` becomes `ci`), the preflight will fail to find the check and block releases. **Mitigation**: The error message explicitly names the check and its status, making diagnosis straightforward. The fix is a one-line change to the `REQUIRED_CHECKS` array. Implementation should include a comment documenting the coupling: `# These check names must match the job IDs/names in ci.yml and mega-linter.yml`.
+
+### Risk: MegaLinter timing
+
+MegaLinter applies auto-fixes and commits them, which can cause transient states. If a release is attempted while MegaLinter is still running, the check won't show as `success` yet. **Mitigation**: The error message advises waiting for CI to complete before releasing.
+
+### Risk: GitHub API availability
+
+The Checks API query could fail due to rate limiting, network timeouts, or GitHub outages. **Mitigation**: API failures cause the step to fail, and the operator re-runs the workflow. The `timeout-minutes: 10` on the preflight job prevents indefinite hangs. No retry logic is added for simplicity -- transient failures are rare and re-running is trivial.
+
+### Risk: Platform dependency on `sort -V`
+
+The semver comparison uses GNU `sort -V` (version sort), which is a GNU coreutils extension. Ubuntu-based GitHub Actions runners include GNU sort. **Mitigation**: This is a platform assumption documented here. If the runner image changes, the comparison step would need to be rewritten with a pure-bash numeric comparison. The reference implementation uses the same approach.
+
+### Trade-off: Manual trigger vs. tag-push automation
+
+Moving to `workflow_dispatch` removes the ability to trigger a release by pushing a tag. Some CI/CD tools and scripts may expect the tag-push pattern. **Accepted**: The safety benefit of pre-validation outweighs the convenience of tag-push. The `gh workflow run` CLI command provides scriptability for automation needs.
+
+### Recovery: Partial failure (preflight passes, release fails)
+
+If the preflight creates the tag but GoReleaser fails, a tag exists on the remote with no release artifacts. **Recovery path**: Re-run the workflow with the same tag input. The tag uniqueness check recognizes the existing tag points to the same commit (idempotent re-run) and skips tag creation. GoReleaser then proceeds normally. Alternative: manually delete the tag via `git push origin :refs/tags/v1.2.3` and re-trigger.

--- a/openspec/changes/release-ci-gate/proposal.md
+++ b/openspec/changes/release-ci-gate/proposal.md
@@ -1,0 +1,61 @@
+## Why
+
+The current `release.yml` workflow triggers on any `v*` tag push and immediately runs GoReleaser with no verification that CI checks passed on the tagged commit. A tag pushed from a commit that never passed tests will produce and distribute broken release binaries.
+
+The `unbound-force/unbound-force` repository already solved this with a `preflight` job that verifies CI status via the GitHub Checks API before building artifacts. Dewey should adopt the same pattern.
+
+Reference: [unbound-force/dewey#65](https://github.com/unbound-force/dewey/issues/65)
+
+## What Changes
+
+Replace the `push.tags` trigger with `workflow_dispatch` (manual trigger with a `tag` input) and add a `preflight` job that gates artifact publishing on CI verification. Add branch validation to ensure releases only come from `main`.
+
+## Capabilities
+
+### New Capabilities
+- `preflight job`: Validates branch (main-only), tag format, tag uniqueness, semver ordering, CI status on HEAD via Checks API, and unreleased commits before creating the tag and proceeding to GoReleaser
+- `workflow_dispatch trigger`: Manual release trigger with explicit version input, replacing automatic tag-push trigger
+- `branch validation`: Rejects releases triggered from non-main branches
+
+### Modified Capabilities
+- `release job`: Now depends on `preflight` completing successfully; checks out the tag created by preflight; uses `RELEASE_TAG` env var instead of `GITHUB_REF_NAME`
+- `sign-macos job`: Updated to reference `RELEASE_TAG` instead of `GITHUB_REF_NAME`; gains explicit per-job `permissions: { contents: write }`
+
+### Removed Capabilities
+- `push.tags trigger`: Removed in favor of `workflow_dispatch` to prevent unverified releases
+
+## Impact
+
+- **Single file changed**: `.github/workflows/release.yml`
+- **Documentation update**: `AGENTS.md` CI/CD section updated to reflect new trigger and preflight gate
+- **Release process**: Operators must use the GitHub Actions "Run workflow" UI (or `gh workflow run`) instead of pushing a tag manually. The tag is created by the workflow after preflight passes.
+- **No Go code changes**: This is a CI-only change with no impact on the binary, tests, or production behavior.
+- **Existing macOS signing**: The `sign-macos` job structure is preserved; tag reference variable and permissions are updated.
+
+## Constitution Alignment
+
+Assessed against the Dewey project constitution (v1.4.0).
+
+### I. Autonomous Collaboration
+
+**Assessment**: N/A
+
+This change modifies a GitHub Actions workflow file only. No artifact-based communication between heroes is affected. No runtime coupling is introduced or changed.
+
+### II. Composability First
+
+**Assessment**: PASS
+
+Dewey remains independently installable and usable. The release workflow is an operational concern that does not affect the binary's standalone functionality. No new dependencies are introduced to the Go module.
+
+### III. Observable Quality
+
+**Assessment**: PASS
+
+This change directly improves observable quality by ensuring that release artifacts are only published from commits that have passed CI verification. The preflight job produces clear, auditable output for each validation step (branch, tag format, uniqueness, semver ordering, CI status, unreleased commits).
+
+### IV. Testability
+
+**Assessment**: PASS
+
+This change modifies a GitHub Actions workflow. Testability is addressed through YAML validation (task 2.1) and the workflow's own execution as the integration test. No new Go packages are introduced. Workflow changes have inherently limited unit-testability -- the verification strategy (YAML lint + first execution) is the best available approach for CI-only changes.

--- a/openspec/changes/release-ci-gate/specs/release-preflight.md
+++ b/openspec/changes/release-ci-gate/specs/release-preflight.md
@@ -1,0 +1,195 @@
+## ADDED Requirements
+
+### Requirement: Release Preflight Gate
+
+The release workflow MUST execute a preflight validation job before building or publishing any release artifacts. The preflight job MUST pass all validation steps before the release job is allowed to run.
+
+#### Scenario: Successful release with all checks passing
+- **GIVEN** the `release.yml` workflow is triggered via `workflow_dispatch` with `tag: "v1.2.3"` from the `main` branch
+- **WHEN** the dispatched commit (`github.sha`) has passed both `build-and-test` and `MegaLinter` CI checks, the tag format is valid, the tag does not already exist, the version is greater than the latest existing tag, and there are unreleased commits since the last tag
+- **THEN** the preflight job SHALL create and push the annotated tag `v1.2.3` (message: `v1.2.3`), and the release job SHALL proceed to build and publish artifacts
+
+#### Scenario: Release blocked by failed CI
+- **GIVEN** the `release.yml` workflow is triggered via `workflow_dispatch` with `tag: "v1.2.3"`
+- **WHEN** the `build-and-test` check on the dispatched commit (`github.sha`) has concluded with a status other than `success` (e.g., `failure`, `cancelled`)
+- **THEN** the preflight job MUST fail with an error message naming the failing check and its current status, and the release job MUST NOT run
+
+#### Scenario: Release blocked by incomplete MegaLinter check
+- **GIVEN** the `release.yml` workflow is triggered via `workflow_dispatch` with `tag: "v1.2.3"`
+- **WHEN** the `MegaLinter` check on the dispatched commit (`github.sha`) has not concluded with `success` (absent, in-progress, failed, or cancelled)
+- **THEN** the preflight job MUST fail with an error message advising the operator to wait for CI to complete before releasing
+
+#### Scenario: Required check not found on dispatched commit
+- **GIVEN** the `release.yml` workflow is triggered with `tag: "v1.2.3"`
+- **WHEN** the Checks API returns no check run named `build-and-test` for the dispatched commit
+- **THEN** the preflight job MUST fail with an error indicating the check was not found and advising the operator to verify CI ran on this commit
+
+#### Scenario: Both required checks fail
+- **GIVEN** the `release.yml` workflow is triggered with `tag: "v1.2.3"`
+- **WHEN** both `build-and-test` and `MegaLinter` checks have not concluded with `success`
+- **THEN** the preflight job MUST report ALL failing checks and their statuses (not fail-fast on the first), then fail
+
+#### Scenario: Release attempted from non-main branch
+- **GIVEN** the workflow is triggered from branch `feature-x` (not `main`)
+- **WHEN** the preflight job starts
+- **THEN** the preflight job MUST fail with an error indicating releases MUST be triggered from the `main` branch
+
+Note: The Checks API is queried at `GET /repos/{owner}/{repo}/commits/{sha}/check-runs`. The check names correspond to: `build-and-test` (the job key in `ci.yml`, which has no explicit `name:` override) and `MegaLinter` (the `name:` field on the `megalinter` job in `mega-linter.yml`). When a check name returns multiple check runs (e.g., from re-runs), the most recent run's conclusion MUST be used.
+
+### Requirement: Tag Format Validation
+
+The preflight job MUST validate that the tag input matches the pattern `vMAJOR.MINOR.PATCH` (e.g., `v1.2.3`). Tags with pre-release suffixes, build metadata, non-numeric segments, or empty/whitespace content MUST be rejected.
+
+#### Scenario: Invalid tag format rejected (too few segments)
+- **GIVEN** the `release.yml` workflow is triggered with `tag: "v1.2"`
+- **WHEN** the preflight job validates the tag format
+- **THEN** the job MUST fail with an error indicating the expected format `vMAJOR.MINOR.PATCH`
+
+#### Scenario: Pre-release suffix rejected
+- **GIVEN** the `release.yml` workflow is triggered with `tag: "v1.2.3-rc1"`
+- **WHEN** the preflight job validates the tag format
+- **THEN** the job MUST fail with an error indicating the expected format
+
+#### Scenario: Build metadata rejected
+- **GIVEN** the `release.yml` workflow is triggered with `tag: "v1.2.3+build.1"`
+- **WHEN** the preflight job validates the tag format
+- **THEN** the job MUST fail with an error indicating the expected format
+
+#### Scenario: Non-numeric segments rejected
+- **GIVEN** the `release.yml` workflow is triggered with `tag: "v1.two.3"`
+- **WHEN** the preflight job validates the tag format
+- **THEN** the job MUST fail with an error indicating the expected format
+
+#### Scenario: Empty tag input rejected
+- **GIVEN** the `release.yml` workflow is triggered with `tag: ""`
+- **WHEN** the preflight job validates the tag format
+- **THEN** the job MUST fail with an error indicating the expected format
+
+#### Scenario: Valid tag format accepted
+- **GIVEN** the `release.yml` workflow is triggered with `tag: "v0.15.0"`
+- **WHEN** the preflight job validates the tag format
+- **THEN** validation SHALL pass and the job SHALL proceed to the next step
+
+### Requirement: Tag Uniqueness
+
+The preflight job MUST verify that the specified tag does not already exist on the remote pointing to a different commit. If the tag exists and points to a commit other than the dispatched commit (`github.sha`), the job MUST fail. If the tag exists and points to the dispatched commit (indicating a previous preflight run), the uniqueness check MUST pass to support idempotent re-runs.
+
+#### Scenario: Duplicate tag rejected (different commit)
+- **GIVEN** tag `v1.0.0` already exists on the remote pointing to commit `abc123`
+- **WHEN** the workflow is triggered with `tag: "v1.0.0"` on a different commit `def456`
+- **THEN** the preflight job MUST fail with an error indicating the tag already exists and points to a different commit
+
+#### Scenario: Existing tag accepted (same commit, re-run)
+- **GIVEN** tag `v1.0.0` already exists on the remote pointing to the dispatched commit
+- **WHEN** the workflow is re-run with `tag: "v1.0.0"`
+- **THEN** the uniqueness check MUST pass (idempotent re-run)
+
+### Requirement: Semver Ordering
+
+The preflight job MUST verify that the new tag version is strictly greater than the latest existing tag. If the new version is less than or equal to the latest tag, the job MUST fail. "Latest" means the highest version by semver ordering (not the most recently created tag).
+
+#### Scenario: Version regression rejected
+- **GIVEN** the latest tag on the remote is `v1.5.0`
+- **WHEN** the workflow is triggered with `tag: "v1.4.0"`
+- **THEN** the preflight job MUST fail with an error indicating the version is not greater than the latest release
+
+#### Scenario: First release accepted
+- **GIVEN** no version tags exist on the remote
+- **WHEN** the workflow is triggered with `tag: "v0.1.0"`
+- **THEN** the semver ordering check SHALL pass (first release)
+
+#### Scenario: Major version bump accepted
+- **GIVEN** the latest tag on the remote is `v1.5.0`
+- **WHEN** the workflow is triggered with `tag: "v2.0.0"`
+- **THEN** the semver ordering check SHALL pass
+
+#### Scenario: Multi-digit version comparison
+- **GIVEN** the latest tag on the remote is `v0.9.0`
+- **WHEN** the workflow is triggered with `tag: "v0.10.0"`
+- **THEN** the semver ordering check SHALL pass (numeric comparison, not lexicographic)
+
+### Requirement: Unreleased Commits
+
+The preflight job MUST verify that at least one commit exists between the latest tag and the dispatched commit. If there are no unreleased commits, the job MUST fail.
+
+#### Scenario: No unreleased commits rejected
+- **GIVEN** the latest tag `v1.0.0` points to the current dispatched commit
+- **WHEN** the workflow is triggered with `tag: "v1.0.1"`
+- **THEN** the preflight job MUST fail with an error indicating there are no unreleased commits
+
+#### Scenario: First release (no existing tags)
+- **GIVEN** no version tags exist on the remote
+- **WHEN** the workflow checks for unreleased commits
+- **THEN** the check SHALL pass (all commits are unreleased)
+
+### Requirement: Tag Creation by Workflow
+
+The preflight job MUST create an annotated tag and push it to the remote after all validation steps pass. The tag MUST NOT be created before validation succeeds. The tag message MUST be the version string (e.g., `git tag -a v1.2.3 -m "v1.2.3"`).
+
+#### Scenario: Tag created after successful preflight
+- **GIVEN** all preflight validation steps have passed
+- **WHEN** the preflight job reaches the tag creation step
+- **THEN** the job SHALL create an annotated tag with the version as the message and push it to the origin remote
+
+#### Scenario: Tag already exists on re-run (same commit)
+- **GIVEN** the preflight job previously created tag `v1.2.3` pointing to the dispatched commit, but the release job failed
+- **WHEN** the workflow is re-run with the same tag input
+- **THEN** the tag creation step MUST verify the existing tag points to the dispatched commit and skip tag creation (idempotent re-run)
+
+### Requirement: Concurrent Release Prevention
+
+The release workflow MUST use a concurrency group (`release-${{ github.ref }}`) with `cancel-in-progress: false` to prevent parallel release runs.
+
+#### Scenario: Concurrent release queued
+- **GIVEN** a release workflow is already running for tag `v1.2.0`
+- **WHEN** a second release is triggered for tag `v1.3.0`
+- **THEN** the second run SHALL queue until the first completes (not cancel the first)
+
+### Requirement: Branch Validation
+
+The preflight job MUST verify that the workflow was triggered from the `main` branch (`github.ref == 'refs/heads/main'`). Releases from non-main branches MUST be rejected.
+
+#### Scenario: Feature branch release rejected
+- **GIVEN** the workflow is triggered from the GitHub Actions UI with the branch dropdown set to `feature-x`
+- **WHEN** the preflight job validates the branch
+- **THEN** the job MUST fail with an error indicating releases must be triggered from `main`
+
+## MODIFIED Requirements
+
+### Requirement: Release Trigger Mechanism
+
+The release workflow MUST use `workflow_dispatch` with a required `tag` string input instead of `push.tags: v*`.
+
+Previously: The workflow triggered automatically on any `v*` tag push.
+
+#### Scenario: Manual release trigger
+- **GIVEN** an operator wants to release version `v1.2.3`
+- **WHEN** they use the GitHub Actions UI "Run workflow" button or run `gh workflow run release.yml -f tag=v1.2.3`
+- **THEN** the workflow SHALL start with the provided tag value
+
+### Requirement: Release Job Dependencies
+
+The `release` job MUST declare `needs: preflight` so it only runs after successful preflight validation. The `release` job MUST check out the tag created by the preflight job using `ref: ${{ inputs.tag }}`. All references to `GITHUB_REF_NAME` in the `release` job MUST be replaced with `${{ inputs.tag }}` or the `RELEASE_TAG` env var, because `GITHUB_REF_NAME` under `workflow_dispatch` resolves to the branch name (e.g., `main`), not the tag.
+
+Previously: The `release` job ran unconditionally with no dependencies.
+
+### Requirement: Sign-macOS Tag Reference and Permissions
+
+The `sign-macos` job MUST reference the tag via `inputs.tag` (from `workflow_dispatch`) or the `RELEASE_TAG` env var instead of `GITHUB_REF_NAME` in ALL locations. Under `workflow_dispatch`, `GITHUB_REF_NAME` resolves to the branch name, not the tag -- using it would break asset downloads and uploads. The `sign-macos` job MUST also declare per-job `permissions: { contents: write }` because the workflow-level permissions change to `permissions: {}`.
+
+Previously: The job used `GITHUB_REF_NAME` which resolved to the pushed tag. The job inherited workflow-level `permissions: contents: write`.
+
+#### Scenario: macOS signing uses workflow input tag
+- **GIVEN** the release workflow is triggered with `tag: "v1.2.3"`
+- **WHEN** the `sign-macos` job downloads darwin archives, signs them, uploads replacements, and updates the Homebrew cask
+- **THEN** all tag references in the job SHALL resolve to `v1.2.3`, never `GITHUB_REF_NAME`
+
+### Requirement: Signing Secrets Check Location
+
+The signing secrets check (`has_signing_secrets` output) MUST be moved from the `release` job to the `preflight` job. The `release` job MUST forward this output so the `sign-macos` job can access it via `needs.release.outputs.has_signing_secrets`.
+
+Previously: The signing secrets check was in the `release` job.
+
+## REMOVED Requirements
+
+None.

--- a/openspec/changes/release-ci-gate/tasks.md
+++ b/openspec/changes/release-ci-gate/tasks.md
@@ -1,0 +1,37 @@
+<!--
+  [P] marks tasks eligible for parallel execution.
+  Add [P] when a task: (a) touches different files from
+  other [P] tasks in the group, (b) has no dependency
+  on prior tasks in the group, (c) can safely execute
+  without ordering constraints.
+  Do NOT add [P] when tasks modify the same file —
+  parallel workers will cause merge conflicts.
+  Tasks without [P] run sequentially first, then [P]
+  tasks run in parallel.
+-->
+
+## 1. Rewrite Release Workflow
+
+All tasks modify `.github/workflows/release.yml` — no parallel execution.
+
+- [x] 1.1 Replace `on: push: tags` trigger with `workflow_dispatch` trigger accepting a required `tag` string input. Add `concurrency` block (`release-${{ github.ref }}`, `cancel-in-progress: false`). Change top-level `permissions` to `permissions: {}`.
+- [x] 1.2 Add `preflight` job with per-job `permissions: { contents: write, checks: read }` and `timeout-minutes: 10`. Add `RELEASE_TAG` env var from `${{ inputs.tag }}`. Include `actions/checkout` with `fetch-depth: 0` using a pinned SHA matching the existing workflow convention (e.g., `actions/checkout@<sha> # v4.2.2`).
+- [x] 1.3 Add branch validation step: verify `github.ref == 'refs/heads/main'` and reject releases triggered from non-main branches with a clear error message.
+- [x] 1.4 Add tag format validation step: reject tags not matching `^v[0-9]+\.[0-9]+\.[0-9]+$`. This implicitly rejects empty strings, whitespace, pre-release suffixes (`v1.2.3-rc1`), build metadata (`v1.2.3+build.1`), and non-numeric segments.
+- [x] 1.5 Add tag uniqueness check step: verify tag does not exist on remote via `git ls-remote --tags origin`. If the tag exists, check whether it points to the dispatched commit (`github.sha`): if same commit, pass (idempotent re-run); if different commit, fail with error.
+- [x] 1.6 Add semver ordering step: verify new tag is strictly greater than latest existing tag using `sort -V`. "Latest" means highest version by semver ordering. Handle first-release case (no existing tags). Add comment: `# sort -V is a GNU coreutils extension, available on ubuntu-latest runners`.
+- [x] 1.7 Add CI status verification step: query GitHub Checks API (`gh api repos/${GH_REPO}/commits/${HEAD_SHA}/check-runs`) for `build-and-test` and `MegaLinter` checks on the dispatched commit (`github.sha`). Both MUST have `conclusion: "success"`. Check ALL required checks and report ALL failures (not fail-fast). Include descriptive error messages distinguishing "check not found" from "check found but not successful". Add comment: `# Check names must match job IDs/names in ci.yml and mega-linter.yml`.
+- [x] 1.8 Add unreleased commits check: verify at least one commit exists between latest tag and the dispatched commit. Handle first-release case (no existing tags — all commits are unreleased).
+- [x] 1.9 Add tag creation step: create annotated tag (`git tag -a "$RELEASE_TAG" -m "$RELEASE_TAG"`) and push to origin. Skip if tag already exists and points to the dispatched commit (idempotent re-run support). Fail if tag exists but points to a different commit.
+- [x] 1.10 Move signing secrets check from `release` job to `preflight` job. Wire `has_signing_secrets` output from `preflight`.
+- [x] 1.11 Update `release` job: add `needs: preflight`, add per-job `permissions: { contents: write }`, update checkout to use `ref: ${{ inputs.tag }}`, add `RELEASE_TAG` env var from `${{ inputs.tag }}`. Replace all `${GITHUB_REF_NAME}` references with `$RELEASE_TAG` (including the `gh release upload` command for the cask). Forward `has_signing_secrets` output from preflight so `sign-macos` can access it.
+- [x] 1.12 Update `sign-macos` job: add per-job `permissions: { contents: write }`. Add `RELEASE_TAG` env var from `${{ inputs.tag }}`. Replace ALL `${GITHUB_REF_NAME}` references with `$RELEASE_TAG` (7 locations in the current workflow: asset download, version extraction, signed asset upload, checksum download, checksum upload, cask version extraction, and cask download). Update `needs` and output references to use the preflight output path for `has_signing_secrets`. Verify no `GITHUB_REF_NAME` references remain after edits.
+
+## 2. Verification
+
+- [x] 2.1 Validate the complete workflow YAML is valid by running `python3 -c "import yaml; yaml.safe_load(open('.github/workflows/release.yml'))"` or equivalent YAML lint. Note: this validates YAML syntax only, not GitHub Actions schema — the real validation is the first workflow execution.
+- [x] 2.2 Verify no remaining `GITHUB_REF_NAME` references exist in the workflow file (grep check).
+- [x] 2.3 Verify constitution alignment: confirm the change maintains Observable Quality (preflight produces auditable step output), Composability First (no new dependencies on external tools), and does not affect Autonomous Collaboration or Testability (N/A per proposal).
+- [x] 2.4 Update `AGENTS.md` CI/CD section: change the Release workflow description from "Triggered on `v*` tag push" to reflect the `workflow_dispatch` trigger, the new preflight job with its 6 validation steps, and the `gh workflow run` command for scriptable releases. Verify the updated description is accurate.
+<!-- spec-review: passed -->
+<!-- code-review: passed -->


### PR DESCRIPTION
## Summary

Adds a CI preflight gate to the release workflow, preventing publication of release binaries from commits that haven't passed CI checks.

Closes #65

## Changes

- **Trigger**: Replace `push.tags: v*` with `workflow_dispatch` (manual trigger with `tag` input)
- **Preflight job**: 7 validation steps before GoReleaser runs:
  1. Branch validation (main-only)
  2. Tag format (`vMAJOR.MINOR.PATCH`)
  3. Tag uniqueness (with idempotent re-run support)
  4. Semver ordering
  5. CI status via Checks API (`build-and-test` + `MegaLinter`)
  6. Unreleased commits
  7. Tag creation (annotated)
- **Permissions**: Per-job `permissions` (least privilege) instead of workflow-level
- **Recovery**: Idempotent re-runs for partial failure (preflight passes, GoReleaser fails)
- **Documentation**: AGENTS.md CI/CD section updated

## How to Release (after merge)

```bash
gh workflow run release.yml -f tag=v0.X.Y
```

Or use the GitHub Actions "Run workflow" UI button.

## Reference

- Adopts the proven preflight pattern from `unbound-force/unbound-force`
- OpenSpec artifacts at `openspec/changes/release-ci-gate/`