### PR TITLE
fix: send array form for single-text Ollama embed input

### DIFF
--- a/embed/embed.go
+++ b/embed/embed.go
@@ -128,7 +128,7 @@ type tagModel struct {
 // Ollama returns a non-200 status, the response cannot be parsed, or
 // the response contains no embeddings.
 func (o *OllamaEmbedder) Embed(ctx context.Context, text string) ([]float32, error) {
-	vectors, err := o.doEmbed(ctx, text)
+	vectors, err := o.doEmbed(ctx, []string{text})
 	if err != nil {
 		return nil, err
 	}
@@ -185,7 +185,7 @@ func (o *OllamaEmbedder) ModelID() string {
 }
 
 // doEmbed performs the actual HTTP call to POST /api/embed.
-// The input parameter can be a string (single) or []string (batch).
+// The input parameter should be a []string (one or more texts to embed).
 func (o *OllamaEmbedder) doEmbed(ctx context.Context, input any) ([][]float32, error) {
 	reqBody := embedRequest{
 		Model: o.model,

--- a/embed/embed_test.go
+++ b/embed/embed_test.go
@@ -32,6 +32,22 @@ func TestOllamaEmbedder_Embed(t *testing.T) {
 			return
 		}
 
+		// Verify input is always sent as an array, not a bare string.
+		// This mirrors the assertion in TestOllamaEmbedder_EmbedBatch.
+		inputs, ok := req.Input.([]any)
+		if !ok {
+			http.Error(w, "expected array input, got bare string", http.StatusBadRequest)
+			return
+		}
+		if len(inputs) != 1 {
+			http.Error(w, "expected exactly 1 input", http.StatusBadRequest)
+			return
+		}
+		if inputs[0] != "test text" {
+			http.Error(w, "unexpected input content", http.StatusBadRequest)
+			return
+		}
+
 		resp := embedResponse{
 			Embeddings: [][]float64{{0.1, 0.2, 0.3}},
 		}

--- a/openspec/changes/fix-embed-bare-string/.openspec.yaml
+++ b/openspec/changes/fix-embed-bare-string/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: unbound-force
+created: 2026-06-18

--- a/openspec/changes/fix-embed-bare-string/design.md
+++ b/openspec/changes/fix-embed-bare-string/design.md
@@ -1,0 +1,29 @@
+## Context
+
+The `OllamaEmbedder.Embed()` method in `embed/embed.go` passes a bare `string` to `doEmbed()`, which serializes it as `"input": "text"` in the JSON body sent to Ollama's `/api/embed` endpoint. While the Ollama API historically accepted both `string` and `[]string` for the `input` field, strict implementations (including the `uf ollama-proxy`) require the array form `"input": ["text"]`. The `EmbedBatch()` method already correctly sends `[]string`. The Vertex AI embedder also wraps single strings in arrays at `embed/vertex.go:119`.
+
+## Goals / Non-Goals
+
+### Goals
+
+- Ensure `Embed()` always sends the array form `"input": ["text"]` to `/api/embed`
+- Add test coverage verifying the wire format of single-text embed requests
+- Maintain backward compatibility with all Ollama versions
+
+### Non-Goals
+
+- Changing the `doEmbed()` signature or `embedRequest.Input` type (keeping it minimal per user decision)
+- Modifying `EmbedBatch()` (already correct)
+- Changing the Vertex AI embedder (already correct)
+
+## Decisions
+
+**Wrap at the call site, not the type level.** The fix wraps `text` in `[]string{text}` at `embed/embed.go:131` rather than changing `doEmbed(input any)` to `doEmbed(input []string)` or narrowing the `embedRequest.Input` type from `any` to `[]string`. This is the minimal change that fixes the bug while preserving the existing type flexibility of `doEmbed()`.
+
+**Mirror the Vertex pattern.** The Vertex embedder's `Embed()` method already delegates to `EmbedBatch(ctx, []string{text})` at `embed/vertex.go:119`. Our fix follows the same spirit — always send arrays — without requiring the Ollama embedder to restructure its call chain.
+
+**Test at the wire level.** The test assertion validates the JSON wire format by checking that `req.Input` is `[]any` (how `encoding/json` unmarshals a JSON array into `any`), matching the existing assertion pattern in `TestOllamaEmbedder_EmbedBatch` at `embed/embed_test.go:74`.
+
+## Risks / Trade-offs
+
+**Minimal risk.** The Ollama `/api/embed` endpoint accepts `[]string` for single inputs identically to bare strings — the response format (`embeddings: [[...]]`) is the same. No behavioral change for any working setup. The only effect is that previously-broken strict Ollama implementations now work.

--- a/openspec/changes/fix-embed-bare-string/proposal.md
+++ b/openspec/changes/fix-embed-bare-string/proposal.md
@@ -1,0 +1,57 @@
+## Why
+
+The Ollama embed client in `embed/embed.go` sends a bare JSON string for the `input` field when embedding a single text (`"input": "text"`). The Ollama `/api/embed` endpoint accepts both string and array forms, but some Ollama versions and proxies (e.g., `uf ollama-proxy`) strictly require the array form (`"input": ["text"]`). This causes `dewey reindex` and semantic search queries to fail with HTTP 400 errors.
+
+Reported in [unbound-force/dewey#55](https://github.com/unbound-force/dewey/issues/55).
+
+## What Changes
+
+## Capabilities
+
+### New Capabilities
+
+_None._
+
+### Modified Capabilities
+
+- `OllamaEmbedder.Embed()`: Wraps the single input string in a `[]string` before passing to `doEmbed()`, ensuring the JSON body always contains `"input": ["text"]` (array form).
+
+### Removed Capabilities
+
+_None._
+
+## Impact
+
+- **`embed/embed.go`** — One-line change in `Embed()` at line 131: `o.doEmbed(ctx, text)` becomes `o.doEmbed(ctx, []string{text})`.
+- **`embed/embed_test.go`** — Add assertion in `TestOllamaEmbedder_Embed` verifying that the wire format sends an array, not a bare string.
+- **Callers unaffected** — `vault/parse_export.go` (single-chunk fallback), `tools/semantic.go` (query embedding) call `Embed()` and benefit automatically.
+- **`EmbedBatch()` unaffected** — already sends `[]string`.
+- **Backward compatible** — Ollama accepts `[]string` for single inputs; no behavior change for working setups.
+
+## Constitution Alignment
+
+Assessed against the Unbound Force org constitution.
+
+### I. Autonomous Collaboration
+
+**Assessment**: N/A
+
+This is an internal bug fix to JSON serialization. No change to artifact-based communication or MCP tool interfaces.
+
+### II. Composability First
+
+**Assessment**: PASS
+
+Dewey remains independently installable. The fix improves compatibility with a wider range of Ollama implementations and proxies without introducing new dependencies.
+
+### III. Observable Quality
+
+**Assessment**: N/A
+
+No change to output formats or provenance metadata. The fix affects the wire format of an internal HTTP request.
+
+### IV. Testability
+
+**Assessment**: PASS
+
+The fix includes a test assertion verifying the wire format, ensuring the array form is enforced at the unit test level. The embed client remains testable in isolation via `httptest`.

--- a/openspec/changes/fix-embed-bare-string/specs/embed-array-format.md
+++ b/openspec/changes/fix-embed-bare-string/specs/embed-array-format.md
@@ -1,0 +1,43 @@
+## ADDED Requirements
+
+_None._
+
+## MODIFIED Requirements
+
+### Requirement: Ollama Embed Input Format
+
+The `OllamaEmbedder.Embed()` method MUST send the `input` field as a JSON array of strings (`["text"]`) when calling the Ollama `/api/embed` endpoint. Previously, it sent a bare JSON string (`"text"`).
+
+Previously: `Embed()` passed a bare `string` to `doEmbed()`, producing `"input": "text"` in the request body.
+
+#### Scenario: Single text embedding sends array format
+
+- **GIVEN** a caller invokes `OllamaEmbedder.Embed(ctx, "hello world")`
+- **WHEN** the HTTP request is sent to `/api/embed`
+- **THEN** the JSON body MUST contain `"input": ["hello world"]` (array of one string)
+
+#### Scenario: Batch embedding continues to send array format
+
+- **GIVEN** a caller invokes `OllamaEmbedder.EmbedBatch(ctx, []string{"a", "b"})`
+- **WHEN** the HTTP request is sent to `/api/embed`
+- **THEN** the JSON body MUST contain `"input": ["a", "b"]` (array of strings)
+
+#### Scenario: Strict Ollama proxy accepts single embed request
+
+- **GIVEN** an Ollama proxy that rejects bare-string `input` fields
+- **WHEN** `Embed()` is called with any text
+- **THEN** the request MUST succeed (HTTP 200) because the input is sent as an array
+
+### Requirement: Embed Wire Format Test Coverage
+
+The `TestOllamaEmbedder_Embed` test MUST assert that the `input` field in the HTTP request body is a JSON array, not a bare string. This SHOULD mirror the existing assertion pattern in `TestOllamaEmbedder_EmbedBatch`.
+
+#### Scenario: Test catches bare-string regression
+
+- **GIVEN** the test server receives a request from `Embed()`
+- **WHEN** the test decodes the request body
+- **THEN** the test MUST verify that `req.Input` is of type `[]any` (JSON array)
+
+## REMOVED Requirements
+
+_None._

--- a/openspec/changes/fix-embed-bare-string/tasks.md
+++ b/openspec/changes/fix-embed-bare-string/tasks.md
@@ -1,0 +1,27 @@
+<!--
+  [P] marks tasks eligible for parallel execution.
+  Add [P] when a task: (a) touches different files from
+  other [P] tasks in the group, (b) has no dependency
+  on prior tasks in the group, (c) can safely execute
+  without ordering constraints.
+  Do NOT add [P] when tasks modify the same file —
+  parallel workers will cause merge conflicts.
+  Tasks without [P] run sequentially first, then [P]
+  tasks run in parallel.
+-->
+
+## 1. Fix Embed Wire Format
+
+- [x] 1.1 In `embed/embed.go`, change line 131 from `o.doEmbed(ctx, text)` to `o.doEmbed(ctx, []string{text})` so that `Embed()` always sends the array form to `/api/embed`.
+  - File: `embed/embed.go`
+
+- [x] 1.2 In `embed/embed_test.go`, add an assertion to `TestOllamaEmbedder_Embed` that verifies `req.Input` is `[]any` (JSON array), matching the pattern used in `TestOllamaEmbedder_EmbedBatch` at line 74. The test server handler should reject bare-string input.
+  - File: `embed/embed_test.go`
+
+## 2. Verification
+
+- [x] 2.1 Run `go build ./...`, `go vet ./...`, and `go test -race -count=1 ./embed/...` to confirm the fix passes all existing and new tests.
+
+- [x] 2.2 Verify constitution alignment: Composability (Dewey standalone, no new deps) and Testability (wire format tested in isolation via `httptest`).
+<!-- spec-review: passed -->
+<!-- code-review: passed -->


### PR DESCRIPTION
## Summary

Fix the Ollama embed client to always send `"input": ["text"]` (array form) instead of `"input": "text"` (bare string) when embedding a single text via `/api/embed`.

Fixes #55

## Changes

- **`embed/embed.go`**: Wrap single text in `[]string{text}` at the `Embed()` call site (line 131), ensuring the JSON wire format is always an array. Updated `doEmbed` comment to reflect array-only usage.
- **`embed/embed_test.go`**: Add wire-format regression test in `TestOllamaEmbedder_Embed` that validates `req.Input` is `[]any` (JSON array), rejects bare strings, and verifies array content. Mirrors the existing pattern in `TestOllamaEmbedder_EmbedBatch`.

## Context

The Ollama `/api/embed` endpoint accepts both `string` and `[]string` for the `input` field, but strict implementations (including the `uf ollama-proxy`) require the array form. The `EmbedBatch()` method already sent `[]string` correctly; only `Embed()` was affected.

## Verification

- `go build ./...` — PASS
- `go vet ./...` — PASS
- `go test -race -count=1 ./...` — PASS (15 packages)
- Spec review council: APPROVE (5/5)
- Code review council: APPROVE (5/5)