### PR TITLE
feat: add configurable embedding chunk limit

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -348,6 +348,7 @@ embedding:
   provider: ollama  # or: vertex
   model: granite-embedding:30m
   endpoint: http://localhost:11434
+  max_chunk_chars: 12288  # optional: override chunk size limit
 
 synthesis:
   provider: vertex
@@ -365,6 +366,13 @@ Vertex providers use `golang.org/x/oauth2/google` application-default credential
 4. `http://localhost:11434` (default)
 
 When `OLLAMA_HOST` is set without a URL scheme (e.g., `0.0.0.0:11434`), `http://` is prepended automatically.
+
+**Chunk size limit resolution** (highest to lowest precedence):
+1. `DEWEY_CHUNK_MAX_CHARS` env var
+2. `config.yaml` `embedding.max_chunk_chars` (per-vault, then global)
+3. Default: `12288` (~8192 tokens at 1.5 chars/token)
+
+The chunk size limit controls the maximum character length of text chunks sent to the embedding model. Different models have different context windows — adjust this value to match your model. Invalid values (non-positive or non-numeric) are logged as a warning and fall back to the default.
 
 **Graceful degradation**: When Ollama is reachable but the configured embedding model has not been pulled, Dewey logs a warning and continues in keyword-only mode instead of exiting. Semantic search MCP tools return clear error messages indicating embeddings are unavailable.
 

--- a/README.md
+++ b/README.md
@@ -306,6 +306,7 @@ Add `.uf/dewey/` to your `.gitignore`. The index is machine-local and rebuilt fr
 | `OBSIDIAN_VAULT_PATH` | — | Path to Obsidian vault root |
 | `DEWEY_EMBEDDING_MODEL` | `granite-embedding:30m` | Ollama embedding model name |
 | `DEWEY_EMBEDDING_ENDPOINT` | `http://localhost:11434` | Ollama API endpoint |
+| `DEWEY_CHUNK_MAX_CHARS` | `12288` | Max chunk characters for embedding (model-dependent) |
 | `DEWEY_AUTHOR` | — | Override author identity for `store_learning` (useful in CI or shared environments) |
 | `GITHUB_TOKEN` / `GH_TOKEN` | — | GitHub API token for content sources |
 
@@ -550,6 +551,7 @@ embedding:
   provider: ollama
   model: granite-embedding:30m
   endpoint: http://localhost:11434
+  max_chunk_chars: 12288  # optional: adjust for your model's context window
 
 # Vertex AI — for cloud-powered embeddings or synthesis
 embedding:
@@ -605,6 +607,7 @@ Environment variables override config file values for embedding. For synthesis, 
 |----------|---------|-------------|
 | `DEWEY_EMBEDDING_MODEL` | `granite-embedding:30m` | Embedding model (overrides config) |
 | `DEWEY_EMBEDDING_ENDPOINT` | `http://localhost:11434` | Embedding API endpoint (overrides config) |
+| `DEWEY_CHUNK_MAX_CHARS` | `12288` | Max chunk characters for embedding (overrides config) |
 | `DEWEY_GENERATION_MODEL` | *(none)* | Synthesis model (fallback when no config) |
 
 ## Knowledge Compilation

--- a/cli.go
+++ b/cli.go
@@ -248,8 +248,9 @@ func newInitCmd() *cobra.Command {
 # See: https://github.com/unbound-force/dewey
 
 embedding:
-  model: granite-embedding:30m
+  model: granite-embedding:30m  # Override with DEWEY_EMBEDDING_MODEL env var
   # endpoint: http://localhost:11434  # Uncomment to override OLLAMA_HOST
+  # max_chunk_chars: 12288  # Override with DEWEY_CHUNK_MAX_CHARS env var
 `
 			if err := os.WriteFile(configPath, []byte(configContent), 0o644); err != nil {
 				return fmt.Errorf("write config.yaml: %w", err)
@@ -713,7 +714,8 @@ Fetches content from all configured sources and indexes it.`,
 			mgr := source.NewManager(configs, vp, cacheDir)
 			result, allDocs := mgr.FetchAll(sourceName, force, lastFetchedTimes)
 
-			indexResult, indexErr := vault.IndexDocuments(s, allDocs, configs, embedder)
+			embCfg := embed.ReadEmbeddingConfig(deweyDir)
+			indexResult, indexErr := vault.IndexDocuments(s, allDocs, configs, embedder, embCfg.MaxChunkChars)
 			reportSourceErrors(s, result)
 
 			if indexErr != nil {
@@ -851,7 +853,8 @@ The command removes: graph.db, graph.db-wal, graph.db-shm, dewey.lock`,
 				logger.Info("source fetched for reindex", "source", srcID, "documents", len(docs))
 			}
 
-			indexResult, indexErr := vault.IndexDocuments(s, allDocs, configs, embedder)
+			embCfg := embed.ReadEmbeddingConfig(deweyDir)
+			indexResult, indexErr := vault.IndexDocuments(s, allDocs, configs, embedder, embCfg.MaxChunkChars)
 			reportSourceErrors(s, result)
 
 			if indexErr != nil {
@@ -1066,8 +1069,17 @@ func (c *doctorCounter) printCheck(w io.Writer, marker, name, description string
 	case "FAIL":
 		c.fail++
 		emoji = "❌"
+	case "INFO":
+		emoji = "ℹ️"
 	}
 	_, _ = fmt.Fprintf(w, "  %s %-20s%s\n", emoji, name, description)
+}
+
+// isLegacyEmbeddingModel reports whether the given model name is a legacy
+// embedding model that has a newer replacement available. Used by the doctor
+// advisory to suggest upgrading.
+func isLegacyEmbeddingModel(model string) bool {
+	return model == "granite-embedding:30m"
 }
 
 // countExcludedDirs walks the vault directory and counts how many directories
@@ -1390,6 +1402,12 @@ func runDoctorChecks(w io.Writer, vaultPath string) {
 		}
 	} else {
 		c.printCheck(w, "WARN", "model", fmt.Sprintf("%s skipped (ollama not reachable)", embedModel))
+	}
+
+	// Legacy model advisory — inform users about the newer R2 model.
+	if isLegacyEmbeddingModel(embedModel) {
+		c.printCheck(w, "INFO", "model", "granite-embedding:30m has a newer replacement (Granite Embedding R2)")
+		dp("     Tip: update embedding.model in config.yaml, then run: dewey reindex\n")
 	}
 
 	// Embedding count — uses value queried from the already-open store above.
@@ -1947,7 +1965,8 @@ Examples:
 			}
 
 			// Create compile tool and run.
-			compile := tools.NewCompile(s, embedder, synth, vp)
+			compileEmbCfg := embed.ReadEmbeddingConfig(deweyDir)
+			compile := tools.NewCompile(s, embedder, synth, vp, compileEmbCfg.MaxChunkChars)
 			input := types.CompileInput{Incremental: incremental}
 
 			start := time.Now()
@@ -2168,7 +2187,8 @@ Exit code 0 if clean, 1 if issues found.`,
 			}
 
 			// Create lint tool and run.
-			lint := tools.NewLint(s, embedder, vp)
+			lintEmbCfg := embed.ReadEmbeddingConfig(deweyDir)
+			lint := tools.NewLint(s, embedder, vp, lintEmbCfg.MaxChunkChars)
 			input := types.LintInput{Fix: fix}
 
 			result, _, mcpErr := lint.Lint(context.Background(), nil, input)

--- a/cli_test.go
+++ b/cli_test.go
@@ -1923,7 +1923,7 @@ func TestIndexDocuments_InsertNew(t *testing.T) {
 		},
 	}
 
-	indexResult, _ := vault.IndexDocuments(s, docs, nil, nil)
+	indexResult, _ := vault.IndexDocuments(s, docs, nil, nil, 0)
 	if indexResult.TotalIndexed != 1 {
 		t.Fatalf("IndexDocuments() = %d, want 1", indexResult.TotalIndexed)
 	}
@@ -1984,7 +1984,7 @@ func TestIndexDocuments_UpdateExisting(t *testing.T) {
 		},
 	}
 
-	indexResult, _ := vault.IndexDocuments(s, docs, nil, nil)
+	indexResult, _ := vault.IndexDocuments(s, docs, nil, nil, 0)
 	if indexResult.TotalIndexed != 1 {
 		t.Fatalf("IndexDocuments() = %d, want 1", indexResult.TotalIndexed)
 	}
@@ -2034,7 +2034,7 @@ func TestIndexDocuments_SourceRecord(t *testing.T) {
 		},
 	}
 
-	_, _ = vault.IndexDocuments(s, docs, configs, nil)
+	_, _ = vault.IndexDocuments(s, docs, configs, nil, 0)
 
 	src, err := s.GetSource("test-src")
 	if err != nil {
@@ -2075,7 +2075,7 @@ func TestIndexDocuments_WithProperties(t *testing.T) {
 		},
 	}
 
-	indexResult, _ := vault.IndexDocuments(s, docs, nil, nil)
+	indexResult, _ := vault.IndexDocuments(s, docs, nil, nil, 0)
 	if indexResult.TotalIndexed != 1 {
 		t.Fatalf("IndexDocuments() = %d, want 1", indexResult.TotalIndexed)
 	}
@@ -2135,7 +2135,7 @@ Found a bug in [[architecture]] module.
 		},
 	}
 
-	indexResult, _ := vault.IndexDocuments(s, docs, nil, nil)
+	indexResult, _ := vault.IndexDocuments(s, docs, nil, nil, 0)
 	if indexResult.TotalIndexed != 1 {
 		t.Fatalf("IndexDocuments() = %d, want 1", indexResult.TotalIndexed)
 	}
@@ -2195,7 +2195,7 @@ func TestIndexDocuments_ReIndexReplacesBlocks(t *testing.T) {
 			},
 		},
 	}
-	_, _ = vault.IndexDocuments(s, docs1, nil, nil)
+	_, _ = vault.IndexDocuments(s, docs1, nil, nil, 0)
 
 	blocks1, _ := s.GetBlocksByPage(pageName)
 	if len(blocks1) == 0 {
@@ -2215,7 +2215,7 @@ func TestIndexDocuments_ReIndexReplacesBlocks(t *testing.T) {
 			},
 		},
 	}
-	_, _ = vault.IndexDocuments(s, docs2, nil, nil)
+	_, _ = vault.IndexDocuments(s, docs2, nil, nil, 0)
 
 	blocks2, _ := s.GetBlocksByPage(pageName)
 	if len(blocks2) == 0 {
@@ -2408,7 +2408,7 @@ func TestIndexDocuments_GracefulDegradationWithoutEmbedder(t *testing.T) {
 	}
 
 	// Index with nil embedder (simulates Ollama unavailable).
-	indexResult, _ := vault.IndexDocuments(s, docs, nil, nil)
+	indexResult, _ := vault.IndexDocuments(s, docs, nil, nil, 0)
 	if indexResult.TotalIndexed != 1 {
 		t.Fatalf("IndexDocuments() = %d, want 1", indexResult.TotalIndexed)
 	}
@@ -2489,7 +2489,7 @@ func TestIndexDocuments_CrossSourceUUIDUniqueness(t *testing.T) {
 		},
 	}
 
-	indexResult, _ := vault.IndexDocuments(s, docs, nil, nil)
+	indexResult, _ := vault.IndexDocuments(s, docs, nil, nil, 0)
 	if indexResult.TotalIndexed != 3 {
 		t.Fatalf("IndexDocuments() = %d, want 3", indexResult.TotalIndexed)
 	}
@@ -2671,6 +2671,51 @@ func TestDoctorCounter_PrintCheck(t *testing.T) {
 	}
 	if !strings.Contains(output, "/tmp/vault") {
 		t.Errorf("PASS description missing, got:\n%s", output)
+	}
+}
+
+// TestDoctorCounter_PrintCheck_InfoMarker verifies that the INFO marker
+// renders with the info emoji and does not increment pass/warn/fail counters.
+func TestDoctorCounter_PrintCheck_InfoMarker(t *testing.T) {
+	var buf bytes.Buffer
+	c := &doctorCounter{}
+
+	c.printCheck(&buf, "INFO", "model", "granite-embedding:30m has a newer replacement")
+
+	if c.pass != 0 || c.warn != 0 || c.fail != 0 {
+		t.Errorf("INFO should not increment any counter, got pass=%d warn=%d fail=%d", c.pass, c.warn, c.fail)
+	}
+
+	output := buf.String()
+	if !strings.Contains(output, "model") {
+		t.Errorf("INFO line missing model name, got:\n%s", output)
+	}
+	if !strings.Contains(output, "newer replacement") {
+		t.Errorf("INFO line missing description, got:\n%s", output)
+	}
+}
+
+// TestDoctorLegacyModelAdvisory verifies the legacy model advisory logic:
+// granite-embedding:30m triggers an advisory, other models do not.
+func TestDoctorLegacyModelAdvisory(t *testing.T) {
+	tests := []struct {
+		model        string
+		wantAdvisory bool
+	}{
+		{"granite-embedding:30m", true},
+		{"granite-embedding:278m", false},
+		{"granite-embedding-small-english-r2", false},
+		{"nomic-embed-text", false},
+		{"", false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.model, func(t *testing.T) {
+			got := isLegacyEmbeddingModel(tt.model)
+			if got != tt.wantAdvisory {
+				t.Errorf("isLegacyEmbeddingModel(%q) = %v, want %v", tt.model, got, tt.wantAdvisory)
+			}
+		})
 	}
 }
 

--- a/embed/chunker.go
+++ b/embed/chunker.go
@@ -2,14 +2,6 @@ package embed
 
 import "strings"
 
-// maxChunkChars is the approximate character limit for a chunk.
-// Granite-embedding:30m has a 512-token context window. Code-heavy
-// and YAML content tokenizes at 1-2 chars/token in the worst case.
-// At 1.5 chars/token, 512 tokens = 768 chars. We use 768 as the
-// limit to prevent "input length exceeds context length" errors
-// from Ollama even for code-heavy blocks.
-const maxChunkChars = 768
-
 // PrepareChunk creates an embedding-ready chunk from block content by
 // prepending the heading hierarchy context path. This provides semantic
 // context for the embedding model — a block about "From Source" under
@@ -17,8 +9,8 @@ const maxChunkChars = 768
 //
 //	"setup.md > Installation > From Source\n\ncontent..."
 //
-// Returns the formatted chunk string, truncated to maxChunkChars (~512
-// tokens) to fit within the embedding model's context window. Empty
+// maxChars limits the total chunk length in characters (rune-based).
+// Use embed.DefaultMaxChunkChars for the recommended default. Empty
 // headings in the path are skipped. Uses rune-based truncation to avoid
 // splitting multi-byte UTF-8 characters.
 //
@@ -26,7 +18,11 @@ const maxChunkChars = 768
 // fixed-size windows because blocks are the natural semantic units in
 // a Markdown vault (Decision 4 in research.md). Each block has a stable
 // UUID enabling incremental re-embedding when content changes.
-func PrepareChunk(pageName string, headingPath []string, content string) string {
+func PrepareChunk(pageName string, headingPath []string, content string, maxChars int) string {
+	if maxChars <= 0 {
+		maxChars = DefaultMaxChunkChars
+	}
+
 	var sb strings.Builder
 
 	// Build context path: "pageName > heading1 > heading2"
@@ -50,8 +46,8 @@ func PrepareChunk(pageName string, headingPath []string, content string) string 
 	// Use rune-based truncation to avoid splitting multi-byte UTF-8 characters,
 	// which would produce invalid UTF-8 and corrupt embedding input.
 	runes := []rune(result)
-	if len(runes) > maxChunkChars {
-		result = string(runes[:maxChunkChars])
+	if len(runes) > maxChars {
+		result = string(runes[:maxChars])
 	}
 
 	return result

--- a/embed/chunker_test.go
+++ b/embed/chunker_test.go
@@ -8,7 +8,7 @@ import (
 // TestPrepareChunk_BasicHeadingPath verifies the heading hierarchy context
 // is prepended correctly.
 func TestPrepareChunk_BasicHeadingPath(t *testing.T) {
-	result := PrepareChunk("setup.md", []string{"Installation", "From Source"}, "Run `make install` to build from source.")
+	result := PrepareChunk("setup.md", []string{"Installation", "From Source"}, "Run `make install` to build from source.", DefaultMaxChunkChars)
 
 	want := "setup.md > Installation > From Source\n\nRun `make install` to build from source."
 	if result != want {
@@ -18,7 +18,7 @@ func TestPrepareChunk_BasicHeadingPath(t *testing.T) {
 
 // TestPrepareChunk_NoHeadings verifies behavior when there are no headings.
 func TestPrepareChunk_NoHeadings(t *testing.T) {
-	result := PrepareChunk("readme.md", nil, "This is the introduction.")
+	result := PrepareChunk("readme.md", nil, "This is the introduction.", DefaultMaxChunkChars)
 
 	want := "readme.md\n\nThis is the introduction."
 	if result != want {
@@ -28,7 +28,7 @@ func TestPrepareChunk_NoHeadings(t *testing.T) {
 
 // TestPrepareChunk_EmptyHeadingPath verifies behavior with empty heading slice.
 func TestPrepareChunk_EmptyHeadingPath(t *testing.T) {
-	result := PrepareChunk("readme.md", []string{}, "Content here.")
+	result := PrepareChunk("readme.md", []string{}, "Content here.", DefaultMaxChunkChars)
 
 	want := "readme.md\n\nContent here."
 	if result != want {
@@ -39,7 +39,7 @@ func TestPrepareChunk_EmptyHeadingPath(t *testing.T) {
 // TestPrepareChunk_DeeplyNested verifies deeply nested heading paths.
 func TestPrepareChunk_DeeplyNested(t *testing.T) {
 	path := []string{"Chapter 1", "Section A", "Subsection i", "Paragraph 1"}
-	result := PrepareChunk("book.md", path, "Deep content.")
+	result := PrepareChunk("book.md", path, "Deep content.", DefaultMaxChunkChars)
 
 	want := "book.md > Chapter 1 > Section A > Subsection i > Paragraph 1\n\nDeep content."
 	if result != want {
@@ -49,7 +49,7 @@ func TestPrepareChunk_DeeplyNested(t *testing.T) {
 
 // TestPrepareChunk_EmptyContent verifies behavior with empty content.
 func TestPrepareChunk_EmptyContent(t *testing.T) {
-	result := PrepareChunk("page.md", []string{"Heading"}, "")
+	result := PrepareChunk("page.md", []string{"Heading"}, "", DefaultMaxChunkChars)
 
 	want := "page.md > Heading\n\n"
 	if result != want {
@@ -59,7 +59,7 @@ func TestPrepareChunk_EmptyContent(t *testing.T) {
 
 // TestPrepareChunk_WhitespaceContent verifies content is trimmed.
 func TestPrepareChunk_WhitespaceContent(t *testing.T) {
-	result := PrepareChunk("page.md", nil, "  \n  content with whitespace  \n  ")
+	result := PrepareChunk("page.md", nil, "  \n  content with whitespace  \n  ", DefaultMaxChunkChars)
 
 	want := "page.md\n\ncontent with whitespace"
 	if result != want {
@@ -69,7 +69,7 @@ func TestPrepareChunk_WhitespaceContent(t *testing.T) {
 
 // TestPrepareChunk_EmptyHeadingInPath verifies empty strings in heading path are skipped.
 func TestPrepareChunk_EmptyHeadingInPath(t *testing.T) {
-	result := PrepareChunk("page.md", []string{"Heading", "", "SubHeading"}, "Content.")
+	result := PrepareChunk("page.md", []string{"Heading", "", "SubHeading"}, "Content.", DefaultMaxChunkChars)
 
 	want := "page.md > Heading > SubHeading\n\nContent."
 	if result != want {
@@ -79,25 +79,74 @@ func TestPrepareChunk_EmptyHeadingInPath(t *testing.T) {
 
 // TestPrepareChunk_Truncation verifies content is truncated at maxChunkChars.
 func TestPrepareChunk_Truncation(t *testing.T) {
-	// Create content that exceeds maxChunkChars.
-	longContent := strings.Repeat("a", maxChunkChars+500)
-	result := PrepareChunk("page.md", nil, longContent)
+	// Create content that exceeds DefaultMaxChunkChars.
+	longContent := strings.Repeat("a", DefaultMaxChunkChars+500)
+	result := PrepareChunk("page.md", nil, longContent, DefaultMaxChunkChars)
 
-	if len(result) > maxChunkChars {
-		t.Errorf("PrepareChunk(long content) length = %d, want <= %d", len(result), maxChunkChars)
+	if len([]rune(result)) > DefaultMaxChunkChars {
+		t.Errorf("PrepareChunk(long content) rune length = %d, want <= %d", len([]rune(result)), DefaultMaxChunkChars)
 	}
 }
 
 // TestPrepareChunk_TruncationPreservesContext verifies the context path
 // is preserved even when content is truncated.
 func TestPrepareChunk_TruncationPreservesContext(t *testing.T) {
-	longContent := strings.Repeat("x", maxChunkChars+100)
-	result := PrepareChunk("setup.md", []string{"Installation"}, longContent)
+	longContent := strings.Repeat("x", DefaultMaxChunkChars+100)
+	result := PrepareChunk("setup.md", []string{"Installation"}, longContent, DefaultMaxChunkChars)
 
 	if !strings.HasPrefix(result, "setup.md > Installation\n\n") {
 		t.Error("truncated chunk should preserve context path prefix")
 	}
-	if len(result) > maxChunkChars {
-		t.Errorf("truncated chunk length = %d, want <= %d", len(result), maxChunkChars)
+	if len([]rune(result)) > DefaultMaxChunkChars {
+		t.Errorf("truncated chunk rune length = %d, want <= %d", len([]rune(result)), DefaultMaxChunkChars)
+	}
+}
+
+// TestPrepareChunk_SmallLimit verifies truncation with a very small maxChars.
+func TestPrepareChunk_SmallLimit(t *testing.T) {
+	result := PrepareChunk("page.md", []string{"Heading"}, "Some content here.", 50)
+
+	if len([]rune(result)) > 50 {
+		t.Errorf("PrepareChunk(small limit) rune length = %d, want <= 50", len([]rune(result)))
+	}
+	// With maxChars=50, the context path "page.md > Heading\n\n" (21 chars) fits,
+	// and some content should be present.
+	if !strings.HasPrefix(result, "page.md > Heading") {
+		t.Error("PrepareChunk(small limit) should preserve context path when it fits")
+	}
+}
+
+// TestPrepareChunk_LargeLimit verifies no truncation with a large maxChars.
+func TestPrepareChunk_LargeLimit(t *testing.T) {
+	content := "Short content."
+	result := PrepareChunk("page.md", nil, content, 12288)
+
+	want := "page.md\n\nShort content."
+	if result != want {
+		t.Errorf("PrepareChunk(large limit) =\n%q\nwant:\n%q", result, want)
+	}
+}
+
+// TestPrepareChunk_ExactBoundary verifies behavior when content is exactly at maxChars.
+func TestPrepareChunk_ExactBoundary(t *testing.T) {
+	// Build a chunk that is exactly 100 runes: "page.md\n\n" (9 chars) + 91 chars of content.
+	prefix := "page.md\n\n"
+	contentLen := 100 - len([]rune(prefix))
+	content := strings.Repeat("b", contentLen)
+	result := PrepareChunk("page.md", nil, content, 100)
+
+	if len([]rune(result)) != 100 {
+		t.Errorf("PrepareChunk(exact boundary) rune length = %d, want 100", len([]rune(result)))
+	}
+}
+
+// TestPrepareChunk_NoTruncation verifies content shorter than maxChars is returned fully.
+func TestPrepareChunk_NoTruncation(t *testing.T) {
+	content := strings.Repeat("c", 100)
+	result := PrepareChunk("page.md", nil, content, 12288)
+
+	want := "page.md\n\n" + content
+	if result != want {
+		t.Errorf("PrepareChunk(no truncation) =\n%q\nwant:\n%q", result, want)
 	}
 }

--- a/embed/config.go
+++ b/embed/config.go
@@ -3,6 +3,7 @@ package embed
 import (
 	"os"
 	"path/filepath"
+	"strconv"
 	"strings"
 
 	"gopkg.in/yaml.v3"
@@ -12,6 +13,11 @@ import (
 // All code referencing the default endpoint should use this constant
 // instead of hardcoding the URL string.
 const DefaultOllamaEndpoint = "http://localhost:11434"
+
+// DefaultMaxChunkChars is the default maximum number of characters per
+// embedding chunk. Used when no config file or environment variable
+// specifies a value.
+const DefaultMaxChunkChars = 12288
 
 // ResolveOllamaEndpoint resolves the Ollama endpoint from environment
 // variables with the following precedence (highest to lowest):
@@ -64,11 +70,12 @@ func globalConfigDir() string {
 // relevant to embedding configuration.
 type configFile struct {
 	Embedding struct {
-		Provider string `yaml:"provider"`
-		Model    string `yaml:"model"`
-		Endpoint string `yaml:"endpoint"`
-		Project  string `yaml:"project"`
-		Region   string `yaml:"region"`
+		Provider      string `yaml:"provider"`
+		Model         string `yaml:"model"`
+		Endpoint      string `yaml:"endpoint"`
+		Project       string `yaml:"project"`
+		Region        string `yaml:"region"`
+		MaxChunkChars int    `yaml:"max_chunk_chars"`
 	} `yaml:"embedding"`
 }
 
@@ -110,11 +117,12 @@ func ReadEmbeddingConfig(deweyDir string) ProviderConfig {
 	}
 
 	pc := ProviderConfig{
-		Provider: cfg.Embedding.Provider,
-		Model:    cfg.Embedding.Model,
-		Endpoint: cfg.Embedding.Endpoint,
-		Project:  cfg.Embedding.Project,
-		Region:   cfg.Embedding.Region,
+		Provider:      cfg.Embedding.Provider,
+		Model:         cfg.Embedding.Model,
+		Endpoint:      cfg.Embedding.Endpoint,
+		Project:       cfg.Embedding.Project,
+		Region:        cfg.Embedding.Region,
+		MaxChunkChars: cfg.Embedding.MaxChunkChars,
 	}
 
 	// Environment variables override config file values (existing behavior).
@@ -124,6 +132,17 @@ func ReadEmbeddingConfig(deweyDir string) ProviderConfig {
 	// DEWEY_EMBEDDING_ENDPOINT always overrides config.yaml.
 	if envEndpoint := os.Getenv("DEWEY_EMBEDDING_ENDPOINT"); envEndpoint != "" {
 		pc.Endpoint = envEndpoint
+	}
+
+	// DEWEY_CHUNK_MAX_CHARS env var overrides config file value.
+	if envChunk := resolveMaxChunkChars(); envChunk > 0 {
+		pc.MaxChunkChars = envChunk
+	}
+
+	// Default MaxChunkChars if neither config file nor env var set it,
+	// or if config file specified a non-positive value.
+	if pc.MaxChunkChars <= 0 {
+		pc.MaxChunkChars = DefaultMaxChunkChars
 	}
 
 	// If no endpoint was set by config.yaml or DEWEY_EMBEDDING_ENDPOINT,
@@ -141,16 +160,42 @@ func ReadEmbeddingConfig(deweyDir string) ProviderConfig {
 	return pc
 }
 
+// resolveMaxChunkChars parses DEWEY_CHUNK_MAX_CHARS from the environment.
+// Returns the parsed value if valid (positive integer), or 0 if unset.
+// Invalid values (non-numeric, zero, negative) log a warning and return DefaultMaxChunkChars.
+func resolveMaxChunkChars() int {
+	envChunk := os.Getenv("DEWEY_CHUNK_MAX_CHARS")
+	if envChunk == "" {
+		return 0 // signal: not set by env
+	}
+	if v, err := strconv.Atoi(envChunk); err != nil || v <= 0 {
+		embedLogger.Warn("invalid DEWEY_CHUNK_MAX_CHARS, using default", "value", envChunk, "default", DefaultMaxChunkChars)
+		return DefaultMaxChunkChars
+	} else {
+		return v
+	}
+}
+
 // embedConfigFromEnv builds an embedding config from environment variables.
 // Uses ResolveOllamaEndpoint() for the endpoint fallback chain.
 func embedConfigFromEnv() ProviderConfig {
 	model := os.Getenv("DEWEY_EMBEDDING_MODEL")
 	if model == "" {
+		// TODO(#53): Update to granite-embedding-small-english-r2 (or Ollama
+		// equivalent) once the R2 model is published to Ollama's library.
+		// See: https://github.com/unbound-force/dewey/issues/53
 		model = "granite-embedding:30m"
 	}
+
+	maxChunk := resolveMaxChunkChars()
+	if maxChunk <= 0 {
+		maxChunk = DefaultMaxChunkChars
+	}
+
 	return ProviderConfig{
-		Provider: "ollama",
-		Model:    model,
-		Endpoint: ResolveOllamaEndpoint(),
+		Provider:      "ollama",
+		Model:         model,
+		Endpoint:      ResolveOllamaEndpoint(),
+		MaxChunkChars: maxChunk,
 	}
 }

--- a/embed/config_test.go
+++ b/embed/config_test.go
@@ -107,3 +107,104 @@ func TestReadEmbeddingConfig_ConfigYAMLWinsOverOllamaHost(t *testing.T) {
 			cfg.Endpoint, "http://config-host:11434")
 	}
 }
+
+// TestReadEmbeddingConfig_MaxChunkCharsDefault verifies that MaxChunkChars
+// defaults to DefaultMaxChunkChars when no config file or env var sets it.
+func TestReadEmbeddingConfig_MaxChunkCharsDefault(t *testing.T) {
+	dir := t.TempDir()
+	// No config.yaml, no DEWEY_CHUNK_MAX_CHARS env var.
+	t.Setenv("DEWEY_CHUNK_MAX_CHARS", "")
+	t.Setenv("DEWEY_EMBEDDING_ENDPOINT", "")
+	t.Setenv("OLLAMA_HOST", "")
+
+	cfg := ReadEmbeddingConfig(dir)
+	if cfg.MaxChunkChars != DefaultMaxChunkChars {
+		t.Errorf("ReadEmbeddingConfig().MaxChunkChars = %d, want %d (default)",
+			cfg.MaxChunkChars, DefaultMaxChunkChars)
+	}
+}
+
+// TestReadEmbeddingConfig_MaxChunkCharsFromConfig verifies that
+// config.yaml embedding.max_chunk_chars is respected.
+func TestReadEmbeddingConfig_MaxChunkCharsFromConfig(t *testing.T) {
+	dir := t.TempDir()
+	configYAML := "embedding:\n  model: test-model\n  max_chunk_chars: 4096\n"
+	if err := os.WriteFile(filepath.Join(dir, "config.yaml"), []byte(configYAML), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	t.Setenv("DEWEY_CHUNK_MAX_CHARS", "")
+	t.Setenv("DEWEY_EMBEDDING_ENDPOINT", "")
+	t.Setenv("OLLAMA_HOST", "")
+
+	cfg := ReadEmbeddingConfig(dir)
+	if cfg.MaxChunkChars != 4096 {
+		t.Errorf("ReadEmbeddingConfig().MaxChunkChars = %d, want %d (from config.yaml)",
+			cfg.MaxChunkChars, 4096)
+	}
+}
+
+// TestReadEmbeddingConfig_MaxChunkCharsEnvOverridesConfig verifies that
+// DEWEY_CHUNK_MAX_CHARS env var takes precedence over config.yaml.
+func TestReadEmbeddingConfig_MaxChunkCharsEnvOverridesConfig(t *testing.T) {
+	dir := t.TempDir()
+	configYAML := "embedding:\n  model: test-model\n  max_chunk_chars: 4096\n"
+	if err := os.WriteFile(filepath.Join(dir, "config.yaml"), []byte(configYAML), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	t.Setenv("DEWEY_CHUNK_MAX_CHARS", "2048")
+	t.Setenv("DEWEY_EMBEDDING_ENDPOINT", "")
+	t.Setenv("OLLAMA_HOST", "")
+
+	cfg := ReadEmbeddingConfig(dir)
+	if cfg.MaxChunkChars != 2048 {
+		t.Errorf("ReadEmbeddingConfig().MaxChunkChars = %d, want %d (env var should override config.yaml)",
+			cfg.MaxChunkChars, 2048)
+	}
+}
+
+// TestReadEmbeddingConfig_MaxChunkCharsEnvInvalidFallsBack verifies that
+// an invalid (non-numeric) DEWEY_CHUNK_MAX_CHARS falls back to the default.
+func TestReadEmbeddingConfig_MaxChunkCharsEnvInvalidFallsBack(t *testing.T) {
+	dir := t.TempDir()
+	t.Setenv("DEWEY_CHUNK_MAX_CHARS", "abc")
+	t.Setenv("DEWEY_EMBEDDING_ENDPOINT", "")
+	t.Setenv("OLLAMA_HOST", "")
+
+	cfg := ReadEmbeddingConfig(dir)
+	if cfg.MaxChunkChars != DefaultMaxChunkChars {
+		t.Errorf("ReadEmbeddingConfig().MaxChunkChars = %d, want %d (invalid env var should fall back to default)",
+			cfg.MaxChunkChars, DefaultMaxChunkChars)
+	}
+}
+
+// TestReadEmbeddingConfig_MaxChunkCharsEnvZeroFallsBack verifies that
+// DEWEY_CHUNK_MAX_CHARS=0 falls back to the default (zero is not a valid chunk size).
+func TestReadEmbeddingConfig_MaxChunkCharsEnvZeroFallsBack(t *testing.T) {
+	dir := t.TempDir()
+	t.Setenv("DEWEY_CHUNK_MAX_CHARS", "0")
+	t.Setenv("DEWEY_EMBEDDING_ENDPOINT", "")
+	t.Setenv("OLLAMA_HOST", "")
+
+	cfg := ReadEmbeddingConfig(dir)
+	if cfg.MaxChunkChars != DefaultMaxChunkChars {
+		t.Errorf("ReadEmbeddingConfig().MaxChunkChars = %d, want %d (zero env var should fall back to default)",
+			cfg.MaxChunkChars, DefaultMaxChunkChars)
+	}
+}
+
+// TestReadEmbeddingConfig_MaxChunkCharsEnvNegativeFallsBack verifies that
+// a negative DEWEY_CHUNK_MAX_CHARS falls back to the default.
+func TestReadEmbeddingConfig_MaxChunkCharsEnvNegativeFallsBack(t *testing.T) {
+	dir := t.TempDir()
+	t.Setenv("DEWEY_CHUNK_MAX_CHARS", "-5")
+	t.Setenv("DEWEY_EMBEDDING_ENDPOINT", "")
+	t.Setenv("OLLAMA_HOST", "")
+
+	cfg := ReadEmbeddingConfig(dir)
+	if cfg.MaxChunkChars != DefaultMaxChunkChars {
+		t.Errorf("ReadEmbeddingConfig().MaxChunkChars = %d, want %d (negative env var should fall back to default)",
+			cfg.MaxChunkChars, DefaultMaxChunkChars)
+	}
+}

--- a/embed/provider.go
+++ b/embed/provider.go
@@ -22,6 +22,10 @@ type ProviderConfig struct {
 
 	// Region is the GCP region (e.g., "us-central1"). Required for vertex only.
 	Region string
+
+	// MaxChunkChars is the maximum number of characters per embedding chunk.
+	// Defaults to DefaultMaxChunkChars (12288) if zero.
+	MaxChunkChars int
 }
 
 // NewEmbedderFromConfig creates an Embedder from the given provider configuration.

--- a/integration_test.go
+++ b/integration_test.go
@@ -767,7 +767,7 @@ func TestEndToEnd_StoreCompileSearch(t *testing.T) {
 	// Pass tmpDir as vaultPath so file-based collision avoidance works when
 	// multiple learnings with the same tag are stored within the same second.
 	t.Setenv("DEWEY_AUTHOR", "testuser")
-	learning := tools.NewLearning(nil, s, tmpDir) // nil embedder — no Ollama in tests.
+	learning := tools.NewLearning(nil, s, tmpDir, 0) // nil embedder — no Ollama in tests.
 
 	// Learning 1: auth decision — "Use Option A"
 	result1, _, err := learning.StoreLearning(context.Background(), nil, types.StoreLearningInput{
@@ -817,7 +817,7 @@ func TestEndToEnd_StoreCompileSearch(t *testing.T) {
 		Avail:    true,
 		Model:    "test-noop",
 	}
-	compile := tools.NewCompile(s, nil, synth, tmpDir)
+	compile := tools.NewCompile(s, nil, synth, tmpDir, 0)
 
 	// Step 5: Call CompileAll (no incremental identities).
 	compileResult, _, err := compile.Compile(context.Background(), nil, types.CompileInput{})
@@ -1117,7 +1117,7 @@ func TestEndToEnd_CurateKnowledgeStore(t *testing.T) {
 	// Use Incremental=false to force re-processing (the first curation
 	// already set a checkpoint, so incremental mode would skip all docs).
 	forceIncremental := false
-	curateTool := tools.NewCurate(s, nil, synth, tmpDir, nil)
+	curateTool := tools.NewCurate(s, nil, synth, tmpDir, nil, 0)
 	curateResult, _, err := curateTool.Curate(context.Background(), nil, types.CurateInput{
 		Store:       "team-knowledge",
 		Incremental: &forceIncremental,

--- a/main.go
+++ b/main.go
@@ -344,9 +344,10 @@ func executeServe(readOnly bool, backendType, vaultPath, dailyFolder, httpAddr s
 				logger.Warn("failed to load knowledge stores config, skipping background curation",
 					"path", configPath, "err", err)
 			} else if len(stores) > 0 {
-				// Extract persistent store from server options for the curation pipeline.
+				// Extract persistent store and config from server options for the curation pipeline.
 				var curationStore *store.Store
 				var curationEmbedder embed.Embedder
+				var curationMaxChunkChars int
 				for _, opt := range srvOpts {
 					var tmpCfg serverConfig
 					opt(&tmpCfg)
@@ -356,9 +357,12 @@ func executeServe(readOnly bool, backendType, vaultPath, dailyFolder, httpAddr s
 					if tmpCfg.embedder != nil {
 						curationEmbedder = tmpCfg.embedder
 					}
+					if tmpCfg.maxChunkChars > 0 {
+						curationMaxChunkChars = tmpCfg.maxChunkChars
+					}
 				}
 				if curationStore != nil {
-					go backgroundCuration(ctx, indexMu, indexReady, stores, curationStore, curationEmbedder, curationVaultPath)
+					go backgroundCuration(ctx, indexMu, indexReady, stores, curationStore, curationEmbedder, curationVaultPath, curationMaxChunkChars)
 				} else {
 					logger.Debug("background curation skipped — no persistent store")
 				}
@@ -662,9 +666,15 @@ func initObsidianBackend(vaultPath, dailyFolder string, noEmbeddings bool) (back
 
 	vc := vault.New(vp, opts...)
 
-	// Configure embedder on the vault store for indexing pipeline integration.
-	if embedder != nil {
-		if vs := vc.Store(); vs != nil {
+	// Thread the configured max chunk chars to the server config so all
+	// MCP tools use the config-derived value instead of the hardcoded default.
+	srvOpts = append(srvOpts, WithMaxChunkChars(embCfg.MaxChunkChars))
+
+	// Configure embedder and max chunk chars on the vault store for
+	// indexing pipeline integration.
+	if vs := vc.Store(); vs != nil {
+		vs.SetMaxChunkChars(embCfg.MaxChunkChars)
+		if embedder != nil {
 			vs.SetEmbedder(embedder)
 		}
 	}
@@ -688,7 +698,7 @@ func initObsidianBackend(vaultPath, dailyFolder string, noEmbeddings bool) (back
 		// deleted or is missing entries. Must run before indexVault so
 		// re-ingested learnings participate in backlink and search construction.
 		if persistentStore != nil {
-			count, err := reIngestLearnings(persistentStore, embedder, vp)
+			count, err := reIngestLearnings(persistentStore, embedder, vp, embCfg.MaxChunkChars)
 			if err != nil {
 				logger.Warn("learning re-ingestion failed", "err", err)
 			} else if count > 0 {
@@ -792,6 +802,7 @@ func backgroundCuration(
 	s *store.Store,
 	embedder embed.Embedder,
 	vaultPath string,
+	maxChunkChars int,
 ) {
 	logger.Info("background curation starting", "stores", len(stores))
 
@@ -845,7 +856,7 @@ func backgroundCuration(
 		}
 
 		// Launch a goroutine per store for independent scheduling.
-		go backgroundCurateStore(ctx, indexMu, storeCfg, interval, s, synth, embedder, vaultPath)
+		go backgroundCurateStore(ctx, indexMu, storeCfg, interval, s, synth, embedder, vaultPath, maxChunkChars)
 	}
 }
 
@@ -865,6 +876,7 @@ func backgroundCurateStore(
 	synth llm.Synthesizer,
 	embedder embed.Embedder,
 	vaultPath string,
+	maxChunkChars int,
 ) {
 	logger.Info("background curation started for store",
 		"store", storeCfg.Name, "interval", interval)
@@ -903,7 +915,7 @@ func backgroundCurateStore(
 				// (FR-027, FR-028). Re-acquire mutex for indexing since we
 				// released it after curation.
 				if indexMu.TryLock() {
-					indexed := autoIndexKnowledgeStore(s, embedder, storeCfg, vaultPath)
+					indexed := autoIndexKnowledgeStore(s, embedder, storeCfg, vaultPath, maxChunkChars)
 					indexMu.Unlock()
 					logger.Info("background curation complete",
 						"store", storeCfg.Name, "files_created", filesCreated, "indexed", indexed)
@@ -927,7 +939,7 @@ func backgroundCurateStore(
 // Design decision: Extracted as a standalone function for use by both the
 // MCP tool (tools/curate.go) and background curation (main.go). Follows
 // the same PersistBlocks/GenerateEmbeddings pipeline as store_learning.
-func autoIndexKnowledgeStore(s *store.Store, embedder embed.Embedder, cfg curate.StoreConfig, vaultPath string) int {
+func autoIndexKnowledgeStore(s *store.Store, embedder embed.Embedder, cfg curate.StoreConfig, vaultPath string, maxChunkChars int) int {
 	storePath := curate.ResolveStorePath(cfg, vaultPath)
 	sourceID := "knowledge-" + cfg.Name
 
@@ -1021,7 +1033,10 @@ func autoIndexKnowledgeStore(s *store.Store, embedder embed.Embedder, cfg curate
 
 		// Generate embeddings if available.
 		if embedder != nil && embedder.Available() {
-			vault.GenerateEmbeddings(s, embedder, pageName, blocks, nil)
+			if maxChunkChars <= 0 {
+				maxChunkChars = embed.DefaultMaxChunkChars
+			}
+			vault.GenerateEmbeddings(s, embedder, pageName, blocks, nil, maxChunkChars)
 		}
 
 		indexed++
@@ -1054,7 +1069,7 @@ type learningFrontmatter struct {
 // (Dependency Inversion — accepts store and embedder as parameters rather
 // than accessing globals). Called during startup after the store is opened
 // but before background indexing starts.
-func reIngestLearnings(s *store.Store, embedder embed.Embedder, vaultPath string) (int, error) {
+func reIngestLearnings(s *store.Store, embedder embed.Embedder, vaultPath string, maxChunkChars int) (int, error) {
 	if s == nil {
 		return 0, nil
 	}
@@ -1172,7 +1187,10 @@ func reIngestLearnings(s *store.Store, embedder embed.Embedder, vaultPath string
 
 		// Generate embeddings if available.
 		if embedder != nil && embedder.Available() {
-			vault.GenerateEmbeddings(s, embedder, pageName, blocks, nil)
+			if maxChunkChars <= 0 {
+				maxChunkChars = embed.DefaultMaxChunkChars
+			}
+			vault.GenerateEmbeddings(s, embedder, pageName, blocks, nil, maxChunkChars)
 		}
 
 		logger.Info("re-ingested learning from file", "identity", fm.Identity)

--- a/main_test.go
+++ b/main_test.go
@@ -985,7 +985,7 @@ func TestBackgroundIndex_MutexBlocksIndexDuringStartup(t *testing.T) {
 	indexMu.Lock()
 
 	// Create an Indexing tool handler with the shared mutex and a valid store.
-	ix := tools.NewIndexing(s, nil, tmpDir, indexMu)
+	ix := tools.NewIndexing(s, nil, tmpDir, indexMu, 0)
 
 	// Attempt to call Index — should be rejected because the mutex is held.
 	result, _, err := ix.Index(context.Background(), nil, types.IndexInput{})
@@ -1066,7 +1066,7 @@ Always use blue-green deployments for zero-downtime releases.
 	defer func() { _ = s.Close() }()
 
 	// Re-ingest — both files should be recovered.
-	count, err := reIngestLearnings(s, nil, vaultPath)
+	count, err := reIngestLearnings(s, nil, vaultPath, 0)
 	if err != nil {
 		t.Fatalf("reIngestLearnings error: %v", err)
 	}
@@ -1166,7 +1166,7 @@ Existing learning content.
 	}
 
 	// Re-ingest — should skip the existing page.
-	count, err := reIngestLearnings(s, nil, vaultPath)
+	count, err := reIngestLearnings(s, nil, vaultPath, 0)
 	if err != nil {
 		t.Fatalf("reIngestLearnings error: %v", err)
 	}
@@ -1201,7 +1201,7 @@ func TestReIngestLearnings_NoFiles(t *testing.T) {
 	}
 	defer func() { _ = s.Close() }()
 
-	count, err := reIngestLearnings(s, nil, vaultPath)
+	count, err := reIngestLearnings(s, nil, vaultPath, 0)
 	if err != nil {
 		t.Fatalf("reIngestLearnings error: %v", err)
 	}
@@ -1222,7 +1222,7 @@ func TestReIngestLearnings_NoDirectory(t *testing.T) {
 	}
 	defer func() { _ = s.Close() }()
 
-	count, err := reIngestLearnings(s, nil, vaultPath)
+	count, err := reIngestLearnings(s, nil, vaultPath, 0)
 	if err != nil {
 		t.Fatalf("reIngestLearnings error: %v", err)
 	}
@@ -1236,7 +1236,7 @@ func TestReIngestLearnings_NoDirectory(t *testing.T) {
 func TestReIngestLearnings_NilStore(t *testing.T) {
 	vaultPath := t.TempDir()
 
-	count, err := reIngestLearnings(nil, nil, vaultPath)
+	count, err := reIngestLearnings(nil, nil, vaultPath, 0)
 	if err != nil {
 		t.Fatalf("reIngestLearnings error: %v", err)
 	}
@@ -1278,7 +1278,7 @@ Test learning with specific timestamp.
 	}
 	defer func() { _ = s.Close() }()
 
-	count, err := reIngestLearnings(s, nil, vaultPath)
+	count, err := reIngestLearnings(s, nil, vaultPath, 0)
 	if err != nil {
 		t.Fatalf("reIngestLearnings error: %v", err)
 	}
@@ -1339,7 +1339,7 @@ Use basic auth for internal services.
 	}
 	defer func() { _ = s.Close() }()
 
-	count, err := reIngestLearnings(s, nil, vaultPath)
+	count, err := reIngestLearnings(s, nil, vaultPath, 0)
 	if err != nil {
 		t.Fatalf("reIngestLearnings error: %v", err)
 	}
@@ -1438,7 +1438,7 @@ New deploy learning by bob.
 	}
 	defer func() { _ = s.Close() }()
 
-	count, err := reIngestLearnings(s, nil, vaultPath)
+	count, err := reIngestLearnings(s, nil, vaultPath, 0)
 	if err != nil {
 		t.Fatalf("reIngestLearnings error: %v", err)
 	}
@@ -1610,7 +1610,7 @@ func TestBackgroundCuration_SkipsWhenMutexHeld(t *testing.T) {
 	done := make(chan struct{})
 	go func() {
 		defer close(done)
-		backgroundCurateStore(ctx, indexMu, storeCfg, 10*time.Millisecond, s, synth, nil, vaultPath)
+		backgroundCurateStore(ctx, indexMu, storeCfg, 10*time.Millisecond, s, synth, nil, vaultPath, 0)
 	}()
 
 	// Wait enough time for several ticker cycles.
@@ -1662,7 +1662,7 @@ func TestBackgroundCuration_NoConfig(t *testing.T) {
 	done := make(chan struct{})
 	go func() {
 		defer close(done)
-		backgroundCuration(ctx, indexMu, indexReady, nil, s, nil, t.TempDir())
+		backgroundCuration(ctx, indexMu, indexReady, nil, s, nil, t.TempDir(), 0)
 	}()
 
 	select {
@@ -1704,7 +1704,7 @@ func TestBackgroundCuration_RespectsContextCancellation(t *testing.T) {
 	done := make(chan struct{})
 	go func() {
 		defer close(done)
-		backgroundCurateStore(ctx, indexMu, storeCfg, 100*time.Millisecond, s, synth, nil, vaultPath)
+		backgroundCurateStore(ctx, indexMu, storeCfg, 100*time.Millisecond, s, synth, nil, vaultPath, 0)
 	}()
 
 	// Let it run for a bit, then cancel.
@@ -1755,7 +1755,7 @@ func TestBackgroundCuration_WaitsForIndexReady(t *testing.T) {
 	done := make(chan struct{})
 	go func() {
 		defer close(done)
-		backgroundCuration(ctx, indexMu, indexReady, stores, s, nil, t.TempDir())
+		backgroundCuration(ctx, indexMu, indexReady, stores, s, nil, t.TempDir(), 0)
 	}()
 
 	// Verify the goroutine is still waiting (indexReady is false).
@@ -1811,7 +1811,7 @@ func TestBackgroundCuration_ContinuesAfterError(t *testing.T) {
 	done := make(chan struct{})
 	go func() {
 		defer close(done)
-		backgroundCurateStore(ctx, indexMu, storeCfg, 10*time.Millisecond, s, synth, nil, vaultPath)
+		backgroundCurateStore(ctx, indexMu, storeCfg, 10*time.Millisecond, s, synth, nil, vaultPath, 0)
 	}()
 
 	// Let it run through several cycles (some will encounter errors).

--- a/openspec/changes/upgrade-embedding-model-r2/.openspec.yaml
+++ b/openspec/changes/upgrade-embedding-model-r2/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: unbound-force
+created: 2026-06-25

--- a/openspec/changes/upgrade-embedding-model-r2/design.md
+++ b/openspec/changes/upgrade-embedding-model-r2/design.md
@@ -1,0 +1,89 @@
+## Context
+
+Dewey's embedding pipeline uses `granite-embedding:30m` with a 768-character chunk limit (derived from the model's 512-token context window). The chunker (`embed/chunker.go`) truncates all block content to this limit before embedding, which means semantic search only indexes small fragments of longer blocks.
+
+The Granite Embedding R2 small model offers 8192-token context (16x improvement) with the same 384-dimensional output, enabling much larger chunks without any schema or storage changes. The proposal (proposal.md) confirmed constitution alignment -- this change maintains composability (configurable defaults, graceful degradation) and testability (pure Go, no external services at test time).
+
+## Goals / Non-Goals
+
+### Goals
+- Update the default embedding model name to the R2 equivalent
+- Increase the chunk character limit to leverage R2's larger context window
+- Make the chunk limit configurable so users with different models get appropriate chunking
+- Maintain full backward compatibility with `granite-embedding:30m`
+- Update doctor diagnostics to report the new default
+
+### Non-Goals
+- Auto-detecting model context window from Ollama's `/api/show` endpoint (future enhancement -- requires HTTP call during chunking, adds latency and coupling)
+- Supporting multiple concurrent embedding models (existing `model_id` primary key already handles this at the storage layer)
+- Automatic migration of existing embeddings (users must run `dewey reindex` manually)
+- Adding R2 large or multilingual variants as defaults
+
+## Decisions
+
+### D1: Configurable chunk limit via ProviderConfig
+
+The `maxChunkChars` constant in `embed/chunker.go` becomes a configurable value. The configuration flows through `ProviderConfig` (adding a `MaxChunkChars` field) and is resolved via the existing precedence chain:
+
+1. `DEWEY_CHUNK_MAX_CHARS` env var (highest precedence)
+2. `embedding.max_chunk_chars` in per-vault `config.yaml`
+3. `embedding.max_chunk_chars` in global `config.yaml`
+4. Default: `12288` (for R2's 8192-token context at ~1.5 chars/token)
+
+**Rationale**: The chunk limit is model-dependent. Hardcoding it couples the chunker to a specific model. Making it configurable via the existing config pipeline (Composability First) allows users with different models -- including the old `granite-embedding:30m` -- to set appropriate limits. The `ProviderConfig` struct already carries model metadata, so this is a natural extension.
+
+**Alternative rejected**: Querying `/api/show` at runtime to auto-detect context window. This adds an HTTP call to the hot path, creates a hard dependency on Ollama availability during chunking (violates graceful degradation), and doesn't work for Vertex AI embeddings.
+
+### D2: Default model name update
+
+The hardcoded default in `embed/config.go:149` changes from `"granite-embedding:30m"` to the R2 model name. The `cli.go` init template (`dewey init`) updates to match.
+
+**Rationale**: New installations should get the best available model by default. Existing users with `granite-embedding:30m` in their `config.yaml` or `DEWEY_EMBEDDING_MODEL` env var are unaffected -- their explicit configuration takes precedence over the default.
+
+**Guard**: The R2 model must be available on Ollama before this change ships. If it's not yet available, the default stays as `granite-embedding:30m` and only the configurable chunk limit ships. The issue notes R2 is not yet on Ollama's library.
+
+### D3: PrepareChunk signature change
+
+`PrepareChunk` gains a `maxChars int` parameter instead of using the package-level constant. Callers pass the configured limit from their `ProviderConfig`.
+
+**Rationale**: This eliminates global state (no package-level constant governing behavior), makes the function testable with arbitrary limits, and follows the project convention of preferring dependency injection over global state.
+
+**Call sites**: The function is called from `vault/parse_export.go` during document indexing. The `maxChars` value flows as an explicit `maxChunkChars int` parameter through the call chain: callers of `GenerateEmbeddings` pass the configured value from `ProviderConfig.MaxChunkChars`, `GenerateEmbeddings` passes it to `flattenBlocks`, and `flattenBlocks` passes it to `PrepareChunk`. The `Embedder` interface is NOT modified.
+
+**Affected call sites** (11 production, 6 test):
+- `main.go` (2 calls)
+- `vault/vault_store.go` (1 call)
+- `vault/index_documents.go` (1 call)
+- `vault/parse_export.go` (indirect via `flattenBlocks`)
+- `tools/lint.go` (1 call)
+- `tools/learning.go` (1 call)
+- `tools/curate.go` (1 call)
+- `tools/compile.go` (2 calls)
+- `vault/parse_export_test.go` (4 test calls)
+- `vault/vault_store_test.go` (2 test calls)
+
+### D4: Doctor warning for legacy model
+
+`dewey doctor` compares the configured model against the new default and emits an informational note (not a failure) if the user is still on `granite-embedding:30m`, suggesting they upgrade and reindex.
+
+**Rationale**: This is advisory, not blocking. Users may intentionally stay on the old model (e.g., resource-constrained environments). Observable Quality principle -- the doctor surfaces actionable information without enforcing behavior.
+
+## Risks / Trade-offs
+
+### R1: R2 model not yet on Ollama
+
+The R2 model is not yet available via `ollama pull`. If it's still unavailable when this change is ready, we ship the configurable chunk limit with the old default model name. The model name update becomes a follow-up one-line change.
+
+**Mitigation**: The design decouples the two changes. The chunk limit is independently valuable (users can set it via env var today). The model name default is a single constant.
+
+### R2: Larger chunks increase embedding time
+
+Embedding 12288-character chunks takes longer per block than 768-character chunks. For large vaults, initial indexing could be noticeably slower.
+
+**Mitigation**: R2's encoding speed is nearly identical to the original (199 vs 198 docs/sec per the benchmarks). The longer context is processed in a single model call, not multiple calls. Users who need faster indexing can reduce `max_chunk_chars` via config.
+
+### R3: Existing embeddings become stale
+
+After upgrading the model or chunk limit, old embeddings (generated with 768-char chunks) are still served until `dewey reindex` is run. Semantic search quality may be inconsistent during this window.
+
+**Mitigation**: The store uses `model_id` in the embedding primary key, so old-model embeddings are automatically replaced during reindex. Doctor output should suggest reindexing if the configured model differs from the model stored in existing embeddings.

--- a/openspec/changes/upgrade-embedding-model-r2/proposal.md
+++ b/openspec/changes/upgrade-embedding-model-r2/proposal.md
@@ -1,0 +1,66 @@
+## Why
+
+Dewey's default embedding model (`granite-embedding:30m`, Dec 2024) has a 512-token context window, forcing the chunker to truncate inputs to 768 characters. This means semantic search only sees small fragments of each block, losing significant context for longer documents, code blocks, and spec artifacts.
+
+IBM released the Granite Embedding R2 family (Aug 2025) with ModernBERT architecture, 16x longer context windows (8192 vs 512 tokens), improved retrieval scores across all benchmarks, and better code retrieval -- directly relevant since Dewey indexes code via the `code` source type.
+
+The R2 small model is a near-drop-in replacement: same 384-dimensional embeddings (no schema changes), similar parameter count (47M vs 30M), same Apache 2.0 license, and comparable encoding speed.
+
+Related: [unbound-force/dewey#53](https://github.com/unbound-force/dewey/issues/53)
+
+## What Changes
+
+1. **Default model name**: Update from `granite-embedding:30m` to R2 equivalent in `embed/config.go` default and `cli.go` init template
+2. **Chunker context window**: Increase `maxChunkChars` from 768 to ~12288 to leverage R2's 8192-token context, dramatically improving semantic search quality
+3. **Configurable chunk limit**: Make `maxChunkChars` model-aware via a new config field or env var (`DEWEY_CHUNK_MAX_CHARS`), so users with different models get appropriate chunking
+4. **Doctor output**: Report the new model name and warn if the old model is still configured
+5. **Migration documentation**: Document the upgrade path for existing users
+
+## Capabilities
+
+### New Capabilities
+- `configurable-chunk-limit`: Allow users to override the chunk character limit via `DEWEY_CHUNK_MAX_CHARS` env var or `embedding.max_chunk_chars` config field, supporting models with different context windows
+
+### Modified Capabilities
+- `embedding-defaults`: Default model changes from `granite-embedding:30m` to the R2 equivalent; default chunk limit increases from 768 to 12288
+- `semantic-search`: Quality improvement from embedding larger text chunks (up to 16x more context per block)
+- `doctor-diagnostics`: Reports R2 model name; warns when using the legacy model with a suggestion to upgrade
+
+### Removed Capabilities
+- None
+
+## Impact
+
+- **Files modified**: `embed/config.go`, `embed/provider.go`, `embed/chunker.go`, `embed/chunker_test.go`, `embed/config_test.go`, `cli.go` (init template, doctor output), `vault/parse_export.go`, `vault/parse_export_test.go`, `vault/vault_store.go`, `vault/vault_store_test.go`, `vault/index_documents.go`, `main.go`, `tools/lint.go`, `tools/learning.go`, `tools/curate.go`, `tools/compile.go`, `README.md`, `AGENTS.md`
+- **Backward compatible**: Existing `granite-embedding:30m` installations continue to work. The old model name is still valid -- only the default changes.
+- **No schema changes**: R2 produces 384-dimensional embeddings, same as the current model. No database migration needed.
+- **Reindex required**: Users upgrading to R2 must run `dewey reindex` to regenerate embeddings with the new model. Old embeddings are cleaned up automatically (store uses `model_id` in primary key).
+- **No new dependencies**: All changes are in existing packages.
+
+## Constitution Alignment
+
+Assessed against the Dewey project constitution (v1.4.0).
+
+### I. Composability First
+
+**Assessment**: PASS
+
+Dewey remains independently installable. The model default change is a configuration value -- users can override it via env var or config.yaml. Graceful degradation is preserved: if the R2 model is not pulled, Dewey logs a warning and continues in keyword-only mode. No new mandatory dependencies are introduced.
+
+### II. Autonomous Collaboration
+
+**Assessment**: PASS
+
+This change modifies embedding configuration defaults and chunking behavior. It does not affect artifact-based communication between heroes or MCP tool interfaces. All 50 MCP tools continue to produce identical output formats.
+
+### III. Observable Quality
+
+**Assessment**: PASS
+
+The `dewey doctor` command continues to report embedding model status with machine-parseable output. The chunker change improves provenance quality by embedding more context per block, making semantic search results more accurate. The configurable chunk limit is observable via config inspection.
+
+### IV. Testability
+
+**Assessment**: PASS
+
+The chunker is tested in isolation via `embed/chunker_test.go` (9 existing tests). Config resolution is tested via `embed/config_test.go` and `embed/provider_test.go`. All changes are to pure Go code with no external service dependencies at test time. The configurable chunk limit can be tested with in-memory config.

--- a/openspec/changes/upgrade-embedding-model-r2/specs/embedding-model-upgrade.md
+++ b/openspec/changes/upgrade-embedding-model-r2/specs/embedding-model-upgrade.md
@@ -1,0 +1,136 @@
+## ADDED Requirements
+
+### Requirement: Configurable chunk character limit
+
+The embedding pipeline MUST support a configurable maximum chunk character limit. The limit SHALL be resolved via the following precedence chain (highest to lowest):
+
+1. `DEWEY_CHUNK_MAX_CHARS` environment variable
+2. `embedding.max_chunk_chars` field in per-vault `config.yaml`
+3. `embedding.max_chunk_chars` field in global `config.yaml`
+4. Default value of `12288`
+
+The configured value MUST be an integer greater than zero. Invalid values (non-positive integers, non-numeric strings) MUST be logged as a warning and MUST fall back to the default value of 12288.
+
+#### Scenario: Invalid chunk limit from env var (non-numeric)
+
+- **GIVEN** `DEWEY_CHUNK_MAX_CHARS=abc` is set in the environment
+- **WHEN** the embedding pipeline resolves its configuration
+- **THEN** a warning is logged and the default value of 12288 is used
+
+#### Scenario: Zero chunk limit from env var
+
+- **GIVEN** `DEWEY_CHUNK_MAX_CHARS=0` is set in the environment
+- **WHEN** the embedding pipeline resolves its configuration
+- **THEN** a warning is logged and the default value of 12288 is used
+
+#### Scenario: Negative chunk limit from env var
+
+- **GIVEN** `DEWEY_CHUNK_MAX_CHARS=-5` is set in the environment
+- **WHEN** the embedding pipeline resolves its configuration
+- **THEN** a warning is logged and the default value of 12288 is used
+
+#### Scenario: Chunk limit from env var
+
+- **GIVEN** `DEWEY_CHUNK_MAX_CHARS=2048` is set in the environment
+- **WHEN** the embedding pipeline prepares a chunk
+- **THEN** the chunk is truncated to at most 2048 characters
+
+#### Scenario: Chunk limit from config file
+
+- **GIVEN** `config.yaml` contains `embedding.max_chunk_chars: 4096` and no env var is set
+- **WHEN** the embedding pipeline prepares a chunk
+- **THEN** the chunk is truncated to at most 4096 characters
+
+#### Scenario: Default chunk limit
+
+- **GIVEN** no env var or config file sets `max_chunk_chars`
+- **WHEN** the embedding pipeline prepares a chunk
+- **THEN** the chunk is truncated to at most 12288 characters
+
+### Requirement: PrepareChunk accepts configurable limit
+
+The `PrepareChunk` function MUST accept a `maxChars int` parameter instead of using a package-level constant. All callers MUST pass the configured chunk limit.
+
+#### Scenario: PrepareChunk with explicit limit
+
+- **GIVEN** a block with 5000 characters of content
+- **WHEN** `PrepareChunk` is called with `maxChars=3000`
+- **THEN** the returned chunk is at most 3000 characters (rune-based truncation)
+
+#### Scenario: PrepareChunk preserves context path
+
+- **GIVEN** a block with a heading path and long content
+- **WHEN** `PrepareChunk` is called with a limit shorter than context path + content
+- **THEN** the context path prefix is preserved in the truncated result
+
+#### Scenario: PrepareChunk with no truncation needed
+
+- **GIVEN** a block with 100 characters of content
+- **WHEN** `PrepareChunk` is called with `maxChars=12288`
+- **THEN** the full content is returned without truncation
+
+Note: When `maxChars` is smaller than the context path itself, the entire output (including the context path) is truncated to `maxChars` characters. The context path is best-effort preserved but is NOT exempt from truncation.
+
+### Requirement: Doctor legacy model advisory
+
+`dewey doctor` SHOULD display an informational note when the configured embedding model is `granite-embedding:30m`, advising the user that a newer model is available.
+
+The note MUST NOT be a failure -- it SHALL be displayed as an informational marker.
+
+#### Scenario: Doctor detects legacy model
+
+- **GIVEN** the user's `config.yaml` specifies `model: granite-embedding:30m`
+- **WHEN** `dewey doctor` runs the Embedding Layer checks
+- **THEN** an informational note is displayed: the configured model has a newer replacement available, suggesting the user update their config and run `dewey reindex`
+
+#### Scenario: Doctor with current model
+
+- **GIVEN** the user's config specifies the R2 model or any non-legacy model
+- **WHEN** `dewey doctor` runs the Embedding Layer checks
+- **THEN** no legacy model advisory is displayed
+
+## MODIFIED Requirements
+
+### Requirement: Default embedding model
+
+The default embedding model MUST be updated from `granite-embedding:30m` to the Granite Embedding R2 small model name once it is available on Ollama's library.
+
+Previously: The default was `granite-embedding:30m` hardcoded in `embed/config.go:149` and the `dewey init` config template in `cli.go:251`.
+
+**Guard**: If the R2 model is not yet available on Ollama when this change ships, the default MUST remain `granite-embedding:30m`. The configurable chunk limit ships independently.
+
+#### Scenario: New installation gets R2 default
+
+- **GIVEN** no `config.yaml` exists and no `DEWEY_EMBEDDING_MODEL` env var is set
+- **WHEN** the embedding pipeline resolves its configuration
+- **THEN** the model defaults to the R2 model name
+
+#### Scenario: Existing config overrides default
+
+- **GIVEN** `config.yaml` specifies `model: granite-embedding:30m`
+- **WHEN** the embedding pipeline resolves its configuration
+- **THEN** `granite-embedding:30m` is used (config takes precedence over default)
+
+### Requirement: Init template reflects current default
+
+The `dewey init` command MUST write a `config.yaml` template with the current default model name. The template MUST include a comment noting the model can be overridden via `DEWEY_EMBEDDING_MODEL`.
+
+Previously: The template hardcoded `granite-embedding:30m` at `cli.go:251`.
+
+#### Scenario: dewey init writes updated template
+
+- **GIVEN** the user runs `dewey init` in a new vault
+- **WHEN** the config.yaml is generated
+- **THEN** the `embedding.model` field contains the current default model name
+
+## REMOVED Requirements
+
+None. All existing functionality is preserved. The `granite-embedding:30m` model continues to work when explicitly configured.
+
+## Documentation Impact
+
+The following files MUST be updated upon implementation:
+- `README.md` -- Environment Variables table (add `DEWEY_CHUNK_MAX_CHARS`), Provider Configuration examples (add `max_chunk_chars`), Semantic Search Setup section (update model name and `ollama pull` command)
+- `AGENTS.md` -- Provider Configuration section (add `max_chunk_chars`), Active Technologies, Environment Variables
+- `.specify/memory/constitution.md` -- line 156 (update default model name parenthetical, PATCH version bump)
+- Website (`unbound-force/website`) -- file a GitHub issue tracking the new env var, config field, default model change, and doctor advisory

--- a/openspec/changes/upgrade-embedding-model-r2/tasks.md
+++ b/openspec/changes/upgrade-embedding-model-r2/tasks.md
@@ -1,0 +1,58 @@
+<!--
+  [P] marks tasks eligible for parallel execution.
+  Add [P] when a task: (a) touches different files from
+  other [P] tasks in the group, (b) has no dependency
+  on prior tasks in the group, (c) can safely execute
+  without ordering constraints.
+  Do NOT add [P] when tasks modify the same file —
+  parallel workers will cause merge conflicts.
+  Tasks without [P] run sequentially first, then [P]
+  tasks run in parallel.
+-->
+
+## 1. Add configurable chunk limit to ProviderConfig and config pipeline
+
+- [x] 1.1 Add `MaxChunkChars int` field to `ProviderConfig` struct in `embed/provider.go`. Add `MaxChunkChars int` yaml tag `max_chunk_chars` to `configFile.Embedding` struct in `embed/config.go`. Update `ReadEmbeddingConfig()` to populate `MaxChunkChars` from config, env var `DEWEY_CHUNK_MAX_CHARS`, or default `12288`. Ensure the default is applied in both the `embedConfigFromEnv()` path AND the config-file path (when config doesn't specify `max_chunk_chars`). Validate: non-positive or non-numeric values MUST log a warning and fall back to `12288`.
+  - **Files**: `embed/provider.go`, `embed/config.go`
+
+- [x] 1.2 [P] Add tests for `MaxChunkChars` resolution in `embed/config_test.go`: env var override (`DEWEY_CHUNK_MAX_CHARS=2048`), config file value, default fallback (no config or env var), invalid non-numeric value (`DEWEY_CHUNK_MAX_CHARS=abc` logs warning, uses default), zero value (`DEWEY_CHUNK_MAX_CHARS=0` logs warning, uses default), negative value (`DEWEY_CHUNK_MAX_CHARS=-5` logs warning, uses default). Use `t.TempDir()` with written `config.yaml` files for config-file tests and `t.Setenv()` for env var tests, following the pattern in `TestReadEmbeddingConfig_ConfigYAMLWinsOverOllamaHost`.
+  - **Files**: `embed/config_test.go`
+
+## 2. Update PrepareChunk to accept configurable limit
+
+- [x] 2.1 Change `PrepareChunk` signature from `PrepareChunk(pageName string, headingPath []string, content string) string` to `PrepareChunk(pageName string, headingPath []string, content string, maxChars int) string`. Remove the `maxChunkChars` package-level constant. Use the `maxChars` parameter for truncation. Update GoDoc comment to reflect the parameter.
+  - **Files**: `embed/chunker.go`
+
+- [x] 2.2 [P] Update all `PrepareChunk` and `GenerateEmbeddings` call sites. Add `maxChunkChars int` parameter to `GenerateEmbeddings` signature (the `Embedder` interface is NOT modified). Thread the parameter through `GenerateEmbeddings` -> `flattenBlocks` -> `PrepareChunk`. All callers of `GenerateEmbeddings` pass the configured value from `ProviderConfig.MaxChunkChars`. Production call sites (11 total): `main.go` (2 calls), `vault/vault_store.go` (1 call), `vault/index_documents.go` (1 call), `tools/lint.go` (1 call), `tools/learning.go` (1 call), `tools/curate.go` (1 call), `tools/compile.go` (2 calls), `vault/parse_export.go` (indirect via `flattenBlocks`). Test call sites (6 total): `vault/parse_export_test.go` (4 calls), `vault/vault_store_test.go` (2 calls). Verify: run `grep -rn 'GenerateEmbeddings(' --include='*.go'` and confirm every call site passes the configured `maxChunkChars`.
+  - **Files**: `vault/parse_export.go`, `vault/vault_store.go`, `vault/index_documents.go`, `main.go`, `tools/lint.go`, `tools/learning.go`, `tools/curate.go`, `tools/compile.go`, `vault/parse_export_test.go`, `vault/vault_store_test.go`
+
+- [x] 2.3 Update `embed/chunker_test.go`: all 9 existing tests must pass the `maxChars` parameter (use a test-local constant, e.g., `const testMaxChars = 768`). Update truncation test assertions that reference the removed `maxChunkChars` constant to use the test-local value. Add tests for different limit values: small limit (50), large limit (12288), exact boundary, and no-truncation case (content shorter than limit returns full content).
+  - **Files**: `embed/chunker_test.go`
+
+## 3. Update default model name
+
+- [x] 3.1 Update the hardcoded default model in `embed/config.go:149` from `"granite-embedding:30m"` to the R2 model name. Check `https://ollama.com/library/granite-embedding` for an R2 variant. **Guard**: If R2 is not yet on Ollama, keep the current default and add a TODO comment with the target model name and a link to tracking issue (#53).
+  - **Files**: `embed/config.go`
+
+- [x] 3.2 [P] Update the `dewey init` config template in `cli.go` (around line 251) to use the new default model name. Include a comment noting the model can be overridden via `DEWEY_EMBEDDING_MODEL`.
+  - **Files**: `cli.go`
+
+## 4. Update doctor diagnostics
+
+- [x] 4.1 Add legacy model advisory to `dewey doctor` in `cli.go` (Embedding Layer section, around line 1382). After the existing model availability check, compare the configured model against `"granite-embedding:30m"`. If it matches, display an informational note suggesting the user upgrade to the R2 model and run `dewey reindex`. Use `INFO` marker, not `FAIL`.
+  - **Files**: `cli.go`
+
+- [x] 4.2 [P] Add tests for the legacy model advisory in the doctor output. Test that `granite-embedding:30m` triggers the informational note and that other model names do not. Verify the note uses INFO marker, not FAIL. Extract the comparison logic into a testable helper function if needed.
+  - **Files**: `cli.go` or `cli_test.go`
+
+## 5. Verification and documentation
+
+- [x] 5.1 Run `go build ./...` to verify compilation.
+- [x] 5.2 Run `go vet ./...` to verify static analysis.
+- [x] 5.3 Run `go test -race -count=1 ./...` to verify all tests pass. Run `gaze report ./... --coverprofile=coverage.out --max-crapload=48 --max-gaze-crapload=18 --min-contract-coverage=70` if gaze is available and verify no regressions.
+- [x] 5.4 Verify constitution alignment: Composability (configurable defaults, graceful degradation preserved), Observable Quality (doctor reports new model status), Testability (chunker testable with arbitrary limits, no external service deps).
+- [x] 5.5 Update `AGENTS.md` to document the new `DEWEY_CHUNK_MAX_CHARS` env var, `embedding.max_chunk_chars` config field, updated default embedding model, and updated default chunk limit. Update `README.md`: add `DEWEY_CHUNK_MAX_CHARS` to the Environment Variables table, add `max_chunk_chars` to Provider Configuration examples, update `ollama pull` example and model references if the default model changed.
+- [x] 5.6 Create a GitHub issue in `unbound-force/website` documenting: new `DEWEY_CHUNK_MAX_CHARS` env var, new `embedding.max_chunk_chars` config field, changed default model name (if applicable), and `dewey doctor` legacy model advisory. Reference affected website pages: Environment Variables table, Provider Configuration section, Semantic Search Setup section, Doctor section. Use format: `docs: sync dewey embedding model upgrade documentation`.
+- [x] 5.7 If the default model name changed, update `.specify/memory/constitution.md` line 156 (default model name parenthetical) as a PATCH version bump.
+<!-- spec-review: passed -->
+<!-- code-review: passed -->

--- a/server.go
+++ b/server.go
@@ -17,11 +17,12 @@ import (
 
 // serverConfig holds optional dependencies for the MCP server.
 type serverConfig struct {
-	embedder   embed.Embedder
-	store      *store.Store
-	vaultPath  string
-	indexReady *atomic.Bool
-	indexMutex *sync.Mutex
+	embedder      embed.Embedder
+	store         *store.Store
+	vaultPath     string
+	indexReady    *atomic.Bool
+	indexMutex    *sync.Mutex
+	maxChunkChars int // max chars per embedding chunk; 0 uses embed.DefaultMaxChunkChars
 }
 
 // serverOption configures the MCP server.
@@ -54,6 +55,13 @@ func WithIndexReady(ready *atomic.Bool) serverOption {
 // and the index/reindex MCP tools to prevent concurrent indexing operations.
 func WithIndexMutex(mu *sync.Mutex) serverOption {
 	return func(c *serverConfig) { c.indexMutex = mu }
+}
+
+// WithMaxChunkChars sets the maximum character count per embedding chunk.
+// When set to a positive value, overrides embed.DefaultMaxChunkChars for
+// all embedding generation in tools registered on this server.
+func WithMaxChunkChars(n int) serverOption {
+	return func(c *serverConfig) { c.maxChunkChars = n }
 }
 
 // newServer creates and configures the MCP server with all tools registered.
@@ -109,26 +117,26 @@ func newServer(b backend.Backend, readOnly bool, opts ...serverOption) (*mcp.Ser
 	toolCount += registerSemanticTools(srv, semantic)
 
 	if !readOnly {
-		learning := tools.NewLearning(cfg.embedder, cfg.store, cfg.vaultPath)
+		learning := tools.NewLearning(cfg.embedder, cfg.store, cfg.vaultPath, cfg.maxChunkChars)
 		toolCount += registerLearningTools(srv, learning)
 
-		indexing := tools.NewIndexing(cfg.store, cfg.embedder, cfg.vaultPath, cfg.indexMutex)
+		indexing := tools.NewIndexing(cfg.store, cfg.embedder, cfg.vaultPath, cfg.indexMutex, cfg.maxChunkChars)
 		toolCount += registerIndexingTools(srv, indexing)
 
 		// Knowledge compilation tools (013-knowledge-compile, T032/T033).
 		// MCP path: pass nil synthesizer — the compile tool returns clusters
 		// with synthesis prompts, and the calling agent performs synthesis.
 		// This avoids requiring a local LLM for MCP server operation.
-		compile := tools.NewCompile(cfg.store, cfg.embedder, nil, cfg.vaultPath)
+		compile := tools.NewCompile(cfg.store, cfg.embedder, nil, cfg.vaultPath, cfg.maxChunkChars)
 		toolCount += registerCompileTools(srv, compile)
 
 		// Knowledge curation tools (015-curated-knowledge-stores, T022).
 		// MCP path: pass nil synthesizer — the curate tool returns extraction
 		// prompts, and the calling agent performs synthesis externally.
-		curateTool := tools.NewCurate(cfg.store, cfg.embedder, nil, cfg.vaultPath, cfg.indexMutex)
+		curateTool := tools.NewCurate(cfg.store, cfg.embedder, nil, cfg.vaultPath, cfg.indexMutex, cfg.maxChunkChars)
 		toolCount += registerCurateTools(srv, curateTool)
 
-		lint := tools.NewLint(cfg.store, cfg.embedder, cfg.vaultPath)
+		lint := tools.NewLint(cfg.store, cfg.embedder, cfg.vaultPath, cfg.maxChunkChars)
 		toolCount += registerLintTools(srv, lint)
 
 		promote := tools.NewPromote(cfg.store)

--- a/tools/compile.go
+++ b/tools/compile.go
@@ -55,11 +55,12 @@ type Cluster struct {
 // generate articles. When nil, it returns clusters with synthesis prompts
 // as structured output for the calling agent to perform synthesis (D4).
 type Compile struct {
-	mu        sync.Mutex
-	store     *store.Store
-	embedder  embed.Embedder
-	synth     llm.Synthesizer
-	vaultPath string
+	mu            sync.Mutex
+	store         *store.Store
+	embedder      embed.Embedder
+	synth         llm.Synthesizer
+	vaultPath     string
+	maxChunkChars int // max chars per embedding chunk; 0 uses embed.DefaultMaxChunkChars
 }
 
 // NewCompile creates a new Compile tool handler with the given dependencies.
@@ -69,8 +70,19 @@ type Compile struct {
 //   - nil synthesizer: returns clusters + prompts without LLM synthesis
 //
 // vaultPath is the vault root directory (not the .uf/dewey/ workspace).
-func NewCompile(s *store.Store, e embed.Embedder, synth llm.Synthesizer, vaultPath string) *Compile {
-	return &Compile{store: s, embedder: e, synth: synth, vaultPath: vaultPath}
+// The maxChunkChars parameter controls the maximum character length per
+// embedding chunk; pass 0 to use embed.DefaultMaxChunkChars.
+func NewCompile(s *store.Store, e embed.Embedder, synth llm.Synthesizer, vaultPath string, maxChunkChars int) *Compile {
+	return &Compile{store: s, embedder: e, synth: synth, vaultPath: vaultPath, maxChunkChars: maxChunkChars}
+}
+
+// effectiveMaxChunkChars returns the configured max chunk chars, falling back
+// to embed.DefaultMaxChunkChars when no override is set.
+func (c *Compile) effectiveMaxChunkChars() int {
+	if c.maxChunkChars > 0 {
+		return c.maxChunkChars
+	}
+	return embed.DefaultMaxChunkChars
 }
 
 // compiledDir returns the path to the compiled articles directory.
@@ -630,7 +642,7 @@ func (c *Compile) persistCompiledArticle(cl Cluster, articleContent string) erro
 
 	// Generate embeddings if available.
 	if c.embedder != nil && c.embedder.Available() {
-		vault.GenerateEmbeddings(c.store, c.embedder, pageName, blocks, nil)
+		vault.GenerateEmbeddings(c.store, c.embedder, pageName, blocks, nil, c.effectiveMaxChunkChars())
 	}
 
 	return nil
@@ -782,7 +794,7 @@ func (c *Compile) StoreCompiled(_ context.Context, _ *mcp.CallToolRequest, input
 
 	// Generate embeddings if available.
 	if c.embedder != nil && c.embedder.Available() {
-		vault.GenerateEmbeddings(c.store, c.embedder, pageName, blocks, nil)
+		vault.GenerateEmbeddings(c.store, c.embedder, pageName, blocks, nil, c.effectiveMaxChunkChars())
 	}
 
 	compileLogger.Info("stored compiled article", "tag", input.Tag, "path", articlePath)

--- a/tools/compile_test.go
+++ b/tools/compile_test.go
@@ -65,7 +65,7 @@ func storeLearningDirect(t *testing.T, s *store.Store, tag string, seq int, cate
 
 // TestCompile_NilStore verifies that a nil store returns an error result.
 func TestCompile_NilStore(t *testing.T) {
-	c := NewCompile(nil, nil, nil, t.TempDir())
+	c := NewCompile(nil, nil, nil, t.TempDir(), 0)
 
 	result, _, err := c.Compile(context.Background(), nil, types.CompileInput{})
 	if err != nil {
@@ -85,7 +85,7 @@ func TestCompile_NilStore(t *testing.T) {
 func TestCompile_NoLearnings(t *testing.T) {
 	s := newTestStore(t)
 	tmpDir := t.TempDir()
-	c := NewCompile(s, nil, nil, tmpDir)
+	c := NewCompile(s, nil, nil, tmpDir, 0)
 
 	result, _, err := c.Compile(context.Background(), nil, types.CompileInput{})
 	if err != nil {
@@ -251,7 +251,7 @@ func TestCompile_ArticleWrittenToFS(t *testing.T) {
 		Avail:    true,
 		Model:    "test-model",
 	}
-	c := NewCompile(s, nil, synth, tmpDir)
+	c := NewCompile(s, nil, synth, tmpDir, 0)
 
 	// Store learnings.
 	baseTime := time.Date(2026, 3, 15, 10, 0, 0, 0, time.UTC)
@@ -316,7 +316,7 @@ func TestCompile_ArticlePersistedInStore(t *testing.T) {
 		Avail:    true,
 		Model:    "test-model",
 	}
-	c := NewCompile(s, nil, synth, tmpDir)
+	c := NewCompile(s, nil, synth, tmpDir, 0)
 
 	baseTime := time.Date(2026, 3, 15, 10, 0, 0, 0, time.UTC)
 	storeLearningDirect(t, s, "deploy", 1, "pattern", "Blue-green deployment", baseTime)
@@ -364,7 +364,7 @@ func TestCompile_IndexGenerated(t *testing.T) {
 		Avail:    true,
 		Model:    "test-model",
 	}
-	c := NewCompile(s, nil, synth, tmpDir)
+	c := NewCompile(s, nil, synth, tmpDir, 0)
 
 	baseTime := time.Date(2026, 3, 15, 10, 0, 0, 0, time.UTC)
 	storeLearningDirect(t, s, "auth", 1, "decision", "Auth content", baseTime)
@@ -407,7 +407,7 @@ func TestCompile_IndexGenerated(t *testing.T) {
 func TestCompile_SynthesizerUnavailable(t *testing.T) {
 	s := newTestStore(t)
 	tmpDir := t.TempDir()
-	c := NewCompile(s, nil, nil, tmpDir) // nil synthesizer
+	c := NewCompile(s, nil, nil, tmpDir, 0) // nil synthesizer
 
 	baseTime := time.Date(2026, 3, 15, 10, 0, 0, 0, time.UTC)
 	storeLearningDirect(t, s, "auth", 1, "decision", "Use Option A", baseTime)
@@ -473,7 +473,7 @@ func TestCompile_SynthesizerNotAvailable(t *testing.T) {
 		Avail:    false, // Not available
 		Model:    "test-model",
 	}
-	c := NewCompile(s, nil, synth, tmpDir)
+	c := NewCompile(s, nil, synth, tmpDir, 0)
 
 	baseTime := time.Date(2026, 3, 15, 10, 0, 0, 0, time.UTC)
 	storeLearningDirect(t, s, "auth", 1, "decision", "Use Option A", baseTime)
@@ -497,7 +497,7 @@ func TestCompile_SynthesizerNotAvailable(t *testing.T) {
 func TestCompile_ConcurrentCallRejected(t *testing.T) {
 	s := newTestStore(t)
 	tmpDir := t.TempDir()
-	c := NewCompile(s, nil, nil, tmpDir)
+	c := NewCompile(s, nil, nil, tmpDir, 0)
 
 	// Acquire the lock manually to simulate a running compilation.
 	c.mu.Lock()
@@ -529,7 +529,7 @@ func TestCompileIncremental_SingleTag(t *testing.T) {
 		Avail:    true,
 		Model:    "test-model",
 	}
-	c := NewCompile(s, nil, synth, tmpDir)
+	c := NewCompile(s, nil, synth, tmpDir, 0)
 
 	baseTime := time.Date(2026, 3, 15, 10, 0, 0, 0, time.UTC)
 	storeLearningDirect(t, s, "auth", 1, "decision", "Auth content 1", baseTime)
@@ -597,7 +597,7 @@ func TestCompile_FullRebuildDeletesOld(t *testing.T) {
 		Avail:    true,
 		Model:    "test-model",
 	}
-	c := NewCompile(s, nil, synth, tmpDir)
+	c := NewCompile(s, nil, synth, tmpDir, 0)
 
 	baseTime := time.Date(2026, 3, 15, 10, 0, 0, 0, time.UTC)
 	storeLearningDirect(t, s, "auth", 1, "decision", "Auth content", baseTime)
@@ -831,7 +831,7 @@ func TestStoreCompiled_Basic(t *testing.T) {
 	defer func() { _ = s.Close() }()
 
 	vaultPath := t.TempDir()
-	c := NewCompile(s, nil, nil, vaultPath)
+	c := NewCompile(s, nil, nil, vaultPath, 0)
 
 	input := types.StoreCompiledInput{
 		Tag:     "authentication",
@@ -912,7 +912,7 @@ func TestStoreCompiled_ResponseBody(t *testing.T) {
 	s := newTestStore(t)
 	defer func() { _ = s.Close() }()
 
-	c := NewCompile(s, nil, nil, t.TempDir())
+	c := NewCompile(s, nil, nil, t.TempDir(), 0)
 	input := types.StoreCompiledInput{
 		Tag:     "auth",
 		Content: "Test article.",
@@ -982,7 +982,7 @@ func TestStoreCompiled_MissingTag(t *testing.T) {
 	s := newTestStore(t)
 	defer func() { _ = s.Close() }()
 
-	c := NewCompile(s, nil, nil, t.TempDir())
+	c := NewCompile(s, nil, nil, t.TempDir(), 0)
 	input := types.StoreCompiledInput{
 		Content: "some content",
 	}
@@ -1004,7 +1004,7 @@ func TestStoreCompiled_MissingContent(t *testing.T) {
 	s := newTestStore(t)
 	defer func() { _ = s.Close() }()
 
-	c := NewCompile(s, nil, nil, t.TempDir())
+	c := NewCompile(s, nil, nil, t.TempDir(), 0)
 	input := types.StoreCompiledInput{
 		Tag: "auth",
 	}
@@ -1027,7 +1027,7 @@ func TestStoreCompiled_NoModelProvenance(t *testing.T) {
 	defer func() { _ = s.Close() }()
 
 	vaultPath := t.TempDir()
-	c := NewCompile(s, nil, nil, vaultPath)
+	c := NewCompile(s, nil, nil, vaultPath, 0)
 
 	input := types.StoreCompiledInput{
 		Tag:     "auth",
@@ -1057,7 +1057,7 @@ func TestStoreCompiled_PathTraversalRejected(t *testing.T) {
 	s := newTestStore(t)
 	defer func() { _ = s.Close() }()
 
-	c := NewCompile(s, nil, nil, t.TempDir())
+	c := NewCompile(s, nil, nil, t.TempDir(), 0)
 
 	badTags := []string{"../etc/passwd", "auth/evil", "tag\x00bad", "a.b", "tag with spaces"}
 	for _, tag := range badTags {
@@ -1084,7 +1084,7 @@ func TestStoreCompiled_OverwriteExisting(t *testing.T) {
 	defer func() { _ = s.Close() }()
 
 	vaultPath := t.TempDir()
-	c := NewCompile(s, nil, nil, vaultPath)
+	c := NewCompile(s, nil, nil, vaultPath, 0)
 
 	// Store first version.
 	input1 := types.StoreCompiledInput{

--- a/tools/curate.go
+++ b/tools/curate.go
@@ -35,23 +35,26 @@ var curateLogger = log.NewWithOptions(os.Stderr, log.Options{
 // concurrent curation. The indexMutex is shared with indexing tools to
 // prevent curation during indexing (per FR-020).
 type Curate struct {
-	mu        *sync.Mutex
-	store     *store.Store
-	embedder  embed.Embedder
-	synth     llm.Synthesizer
-	vaultPath string
+	mu            *sync.Mutex
+	store         *store.Store
+	embedder      embed.Embedder
+	synth         llm.Synthesizer
+	vaultPath     string
+	maxChunkChars int // max chars per embedding chunk; 0 uses embed.DefaultMaxChunkChars
 }
 
 // NewCurate creates a new Curate tool handler with the given dependencies.
 // The store must be non-nil. The synth may be nil — the tool returns
 // extraction prompts when no synthesizer is available (MCP mode).
 // The mu parameter is the shared index mutex; when non-nil, curation
-// acquires it to prevent concurrent indexing operations.
-func NewCurate(s *store.Store, e embed.Embedder, synth llm.Synthesizer, vaultPath string, mu *sync.Mutex) *Curate {
+// acquires it to prevent concurrent indexing operations. The maxChunkChars
+// parameter controls the maximum character length per embedding chunk;
+// pass 0 to use embed.DefaultMaxChunkChars.
+func NewCurate(s *store.Store, e embed.Embedder, synth llm.Synthesizer, vaultPath string, mu *sync.Mutex, maxChunkChars int) *Curate {
 	if mu == nil {
 		mu = &sync.Mutex{}
 	}
-	return &Curate{store: s, embedder: e, synth: synth, vaultPath: vaultPath, mu: mu}
+	return &Curate{store: s, embedder: e, synth: synth, vaultPath: vaultPath, mu: mu, maxChunkChars: maxChunkChars}
 }
 
 // Curate handles the dewey_curate MCP tool. Reads knowledge-stores.yaml,
@@ -335,7 +338,11 @@ func (c *Curate) autoIndexKnowledgeStore(cfg curate.StoreConfig) int {
 
 		// Generate embeddings if available.
 		if c.embedder != nil && c.embedder.Available() {
-			vault.GenerateEmbeddings(c.store, c.embedder, pageName, blocks, nil)
+			maxChars := c.maxChunkChars
+			if maxChars <= 0 {
+				maxChars = embed.DefaultMaxChunkChars
+			}
+			vault.GenerateEmbeddings(c.store, c.embedder, pageName, blocks, nil, maxChars)
 		}
 
 		indexed++

--- a/tools/curate_test.go
+++ b/tools/curate_test.go
@@ -12,7 +12,7 @@ import (
 )
 
 func TestCurateTool_NilStore(t *testing.T) {
-	curateTool := NewCurate(nil, nil, nil, "", nil)
+	curateTool := NewCurate(nil, nil, nil, "", nil, 0)
 
 	result, _, err := curateTool.Curate(context.Background(), nil, types.CurateInput{})
 	if err != nil {
@@ -37,7 +37,7 @@ func TestCurateTool_NoConfig(t *testing.T) {
 		t.Fatalf("create dewey dir: %v", err)
 	}
 
-	curateTool := NewCurate(s, nil, nil, dir, nil)
+	curateTool := NewCurate(s, nil, nil, dir, nil, 0)
 
 	result, _, err := curateTool.Curate(context.Background(), nil, types.CurateInput{})
 	if err != nil {
@@ -69,7 +69,7 @@ func TestCurateTool_StoreNotFound(t *testing.T) {
 		t.Fatalf("write config: %v", err)
 	}
 
-	curateTool := NewCurate(s, nil, nil, dir, nil)
+	curateTool := NewCurate(s, nil, nil, dir, nil, 0)
 
 	result, _, err := curateTool.Curate(context.Background(), nil, types.CurateInput{
 		Store: "nonexistent",
@@ -103,7 +103,7 @@ func TestCurateTool_ConcurrentCallRejected(t *testing.T) {
 	}
 
 	mu := &sync.Mutex{}
-	curateTool := NewCurate(s, nil, nil, dir, mu)
+	curateTool := NewCurate(s, nil, nil, dir, mu, 0)
 
 	// Lock the mutex to simulate an indexing operation in progress.
 	mu.Lock()

--- a/tools/indexing.go
+++ b/tools/indexing.go
@@ -48,27 +48,32 @@ var indexingLogger = log.NewWithOptions(os.Stderr, log.Options{
 // struct pattern. This enables testing with in-memory stores and nil
 // embedders.
 type Indexing struct {
-	mu        *sync.Mutex
-	store     *store.Store
-	embedder  embed.Embedder
-	vaultPath string
+	mu            *sync.Mutex
+	store         *store.Store
+	embedder      embed.Embedder
+	vaultPath     string
+	maxChunkChars int // max chars per embedding chunk; 0 uses embed.DefaultMaxChunkChars
 }
 
 // NewIndexing creates a new Indexing tool handler with the given store,
-// embedder, vault path, and optional shared mutex. The embedder may be
-// nil — indexing proceeds without embedding generation when unavailable
-// (graceful degradation). The store must be non-nil for the tools to
-// function; a clear error is returned at call time if it is nil. The
-// vaultPath is the vault root directory (not the .uf/dewey/ workspace).
+// embedder, vault path, optional shared mutex, and max chunk chars for
+// embedding generation. The embedder may be nil — indexing proceeds
+// without embedding generation when unavailable (graceful degradation).
+// The store must be non-nil for the tools to function; a clear error is
+// returned at call time if it is nil. The vaultPath is the vault root
+// directory (not the .uf/dewey/ workspace).
 //
 // The mu parameter enables shared mutual exclusion with background startup
 // indexing (per D1, spec 012). When mu is non-nil, it replaces the internal
 // mutex. When mu is nil, an internal mutex is created (backward compatible).
-func NewIndexing(s *store.Store, e embed.Embedder, vaultPath string, mu *sync.Mutex) *Indexing {
+//
+// The maxChunkChars parameter controls the maximum character length per
+// embedding chunk. Pass 0 to use embed.DefaultMaxChunkChars.
+func NewIndexing(s *store.Store, e embed.Embedder, vaultPath string, mu *sync.Mutex, maxChunkChars int) *Indexing {
 	if mu == nil {
 		mu = &sync.Mutex{}
 	}
-	return &Indexing{store: s, embedder: e, vaultPath: vaultPath, mu: mu}
+	return &Indexing{store: s, embedder: e, vaultPath: vaultPath, mu: mu, maxChunkChars: maxChunkChars}
 }
 
 // indexSummary is the structured JSON response returned by both Index
@@ -145,7 +150,7 @@ func (ix *Indexing) Index(ctx context.Context, req *mcp.CallToolRequest, input t
 	result, allDocs := mgr.FetchAll(input.SourceID, true, lastFetchedTimes)
 
 	// Index fetched documents through the shared pipeline.
-	indexResult, indexErr := vault.IndexDocuments(ix.store, allDocs, configs, ix.embedder)
+	indexResult, indexErr := vault.IndexDocuments(ix.store, allDocs, configs, ix.embedder, ix.maxChunkChars)
 	if indexErr != nil {
 		indexingLogger.Warn("index had errors", "err", indexErr)
 	}
@@ -275,7 +280,7 @@ func (ix *Indexing) Reindex(ctx context.Context, req *mcp.CallToolRequest, input
 	result, allDocs := mgr.FetchAll("", true, lastFetchedTimes)
 
 	// Index fetched documents.
-	indexResult, indexErr := vault.IndexDocuments(ix.store, allDocs, configs, ix.embedder)
+	indexResult, indexErr := vault.IndexDocuments(ix.store, allDocs, configs, ix.embedder, ix.maxChunkChars)
 	if indexErr != nil {
 		indexingLogger.Warn("reindex had errors", "err", indexErr)
 	}

--- a/tools/indexing_sanitize_test.go
+++ b/tools/indexing_sanitize_test.go
@@ -70,7 +70,7 @@ func buildDocs(sourceID, docID, title, content string) map[string][]source.Docum
 // in the stored page.
 func TestIndexDocuments_ScanCalledForWebSource(t *testing.T) {
 	s := newTestStore(t)
-	ix := NewIndexing(s, nil, t.TempDir(), nil)
+	ix := NewIndexing(s, nil, t.TempDir(), nil, 0)
 
 	configs := []source.SourceConfig{
 		{
@@ -84,7 +84,7 @@ func TestIndexDocuments_ScanCalledForWebSource(t *testing.T) {
 	}
 	docs := buildDocs("web-docs", "page-with-injection", "Injected Page", injectionContent)
 
-	indexResult, _ := vault.IndexDocuments(ix.store, docs, configs, ix.embedder)
+	indexResult, _ := vault.IndexDocuments(ix.store, docs, configs, ix.embedder, 0)
 	if indexResult.TotalIndexed != 1 {
 		t.Fatalf("totalIndexed = %d, want 1", indexResult.TotalIndexed)
 	}
@@ -141,7 +141,7 @@ func TestIndexDocuments_ScanCalledForWebSource(t *testing.T) {
 // patterns should NOT produce sanitize_findings in the stored page.
 func TestIndexDocuments_ScanSkippedForDiskSource(t *testing.T) {
 	s := newTestStore(t)
-	ix := NewIndexing(s, nil, t.TempDir(), nil)
+	ix := NewIndexing(s, nil, t.TempDir(), nil, 0)
 
 	configs := []source.SourceConfig{
 		{
@@ -155,7 +155,7 @@ func TestIndexDocuments_ScanSkippedForDiskSource(t *testing.T) {
 	}
 	docs := buildDocs("disk-local", "local-page", "Local Page", injectionContent)
 
-	indexResult, _ := vault.IndexDocuments(ix.store, docs, configs, ix.embedder)
+	indexResult, _ := vault.IndexDocuments(ix.store, docs, configs, ix.embedder, 0)
 	if indexResult.TotalIndexed != 1 {
 		t.Fatalf("totalIndexed = %d, want 1", indexResult.TotalIndexed)
 	}
@@ -190,7 +190,7 @@ func TestIndexDocuments_ScanSkippedForDiskSource(t *testing.T) {
 // appear in the store after indexing.
 func TestIndexDocuments_StrictModeSkipsDocument(t *testing.T) {
 	s := newTestStore(t)
-	ix := NewIndexing(s, nil, t.TempDir(), nil)
+	ix := NewIndexing(s, nil, t.TempDir(), nil, 0)
 
 	configs := []source.SourceConfig{
 		{
@@ -205,7 +205,7 @@ func TestIndexDocuments_StrictModeSkipsDocument(t *testing.T) {
 	}
 	docs := buildDocs("web-strict", "malicious-page", "Malicious Page", injectionContent)
 
-	indexResult, _ := vault.IndexDocuments(ix.store, docs, configs, ix.embedder)
+	indexResult, _ := vault.IndexDocuments(ix.store, docs, configs, ix.embedder, 0)
 	if indexResult.TotalIndexed != 0 {
 		t.Fatalf("totalIndexed = %d, want 0 (document should be rejected by strict mode)", indexResult.TotalIndexed)
 	}
@@ -226,7 +226,7 @@ func TestIndexDocuments_StrictModeSkipsDocument(t *testing.T) {
 // merge into properties → store → retrieve → parse.
 func TestIndexDocuments_FindingsSurvivePersistence(t *testing.T) {
 	s := newTestStore(t)
-	ix := NewIndexing(s, nil, t.TempDir(), nil)
+	ix := NewIndexing(s, nil, t.TempDir(), nil, 0)
 
 	configs := []source.SourceConfig{
 		{
@@ -240,7 +240,7 @@ func TestIndexDocuments_FindingsSurvivePersistence(t *testing.T) {
 	}
 	docs := buildDocs("web-persist", "persist-doc", "Persist Doc", injectionContent)
 
-	indexResult, _ := vault.IndexDocuments(ix.store, docs, configs, ix.embedder)
+	indexResult, _ := vault.IndexDocuments(ix.store, docs, configs, ix.embedder, 0)
 	if indexResult.TotalIndexed != 1 {
 		t.Fatalf("totalIndexed = %d, want 1", indexResult.TotalIndexed)
 	}
@@ -313,7 +313,7 @@ func TestIndexDocuments_FindingsSurvivePersistence(t *testing.T) {
 // JSON. Neither should overwrite the other.
 func TestIndexDocuments_FindingsMergedWithFrontmatter(t *testing.T) {
 	s := newTestStore(t)
-	ix := NewIndexing(s, nil, t.TempDir(), nil)
+	ix := NewIndexing(s, nil, t.TempDir(), nil, 0)
 
 	configs := []source.SourceConfig{
 		{
@@ -327,7 +327,7 @@ func TestIndexDocuments_FindingsMergedWithFrontmatter(t *testing.T) {
 	}
 	docs := buildDocs("web-frontmatter", "fm-doc", "Frontmatter Doc", frontmatterContent)
 
-	indexResult, _ := vault.IndexDocuments(ix.store, docs, configs, ix.embedder)
+	indexResult, _ := vault.IndexDocuments(ix.store, docs, configs, ix.embedder, 0)
 	if indexResult.TotalIndexed != 1 {
 		t.Fatalf("totalIndexed = %d, want 1", indexResult.TotalIndexed)
 	}
@@ -395,7 +395,7 @@ func TestIndexDocuments_FindingsMergedWithFrontmatter(t *testing.T) {
 // Clean documents should be indexed normally even under strict sanitization.
 func TestIndexDocuments_StrictModeAllowsCleanDocument(t *testing.T) {
 	s := newTestStore(t)
-	ix := NewIndexing(s, nil, t.TempDir(), nil)
+	ix := NewIndexing(s, nil, t.TempDir(), nil, 0)
 
 	configs := []source.SourceConfig{
 		{
@@ -410,7 +410,7 @@ func TestIndexDocuments_StrictModeAllowsCleanDocument(t *testing.T) {
 	}
 	docs := buildDocs("web-strict-clean", "clean-page", "Clean Page", cleanContent)
 
-	indexResult, _ := vault.IndexDocuments(ix.store, docs, configs, ix.embedder)
+	indexResult, _ := vault.IndexDocuments(ix.store, docs, configs, ix.embedder, 0)
 	if indexResult.TotalIndexed != 1 {
 		t.Fatalf("totalIndexed = %d, want 1 (clean document should pass strict mode)", indexResult.TotalIndexed)
 	}
@@ -429,7 +429,7 @@ func TestIndexDocuments_StrictModeAllowsCleanDocument(t *testing.T) {
 // source config is propagated to the stored page's Tier field.
 func TestIndexDocuments_TrustTierFromConfig(t *testing.T) {
 	s := newTestStore(t)
-	ix := NewIndexing(s, nil, t.TempDir(), nil)
+	ix := NewIndexing(s, nil, t.TempDir(), nil, 0)
 
 	configs := []source.SourceConfig{
 		{
@@ -444,7 +444,7 @@ func TestIndexDocuments_TrustTierFromConfig(t *testing.T) {
 	}
 	docs := buildDocs("web-untrusted", "untrusted-doc", "Untrusted Doc", cleanContent)
 
-	indexResult, _ := vault.IndexDocuments(ix.store, docs, configs, ix.embedder)
+	indexResult, _ := vault.IndexDocuments(ix.store, docs, configs, ix.embedder, 0)
 	if indexResult.TotalIndexed != 1 {
 		t.Fatalf("totalIndexed = %d, want 1", indexResult.TotalIndexed)
 	}

--- a/tools/indexing_test.go
+++ b/tools/indexing_test.go
@@ -16,7 +16,7 @@ import (
 // TestIndexing_Index_NilStore verifies that calling Index with a nil store
 // returns an error result mentioning persistent storage (FR-008).
 func TestIndexing_Index_NilStore(t *testing.T) {
-	ix := NewIndexing(nil, nil, t.TempDir(), nil)
+	ix := NewIndexing(nil, nil, t.TempDir(), nil, 0)
 
 	result, _, err := ix.Index(context.Background(), nil, types.IndexInput{})
 	if err != nil {
@@ -38,7 +38,7 @@ func TestIndexing_Index_NilStore(t *testing.T) {
 // TestIndexing_Reindex_NilStore verifies that calling Reindex with a nil store
 // returns an error result mentioning persistent storage (FR-008).
 func TestIndexing_Reindex_NilStore(t *testing.T) {
-	ix := NewIndexing(nil, nil, t.TempDir(), nil)
+	ix := NewIndexing(nil, nil, t.TempDir(), nil, 0)
 
 	result, _, err := ix.Reindex(context.Background(), nil, types.ReindexInput{})
 	if err != nil {
@@ -71,7 +71,7 @@ func TestIndexing_Index_NoSources(t *testing.T) {
 		t.Fatalf("MkdirAll: %v", err)
 	}
 
-	ix := NewIndexing(s, nil, tmpDir, nil)
+	ix := NewIndexing(s, nil, tmpDir, nil, 0)
 
 	result, _, err := ix.Index(context.Background(), nil, types.IndexInput{})
 	if err != nil {
@@ -96,7 +96,7 @@ func TestIndexing_Index_NoSources(t *testing.T) {
 // operation.
 func TestIndexing_Index_ConcurrentCallRejected(t *testing.T) {
 	s := newTestStore(t)
-	ix := NewIndexing(s, nil, t.TempDir(), nil)
+	ix := NewIndexing(s, nil, t.TempDir(), nil, 0)
 
 	// Simulate an in-progress operation by locking the mutex.
 	ix.mu.Lock()
@@ -124,7 +124,7 @@ func TestIndexing_Index_ConcurrentCallRejected(t *testing.T) {
 // error result (FR-005). The mutex is shared between Index and Reindex.
 func TestIndexing_Reindex_ConcurrentCallRejected(t *testing.T) {
 	s := newTestStore(t)
-	ix := NewIndexing(s, nil, t.TempDir(), nil)
+	ix := NewIndexing(s, nil, t.TempDir(), nil, 0)
 
 	// Simulate an in-progress operation by locking the mutex.
 	ix.mu.Lock()
@@ -220,7 +220,7 @@ func TestIndexing_Reindex_PreservesProtectedSources(t *testing.T) {
 		t.Fatalf("InsertSource(github-org): %v", err)
 	}
 
-	ix := NewIndexing(s, nil, tmpDir, nil)
+	ix := NewIndexing(s, nil, tmpDir, nil, 0)
 
 	result, _, err := ix.Reindex(context.Background(), nil, types.ReindexInput{})
 	if err != nil {
@@ -280,7 +280,7 @@ func TestIndexing_Reindex_PreservesProtectedSources(t *testing.T) {
 // between Index and Reindex — locking via one blocks the other (FR-005).
 func TestIndexing_Index_CrossMutexRejection(t *testing.T) {
 	s := newTestStore(t)
-	ix := NewIndexing(s, nil, t.TempDir(), nil)
+	ix := NewIndexing(s, nil, t.TempDir(), nil, 0)
 
 	// Lock the mutex as if Reindex is running.
 	ix.mu.Lock()
@@ -325,7 +325,7 @@ func TestIndexing_ExternalMutex_SharedLock(t *testing.T) {
 	mu.Lock()
 
 	// Pass the locked external mutex to NewIndexing.
-	ix := NewIndexing(s, nil, tmpDir, mu)
+	ix := NewIndexing(s, nil, tmpDir, mu, 0)
 
 	// Call Index() — should return "already in progress" because the
 	// external mutex is locked.
@@ -373,7 +373,7 @@ func TestIndexing_ExternalMutex_NilFallback(t *testing.T) {
 	s := newTestStore(t)
 
 	// Pass nil mutex — NewIndexing should create an internal one.
-	ix := NewIndexing(s, nil, t.TempDir(), nil)
+	ix := NewIndexing(s, nil, t.TempDir(), nil, 0)
 
 	// Verify the internal mutex works by locking it and checking rejection.
 	// PARALLEL SAFETY: We access ix.mu directly because this is a package-

--- a/tools/learning.go
+++ b/tools/learning.go
@@ -58,19 +58,23 @@ var tagNormalizer = regexp.MustCompile(`[^a-z0-9-]`)
 // The vaultPath field is the vault root directory (not the .uf/dewey/
 // workspace). Markdown files are written to {vaultPath}/.uf/dewey/learnings/.
 type Learning struct {
-	embedder  embed.Embedder
-	store     *store.Store
-	vaultPath string
+	embedder      embed.Embedder
+	store         *store.Store
+	vaultPath     string
+	maxChunkChars int // max chars per embedding chunk; 0 uses embed.DefaultMaxChunkChars
 }
 
 // NewLearning creates a new Learning tool handler with the given embedder,
-// store, and vault root path. The embedder may be nil — the tool stores
-// learnings without embeddings when unavailable (graceful degradation).
-// The store must be non-nil for the tool to function; a clear error is
-// returned at call time if it is nil. The vaultPath is the vault root
-// directory; markdown files are written to {vaultPath}/.uf/dewey/learnings/.
-func NewLearning(e embed.Embedder, s *store.Store, vaultPath string) *Learning {
-	return &Learning{embedder: e, store: s, vaultPath: vaultPath}
+// store, vault root path, and max chunk chars. The embedder may be nil —
+// the tool stores learnings without embeddings when unavailable (graceful
+// degradation). The store must be non-nil for the tool to function; a
+// clear error is returned at call time if it is nil. The vaultPath is the
+// vault root directory; markdown files are written to
+// {vaultPath}/.uf/dewey/learnings/. The maxChunkChars parameter controls
+// the maximum character length per embedding chunk; pass 0 to use
+// embed.DefaultMaxChunkChars.
+func NewLearning(e embed.Embedder, s *store.Store, vaultPath string, maxChunkChars int) *Learning {
+	return &Learning{embedder: e, store: s, vaultPath: vaultPath, maxChunkChars: maxChunkChars}
 }
 
 // normalizeTag lowercases, trims whitespace, replaces spaces with hyphens,
@@ -292,7 +296,11 @@ func (l *Learning) StoreLearning(ctx context.Context, req *mcp.CallToolRequest, 
 	// Ollama is unavailable, remaining searchable via keyword search.
 	var embeddingMsg string
 	if l.embedder != nil && l.embedder.Available() {
-		vault.GenerateEmbeddings(l.store, l.embedder, pageName, blocks, nil)
+		maxChars := l.maxChunkChars
+		if maxChars <= 0 {
+			maxChars = embed.DefaultMaxChunkChars
+		}
+		vault.GenerateEmbeddings(l.store, l.embedder, pageName, blocks, nil, maxChars)
 	} else {
 		embeddingMsg = " Note: Embeddings were not generated (Ollama unavailable). The learning is stored and searchable via keyword search. Semantic search will be available after embeddings are generated."
 	}

--- a/tools/learning_test.go
+++ b/tools/learning_test.go
@@ -183,7 +183,7 @@ func TestResolveAuthor(t *testing.T) {
 func TestStoreLearning_Basic(t *testing.T) {
 	t.Setenv("DEWEY_AUTHOR", "testuser")
 	s := newTestStore(t)
-	l := NewLearning(nil, s, "")
+	l := NewLearning(nil, s, "", 0)
 
 	result, _, err := l.StoreLearning(context.Background(), nil, types.StoreLearningInput{
 		Information: "The vault walker must build its ignore matcher in New()",
@@ -252,7 +252,7 @@ func TestStoreLearning_Basic(t *testing.T) {
 // string returns an error result mentioning "information".
 func TestStoreLearning_EmptyInformation(t *testing.T) {
 	s := newTestStore(t)
-	l := NewLearning(nil, s, "")
+	l := NewLearning(nil, s, "", 0)
 
 	result, _, err := l.StoreLearning(context.Background(), nil, types.StoreLearningInput{
 		Information: "",
@@ -273,7 +273,7 @@ func TestStoreLearning_EmptyInformation(t *testing.T) {
 // TestStoreLearning_NilStore verifies that a nil store returns an error
 // result mentioning persistent storage.
 func TestStoreLearning_NilStore(t *testing.T) {
-	l := NewLearning(nil, nil, "")
+	l := NewLearning(nil, nil, "", 0)
 
 	result, _, err := l.StoreLearning(context.Background(), nil, types.StoreLearningInput{
 		Information: "test learning",
@@ -296,7 +296,7 @@ func TestStoreLearning_NilStore(t *testing.T) {
 func TestStoreLearning_WithTag(t *testing.T) {
 	t.Setenv("DEWEY_AUTHOR", "testuser")
 	s := newTestStore(t)
-	l := NewLearning(nil, s, "")
+	l := NewLearning(nil, s, "", 0)
 
 	result, _, err := l.StoreLearning(context.Background(), nil, types.StoreLearningInput{
 		Information: "OAuth tokens should be rotated every 24 hours",
@@ -367,7 +367,7 @@ func TestStoreLearning_WithTag(t *testing.T) {
 func TestStoreLearning_EmptyTag(t *testing.T) {
 	t.Setenv("DEWEY_AUTHOR", "testuser")
 	s := newTestStore(t)
-	l := NewLearning(nil, s, "")
+	l := NewLearning(nil, s, "", 0)
 
 	result, _, err := l.StoreLearning(context.Background(), nil, types.StoreLearningInput{
 		Information: "a learning without any tag",
@@ -403,7 +403,7 @@ func TestStoreLearning_EmptyTag(t *testing.T) {
 func TestStoreLearning_BackwardCompat(t *testing.T) {
 	t.Setenv("DEWEY_AUTHOR", "testuser")
 	s := newTestStore(t)
-	l := NewLearning(nil, s, "")
+	l := NewLearning(nil, s, "", 0)
 
 	result, _, err := l.StoreLearning(context.Background(), nil, types.StoreLearningInput{
 		Information: "test learning with old tags field",
@@ -457,7 +457,7 @@ func TestStoreLearning_BackwardCompat(t *testing.T) {
 // are provided, Tag takes priority.
 func TestStoreLearning_TagPriorityOverTags(t *testing.T) {
 	s := newTestStore(t)
-	l := NewLearning(nil, s, "")
+	l := NewLearning(nil, s, "", 0)
 
 	result, _, err := l.StoreLearning(context.Background(), nil, types.StoreLearningInput{
 		Information: "test learning with both fields",
@@ -484,7 +484,7 @@ func TestStoreLearning_TagPriorityOverTags(t *testing.T) {
 // correctly on the page and returned in the response.
 func TestStoreLearning_WithCategory(t *testing.T) {
 	s := newTestStore(t)
-	l := NewLearning(nil, s, "")
+	l := NewLearning(nil, s, "", 0)
 
 	result, _, err := l.StoreLearning(context.Background(), nil, types.StoreLearningInput{
 		Information: "Always rotate OAuth tokens after 24 hours",
@@ -533,7 +533,7 @@ func TestStoreLearning_WithCategory(t *testing.T) {
 // returns an MCP error result with a descriptive message.
 func TestStoreLearning_InvalidCategory(t *testing.T) {
 	s := newTestStore(t)
-	l := NewLearning(nil, s, "")
+	l := NewLearning(nil, s, "", 0)
 
 	result, _, err := l.StoreLearning(context.Background(), nil, types.StoreLearningInput{
 		Information: "test learning",
@@ -560,7 +560,7 @@ func TestStoreLearning_InvalidCategory(t *testing.T) {
 // allowed and stored as an empty string.
 func TestStoreLearning_EmptyCategory(t *testing.T) {
 	s := newTestStore(t)
-	l := NewLearning(nil, s, "")
+	l := NewLearning(nil, s, "", 0)
 
 	result, _, err := l.StoreLearning(context.Background(), nil, types.StoreLearningInput{
 		Information: "test learning without category",
@@ -591,7 +591,7 @@ func TestStoreLearning_AllValidCategories(t *testing.T) {
 	for _, cat := range categories {
 		t.Run(cat, func(t *testing.T) {
 			s := newTestStore(t)
-			l := NewLearning(nil, s, "")
+			l := NewLearning(nil, s, "", 0)
 
 			result, _, err := l.StoreLearning(context.Background(), nil, types.StoreLearningInput{
 				Information: "test learning for " + cat,
@@ -622,7 +622,7 @@ func TestStoreLearning_SequenceIncrement(t *testing.T) {
 	t.Setenv("DEWEY_AUTHOR", "testuser")
 	s := newTestStore(t)
 	vaultPath := t.TempDir()
-	l := NewLearning(nil, s, vaultPath)
+	l := NewLearning(nil, s, vaultPath, 0)
 
 	deployPattern := regexp.MustCompile(`^deployment-\d{8}T\d{6}-testuser(-\d+)?$`)
 	identities := make(map[string]bool)
@@ -690,7 +690,7 @@ func TestStoreLearning_TagNormalization(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			s := newTestStore(t)
-			l := NewLearning(nil, s, "")
+			l := NewLearning(nil, s, "", 0)
 
 			result, _, err := l.StoreLearning(context.Background(), nil, types.StoreLearningInput{
 				Information: "test learning",
@@ -716,7 +716,7 @@ func TestStoreLearning_TagNormalization(t *testing.T) {
 // tier "draft" regardless of input.
 func TestStoreLearning_TierDraft(t *testing.T) {
 	s := newTestStore(t)
-	l := NewLearning(nil, s, "")
+	l := NewLearning(nil, s, "", 0)
 
 	result, _, err := l.StoreLearning(context.Background(), nil, types.StoreLearningInput{
 		Information: "test learning for tier check",
@@ -748,7 +748,7 @@ func TestStoreLearning_TierDraft(t *testing.T) {
 // a non-empty created_at field in ISO 8601 format.
 func TestStoreLearning_CreatedAtInResponse(t *testing.T) {
 	s := newTestStore(t)
-	l := NewLearning(nil, s, "")
+	l := NewLearning(nil, s, "", 0)
 
 	result, _, err := l.StoreLearning(context.Background(), nil, types.StoreLearningInput{
 		Information: "test learning for created_at",
@@ -779,7 +779,7 @@ func TestStoreLearning_CreatedAtInResponse(t *testing.T) {
 func TestStoreLearning_EmbedderUnavailable(t *testing.T) {
 	s := newTestStore(t)
 	e := newMockEmbedder(false) // Available() returns false
-	l := NewLearning(e, s, "")
+	l := NewLearning(e, s, "", 0)
 
 	result, _, err := l.StoreLearning(context.Background(), nil, types.StoreLearningInput{
 		Information: "learning with unavailable embedder",
@@ -806,7 +806,7 @@ func TestStoreLearning_EmbedderUnavailable(t *testing.T) {
 // embeddings not being generated.
 func TestStoreLearning_NilEmbedder(t *testing.T) {
 	s := newTestStore(t)
-	l := NewLearning(nil, s, "") // nil embedder
+	l := NewLearning(nil, s, "", 0) // nil embedder
 
 	result, _, err := l.StoreLearning(context.Background(), nil, types.StoreLearningInput{
 		Information: "learning with nil embedder",
@@ -833,7 +833,7 @@ func TestStoreLearning_NilEmbedder(t *testing.T) {
 // set to "learning".
 func TestStoreLearning_Searchable(t *testing.T) {
 	s := newTestStore(t)
-	l := NewLearning(nil, s, "")
+	l := NewLearning(nil, s, "", 0)
 
 	result, _, err := l.StoreLearning(context.Background(), nil, types.StoreLearningInput{
 		Information: "searchable learning content",
@@ -886,7 +886,7 @@ func TestStoreLearning_Searchable(t *testing.T) {
 // from other content sources.
 func TestStoreLearning_FilterBySourceType(t *testing.T) {
 	s := newTestStore(t)
-	l := NewLearning(nil, s, "")
+	l := NewLearning(nil, s, "", 0)
 
 	// Store a learning.
 	result, _, err := l.StoreLearning(context.Background(), nil, types.StoreLearningInput{
@@ -946,7 +946,7 @@ func TestStoreLearning_DifferentTagSequences(t *testing.T) {
 	t.Setenv("DEWEY_AUTHOR", "testuser")
 	s := newTestStore(t)
 	vaultPath := t.TempDir()
-	l := NewLearning(nil, s, vaultPath)
+	l := NewLearning(nil, s, vaultPath, 0)
 
 	authPattern := regexp.MustCompile(`^auth-\d{8}T\d{6}-testuser(-\d+)?$`)
 	deployPattern := regexp.MustCompile(`^deploy-\d{8}T\d{6}-testuser(-\d+)?$`)
@@ -1027,7 +1027,7 @@ func TestStoreLearning_DualWritesMarkdown(t *testing.T) {
 	t.Setenv("DEWEY_AUTHOR", "testuser")
 	s := newTestStore(t)
 	vaultPath := t.TempDir()
-	l := NewLearning(nil, s, vaultPath)
+	l := NewLearning(nil, s, vaultPath, 0)
 
 	result, _, err := l.StoreLearning(context.Background(), nil, types.StoreLearningInput{
 		Information: "OAuth tokens should be rotated every 24 hours",
@@ -1076,7 +1076,7 @@ func TestStoreLearning_MarkdownFormat(t *testing.T) {
 	t.Setenv("DEWEY_AUTHOR", "testuser")
 	s := newTestStore(t)
 	vaultPath := t.TempDir()
-	l := NewLearning(nil, s, vaultPath)
+	l := NewLearning(nil, s, vaultPath, 0)
 
 	info := "Always use parameterized queries for SQL"
 	result, _, err := l.StoreLearning(context.Background(), nil, types.StoreLearningInput{
@@ -1135,7 +1135,7 @@ func TestStoreLearning_MarkdownFormatNoCategory(t *testing.T) {
 	t.Setenv("DEWEY_AUTHOR", "testuser")
 	s := newTestStore(t)
 	vaultPath := t.TempDir()
-	l := NewLearning(nil, s, vaultPath)
+	l := NewLearning(nil, s, vaultPath, 0)
 
 	result, _, err := l.StoreLearning(context.Background(), nil, types.StoreLearningInput{
 		Information: "A learning without a category",
@@ -1186,7 +1186,7 @@ func TestStoreLearning_FileWriteFailure(t *testing.T) {
 		_ = os.Chmod(learningsDir, 0o755)
 	})
 
-	l := NewLearning(nil, s, vaultPath)
+	l := NewLearning(nil, s, vaultPath, 0)
 
 	result, _, err := l.StoreLearning(context.Background(), nil, types.StoreLearningInput{
 		Information: "This learning should still be stored in SQLite",
@@ -1228,7 +1228,7 @@ func TestStoreLearning_FileWriteFailure(t *testing.T) {
 func TestStoreLearning_NoVaultPath(t *testing.T) {
 	t.Setenv("DEWEY_AUTHOR", "testuser")
 	s := newTestStore(t)
-	l := NewLearning(nil, s, "")
+	l := NewLearning(nil, s, "", 0)
 
 	result, _, err := l.StoreLearning(context.Background(), nil, types.StoreLearningInput{
 		Information: "Learning without vault path",

--- a/tools/lint.go
+++ b/tools/lint.go
@@ -51,18 +51,22 @@ type Finding struct {
 // while still providing value from the other 3 checks. The vaultPath is
 // optional — when empty, knowledge store quality checks are skipped.
 type Lint struct {
-	store     *store.Store
-	embedder  embed.Embedder
-	vaultPath string
+	store         *store.Store
+	embedder      embed.Embedder
+	vaultPath     string
+	maxChunkChars int // max chars per embedding chunk; 0 uses embed.DefaultMaxChunkChars
 }
 
 // NewLint creates a new Lint tool handler with the given store, embedder,
-// and vault path. The store must be non-nil for the tool to function; a
-// clear error is returned at call time if it is nil (invariant 7). The
-// embedder may be nil — contradiction checking is skipped when unavailable.
-// The vaultPath may be empty — knowledge store quality checks are skipped.
-func NewLint(s *store.Store, e embed.Embedder, vaultPath string) *Lint {
-	return &Lint{store: s, embedder: e, vaultPath: vaultPath}
+// vault path, and max chunk chars. The store must be non-nil for the tool
+// to function; a clear error is returned at call time if it is nil
+// (invariant 7). The embedder may be nil — contradiction checking is
+// skipped when unavailable. The vaultPath may be empty — knowledge store
+// quality checks are skipped. The maxChunkChars parameter controls the
+// maximum character length per embedding chunk; pass 0 to use
+// embed.DefaultMaxChunkChars.
+func NewLint(s *store.Store, e embed.Embedder, vaultPath string, maxChunkChars int) *Lint {
+	return &Lint{store: s, embedder: e, vaultPath: vaultPath, maxChunkChars: maxChunkChars}
 }
 
 // Lint handles the dewey_lint MCP tool. Scans the index for knowledge
@@ -443,7 +447,11 @@ func (l *Lint) fixEmbeddingGaps(ctx context.Context, gaps []Finding) (int, error
 			})
 		}
 
-		count := vault.GenerateEmbeddings(l.store, l.embedder, pageName, blockEntities, nil)
+		maxChars := l.maxChunkChars
+		if maxChars <= 0 {
+			maxChars = embed.DefaultMaxChunkChars
+		}
+		count := vault.GenerateEmbeddings(l.store, l.embedder, pageName, blockEntities, nil, maxChars)
 		if count > 0 {
 			fixed++
 			lintLogger.Info("regenerated embeddings", "page", pageName, "embeddings", count)

--- a/tools/lint_test.go
+++ b/tools/lint_test.go
@@ -76,7 +76,7 @@ func storeLearningForLint(t *testing.T, s *store.Store, tag string, seq int, cat
 // TestLint_NilStore verifies that a nil store returns an error result
 // mentioning persistent storage.
 func TestLint_NilStore(t *testing.T) {
-	lint := NewLint(nil, nil, "")
+	lint := NewLint(nil, nil, "", 0)
 
 	result, _, err := lint.Lint(context.Background(), nil, types.LintInput{})
 	if err != nil {
@@ -95,7 +95,7 @@ func TestLint_NilStore(t *testing.T) {
 // clean report with all zero counts.
 func TestLint_NoLearnings(t *testing.T) {
 	s := newTestStore(t)
-	lint := NewLint(s, nil, "")
+	lint := NewLint(s, nil, "", 0)
 
 	result, _, err := lint.Lint(context.Background(), nil, types.LintInput{})
 	if err != nil {
@@ -136,7 +136,7 @@ func TestLint_NoLearnings(t *testing.T) {
 // 30 days is reported as stale.
 func TestLint_StaleDecision(t *testing.T) {
 	s := newTestStore(t)
-	lint := NewLint(s, nil, "")
+	lint := NewLint(s, nil, "", 0)
 
 	// Store a decision learning backdated 45 days.
 	staleDate := time.Now().Add(-45 * 24 * time.Hour)
@@ -206,7 +206,7 @@ func TestLint_StaleDecision(t *testing.T) {
 // decision is not reported as stale even if it's old.
 func TestLint_StaleDecision_ValidatedSkipped(t *testing.T) {
 	s := newTestStore(t)
-	lint := NewLint(s, nil, "")
+	lint := NewLint(s, nil, "", 0)
 
 	// Store a decision learning backdated 45 days.
 	staleDate := time.Now().Add(-45 * 24 * time.Hour)
@@ -238,7 +238,7 @@ func TestLint_StaleDecision_ValidatedSkipped(t *testing.T) {
 // any compiled article are reported as uncompiled.
 func TestLint_UncompiledLearnings(t *testing.T) {
 	s := newTestStore(t)
-	lint := NewLint(s, nil, "")
+	lint := NewLint(s, nil, "", 0)
 
 	now := time.Now()
 	storeLearningForLint(t, s, "auth", 1, "decision", "Auth content 1", now)
@@ -311,7 +311,7 @@ func TestLint_UncompiledLearnings(t *testing.T) {
 // are reported as embedding gaps.
 func TestLint_EmbeddingGaps(t *testing.T) {
 	s := newTestStore(t)
-	lint := NewLint(s, nil, "")
+	lint := NewLint(s, nil, "", 0)
 
 	// Insert a page with blocks but no embeddings.
 	page := &store.Page{
@@ -374,7 +374,7 @@ func TestLint_EmbeddingGaps(t *testing.T) {
 func TestLint_FixEmbeddingGaps(t *testing.T) {
 	s := newTestStore(t)
 	e := newMockEmbedder(true)
-	lint := NewLint(s, e, "")
+	lint := NewLint(s, e, "", 0)
 
 	// Insert a page with a block but no embeddings.
 	page := &store.Page{
@@ -440,7 +440,7 @@ func TestLint_FixEmbeddingGaps(t *testing.T) {
 func TestLint_Contradictions(t *testing.T) {
 	s := newTestStore(t)
 	e := newMockEmbedder(true)
-	lint := NewLint(s, e, "")
+	lint := NewLint(s, e, "", 0)
 
 	now := time.Now()
 	storeLearningForLint(t, s, "auth", 1, "decision", "Use basic auth", now)
@@ -496,7 +496,7 @@ func TestLint_Contradictions(t *testing.T) {
 // check is skipped when no embedder is available (invariant 6).
 func TestLint_NoContradictionsWithoutEmbedder(t *testing.T) {
 	s := newTestStore(t)
-	lint := NewLint(s, nil, "") // nil embedder
+	lint := NewLint(s, nil, "", 0) // nil embedder
 
 	now := time.Now()
 	storeLearningForLint(t, s, "auth", 1, "decision", "Use basic auth", now)
@@ -521,7 +521,7 @@ func TestLint_NoContradictionsWithoutEmbedder(t *testing.T) {
 func TestLint_NoContradictionsWithUnavailableEmbedder(t *testing.T) {
 	s := newTestStore(t)
 	e := newMockEmbedder(false) // Available() returns false
-	lint := NewLint(s, e, "")
+	lint := NewLint(s, e, "", 0)
 
 	now := time.Now()
 	storeLearningForLint(t, s, "auth", 1, "decision", "Use basic auth", now)
@@ -544,7 +544,7 @@ func TestLint_NoContradictionsWithUnavailableEmbedder(t *testing.T) {
 // does not crash and reports zero fixed.
 func TestLint_FixWithoutEmbedder(t *testing.T) {
 	s := newTestStore(t)
-	lint := NewLint(s, nil, "") // nil embedder
+	lint := NewLint(s, nil, "", 0) // nil embedder
 
 	// Insert a page with a block but no embeddings.
 	page := &store.Page{
@@ -597,7 +597,7 @@ func TestLint_FixWithoutEmbedder(t *testing.T) {
 func TestLint_NoFixWithoutFlag(t *testing.T) {
 	s := newTestStore(t)
 	e := newMockEmbedder(true)
-	lint := NewLint(s, e, "")
+	lint := NewLint(s, e, "", 0)
 
 	// Insert a page with a block but no embeddings.
 	page := &store.Page{
@@ -655,7 +655,7 @@ func TestLint_NoFixWithoutFlag(t *testing.T) {
 func TestLint_AllChecksClean(t *testing.T) {
 	s := newTestStore(t)
 	e := newMockEmbedder(true)
-	lint := NewLint(s, e, "")
+	lint := NewLint(s, e, "", 0)
 
 	// Store a fresh, non-decision learning — should not trigger any check.
 	now := time.Now()
@@ -795,7 +795,7 @@ func TestLint_KnowledgeStoreMetrics(t *testing.T) {
 	writeKnowledgeFile(t, storePath, "security", 1, "low", []string{"missing_rationale"})
 	writeKnowledgeFile(t, storePath, "infra", 1, "flagged", []string{"implied_assumption", "unsupported_claim"})
 
-	lint := NewLint(s, nil, vaultDir)
+	lint := NewLint(s, nil, vaultDir, 0)
 
 	result, _, err := lint.Lint(context.Background(), nil, types.LintInput{})
 	if err != nil {
@@ -936,7 +936,7 @@ func TestLint_StaleStore(t *testing.T) {
 		t.Fatalf("InsertPage: %v", err)
 	}
 
-	lint := NewLint(s, nil, vaultDir)
+	lint := NewLint(s, nil, vaultDir, 0)
 
 	result, _, err := lint.Lint(context.Background(), nil, types.LintInput{})
 	if err != nil {
@@ -1016,7 +1016,7 @@ func TestLint_StaleStore_NeverCurated(t *testing.T) {
 		t.Fatalf("InsertPage: %v", err)
 	}
 
-	lint := NewLint(s, nil, vaultDir)
+	lint := NewLint(s, nil, vaultDir, 0)
 
 	result, _, err := lint.Lint(context.Background(), nil, types.LintInput{})
 	if err != nil {
@@ -1066,7 +1066,7 @@ func TestLint_NoKnowledgeStores(t *testing.T) {
 		t.Fatalf("create dewey dir: %v", err)
 	}
 
-	lint := NewLint(s, nil, vaultDir)
+	lint := NewLint(s, nil, vaultDir, 0)
 
 	result, _, err := lint.Lint(context.Background(), nil, types.LintInput{})
 	if err != nil {
@@ -1092,7 +1092,7 @@ func TestLint_NoKnowledgeStores(t *testing.T) {
 // store checks when vaultPath is empty.
 func TestLint_KnowledgeStoreEmptyVaultPath(t *testing.T) {
 	s := newTestStore(t)
-	lint := NewLint(s, nil, "") // empty vaultPath
+	lint := NewLint(s, nil, "", 0) // empty vaultPath
 
 	result, _, err := lint.Lint(context.Background(), nil, types.LintInput{})
 	if err != nil {
@@ -1138,7 +1138,7 @@ func TestAutoIndex_KnowledgeStoreRegistered(t *testing.T) {
 	writeKnowledgeFile(t, storePath, "deploy", 1, "medium", []string{"missing_rationale"})
 
 	// Create a Curate tool and run auto-indexing.
-	curateTool := NewCurate(s, nil, nil, vaultDir, nil)
+	curateTool := NewCurate(s, nil, nil, vaultDir, nil, 0)
 	cfg := curate.StoreConfig{
 		Name:    "test-store",
 		Sources: []string{"disk-local"},
@@ -1220,7 +1220,7 @@ func TestAutoIndex_IdempotentReindex(t *testing.T) {
 		Path:    storePath,
 	}
 
-	curateTool := NewCurate(s, nil, nil, vaultDir, nil)
+	curateTool := NewCurate(s, nil, nil, vaultDir, nil, 0)
 
 	// First indexing.
 	indexed1 := curateTool.autoIndexKnowledgeStore(cfg)
@@ -1265,7 +1265,7 @@ func TestAutoIndex_UpdatedContentReindexed(t *testing.T) {
 		Path:    storePath,
 	}
 
-	curateTool := NewCurate(s, nil, nil, vaultDir, nil)
+	curateTool := NewCurate(s, nil, nil, vaultDir, nil, 0)
 
 	// First indexing.
 	indexed1 := curateTool.autoIndexKnowledgeStore(cfg)
@@ -1312,7 +1312,7 @@ func TestAutoIndex_CuratedTier(t *testing.T) {
 		Path:    storePath,
 	}
 
-	curateTool := NewCurate(s, nil, nil, vaultDir, nil)
+	curateTool := NewCurate(s, nil, nil, vaultDir, nil, 0)
 	curateTool.autoIndexKnowledgeStore(cfg)
 
 	// Verify the page has tier "curated".

--- a/vault/index_documents.go
+++ b/vault/index_documents.go
@@ -42,7 +42,10 @@ type IndexResult struct {
 //
 // This is the shared implementation used by both the CLI (dewey index/reindex)
 // and MCP reindex tool, eliminating duplication (D6).
-func IndexDocuments(s *store.Store, allDocs map[string][]source.Document, configs []source.SourceConfig, embedder embed.Embedder) (*IndexResult, error) {
+func IndexDocuments(s *store.Store, allDocs map[string][]source.Document, configs []source.SourceConfig, embedder embed.Embedder, maxChunkChars int) (*IndexResult, error) {
+	if maxChunkChars <= 0 {
+		maxChunkChars = embed.DefaultMaxChunkChars
+	}
 	if len(allDocs) == 0 {
 		return &IndexResult{}, nil
 	}
@@ -62,7 +65,7 @@ func IndexDocuments(s *store.Store, allDocs map[string][]source.Document, config
 			default:
 			}
 
-			indexed, embeds, err := indexSourceDocuments(s, sourceID, docs, configs, embedder)
+			indexed, embeds, err := indexSourceDocuments(s, sourceID, docs, configs, embedder, maxChunkChars)
 			if err != nil {
 				return fmt.Errorf("index source %s: %w", sourceID, err)
 			}
@@ -92,7 +95,7 @@ func IndexDocuments(s *store.Store, allDocs map[string][]source.Document, config
 
 // indexSourceDocuments processes all documents from a single source sequentially.
 // Returns the number of documents indexed and embeddings generated.
-func indexSourceDocuments(s *store.Store, sourceID string, docs []source.Document, configs []source.SourceConfig, embedder embed.Embedder) (int, int, error) {
+func indexSourceDocuments(s *store.Store, sourceID string, docs []source.Document, configs []source.SourceConfig, embedder embed.Embedder, maxChunkChars int) (int, int, error) {
 	start := time.Now()
 	var blockCount, linkCount, embedCount, indexed int
 
@@ -241,7 +244,7 @@ func indexSourceDocuments(s *store.Store, sourceID string, docs []source.Documen
 
 		// Generate and persist embeddings if embedder is available.
 		if embedder != nil && embedder.Available() {
-			ec := GenerateEmbeddings(s, embedder, pageName, blocks, nil)
+			ec := GenerateEmbeddings(s, embedder, pageName, blocks, nil, maxChunkChars)
 			embedCount += ec
 		}
 

--- a/vault/index_documents_test.go
+++ b/vault/index_documents_test.go
@@ -55,7 +55,7 @@ func TestIndexDocuments_TotalCountAccurate(t *testing.T) {
 		allDocs[id] = docs
 	}
 
-	result, err := IndexDocuments(s, allDocs, nil, nil)
+	result, err := IndexDocuments(s, allDocs, nil, nil, 0)
 	if err != nil {
 		t.Fatalf("IndexDocuments: %v", err)
 	}
@@ -73,7 +73,7 @@ func TestIndexDocuments_EmptyInput(t *testing.T) {
 	}
 	defer func() { _ = s.Close() }()
 
-	result, err := IndexDocuments(s, map[string][]source.Document{}, nil, nil)
+	result, err := IndexDocuments(s, map[string][]source.Document{}, nil, nil, 0)
 	if err != nil {
 		t.Fatalf("IndexDocuments: %v", err)
 	}
@@ -94,7 +94,7 @@ func TestIndexDocuments_AllSourcesProcessed(t *testing.T) {
 	allDocs := makeSourceDocs(4, 2)
 
 	// Track that multiple sources are processed (they all complete).
-	result, err := IndexDocuments(s, allDocs, nil, nil)
+	result, err := IndexDocuments(s, allDocs, nil, nil, 0)
 	if err != nil {
 		t.Fatalf("IndexDocuments: %v", err)
 	}
@@ -126,7 +126,7 @@ func TestIndexDocuments_WithEmbeddings(t *testing.T) {
 
 	allDocs := makeSourceDocs(2, 3)
 
-	result, err := IndexDocuments(s, allDocs, nil, e)
+	result, err := IndexDocuments(s, allDocs, nil, e, 0)
 	if err != nil {
 		t.Fatalf("IndexDocuments: %v", err)
 	}
@@ -162,7 +162,7 @@ func TestIndexDocuments_SourceRecordCreated(t *testing.T) {
 		},
 	}
 
-	_, err = IndexDocuments(s, allDocs, configs, nil)
+	_, err = IndexDocuments(s, allDocs, configs, nil, 0)
 	if err != nil {
 		t.Fatalf("IndexDocuments: %v", err)
 	}
@@ -219,7 +219,7 @@ func TestIndexDocuments_PersistenceErrorReturnsError(t *testing.T) {
 		},
 	}
 
-	result, indexErr := IndexDocuments(s, allDocs, nil, nil)
+	result, indexErr := IndexDocuments(s, allDocs, nil, nil, 0)
 
 	// The collision source should cause a persistence error. With concurrent
 	// execution, the error may come from either source depending on scheduling.

--- a/vault/parse_export.go
+++ b/vault/parse_export.go
@@ -112,7 +112,7 @@ func ExtractHeadingFromContent(content string) string {
 }
 
 // embeddingBatchSize is the number of chunks to batch per EmbedBatch() call.
-// Balances memory usage (32 * ~768 chars max per chunk) against HTTP round-trip
+// Balances memory usage (32 chunks * up to maxChunkChars each) against HTTP round-trip
 // reduction. Ollama's /api/embed endpoint accepts arrays natively (D1).
 const embeddingBatchSize = 32
 
@@ -135,12 +135,16 @@ type blockChunk struct {
 // EmbedBatch() with a batch size of 32 (D1). On batch failure, falls back
 // to individual Embed() calls with existing truncation retry logic.
 //
+// The maxChunkChars parameter controls the maximum character length per
+// embedding chunk. Use embed.DefaultMaxChunkChars when no config-derived
+// value is available.
+//
 // Returns the number of embeddings generated. Embedding failures are logged
 // but don't block indexing (graceful degradation).
-func GenerateEmbeddings(s *store.Store, embedder embed.Embedder, pageName string, blocks []types.BlockEntity, headingPath []string) int {
+func GenerateEmbeddings(s *store.Store, embedder embed.Embedder, pageName string, blocks []types.BlockEntity, headingPath []string, maxChunkChars int) int {
 	// Pass 1: Flatten block tree into chunk tuples.
 	var chunks []blockChunk
-	flattenBlocks(blocks, headingPath, pageName, &chunks)
+	flattenBlocks(blocks, headingPath, pageName, &chunks, maxChunkChars)
 
 	if len(chunks) == 0 {
 		return 0
@@ -192,7 +196,9 @@ func GenerateEmbeddings(s *store.Store, embedder embed.Embedder, pageName string
 
 // flattenBlocks recursively collects all non-empty blocks into a flat slice
 // of blockChunk tuples, preserving heading path context for each block.
-func flattenBlocks(blocks []types.BlockEntity, headingPath []string, pageName string, out *[]blockChunk) {
+// The maxChunkChars parameter is forwarded to embed.PrepareChunk to control
+// chunk truncation.
+func flattenBlocks(blocks []types.BlockEntity, headingPath []string, pageName string, out *[]blockChunk, maxChunkChars int) {
 	for _, b := range blocks {
 		if strings.TrimSpace(b.Content) == "" {
 			continue
@@ -204,7 +210,7 @@ func flattenBlocks(blocks []types.BlockEntity, headingPath []string, pageName st
 			currentPath = append(append([]string{}, headingPath...), heading)
 		}
 
-		chunk := embed.PrepareChunk(pageName, currentPath, b.Content)
+		chunk := embed.PrepareChunk(pageName, currentPath, b.Content, maxChunkChars)
 		*out = append(*out, blockChunk{
 			blockUUID:   b.UUID,
 			chunk:       chunk,
@@ -212,7 +218,7 @@ func flattenBlocks(blocks []types.BlockEntity, headingPath []string, pageName st
 		})
 
 		if len(b.Children) > 0 {
-			flattenBlocks(b.Children, currentPath, pageName, out)
+			flattenBlocks(b.Children, currentPath, pageName, out, maxChunkChars)
 		}
 	}
 }

--- a/vault/parse_export_test.go
+++ b/vault/parse_export_test.go
@@ -221,7 +221,7 @@ func TestGenerateEmbeddings_BatchReducesRoundTrips(t *testing.T) {
 		}
 	}
 
-	count := GenerateEmbeddings(s, e, "test-page", blocks, nil)
+	count := GenerateEmbeddings(s, e, "test-page", blocks, nil, embed.DefaultMaxChunkChars)
 
 	if count != 64 {
 		t.Errorf("GenerateEmbeddings returned %d, want 64", count)
@@ -253,7 +253,7 @@ func TestGenerateEmbeddings_BatchFallback(t *testing.T) {
 		}
 	}
 
-	count := GenerateEmbeddings(s, e, "test-page", blocks, nil)
+	count := GenerateEmbeddings(s, e, "test-page", blocks, nil, embed.DefaultMaxChunkChars)
 
 	if count != 5 {
 		t.Errorf("GenerateEmbeddings returned %d, want 5", count)
@@ -301,7 +301,7 @@ func TestGenerateEmbeddings_EmptyBlocksSkipped(t *testing.T) {
 		}
 	}
 
-	count := GenerateEmbeddings(s, e, "test-page", blocks, nil)
+	count := GenerateEmbeddings(s, e, "test-page", blocks, nil, embed.DefaultMaxChunkChars)
 
 	// 10 blocks, 4 empty → 6 should be embedded.
 	if count != 6 {
@@ -351,7 +351,7 @@ func TestGenerateEmbeddings_CorrectCount(t *testing.T) {
 		}
 	}
 
-	count := GenerateEmbeddings(s, e, "test-page", blocks, nil)
+	count := GenerateEmbeddings(s, e, "test-page", blocks, nil, embed.DefaultMaxChunkChars)
 
 	if count != 6 {
 		t.Errorf("GenerateEmbeddings returned %d, want 6", count)
@@ -376,7 +376,7 @@ func TestFlattenBlocks_CollectsAllNonEmpty(t *testing.T) {
 	}
 
 	var chunks []blockChunk
-	flattenBlocks(blocks, nil, "page", &chunks)
+	flattenBlocks(blocks, nil, "page", &chunks, embed.DefaultMaxChunkChars)
 
 	// r1 (Top), c1, c3, r3 = 4 non-empty. r2 and c2 are empty/whitespace.
 	if len(chunks) != 4 {

--- a/vault/vault_store.go
+++ b/vault/vault_store.go
@@ -25,10 +25,11 @@ import (
 // (SOLID Single Responsibility). The vault.Client owns in-memory indexing;
 // VaultStore owns the persistence bridge.
 type VaultStore struct {
-	store     *store.Store
-	embedder  embed.Embedder // optional — nil when Ollama is unavailable
-	vaultPath string
-	sourceID  string // e.g., "disk-local"
+	store        *store.Store
+	embedder     embed.Embedder // optional — nil when Ollama is unavailable
+	vaultPath    string
+	sourceID     string // e.g., "disk-local"
+	maxChunkChars int   // max chars per embedding chunk; 0 uses embed.DefaultMaxChunkChars
 }
 
 // NewVaultStore creates a VaultStore adapter for bridging vault and store.
@@ -46,6 +47,22 @@ func NewVaultStore(s *store.Store, vaultPath, sourceID string) *VaultStore {
 // Pass nil to disable embedding generation (graceful degradation).
 func (vs *VaultStore) SetEmbedder(e embed.Embedder) {
 	vs.embedder = e
+}
+
+// SetMaxChunkChars configures the maximum character count per embedding chunk.
+// When set to a positive value, overrides embed.DefaultMaxChunkChars for all
+// embedding generation in this vault store. Pass 0 to use the default.
+func (vs *VaultStore) SetMaxChunkChars(n int) {
+	vs.maxChunkChars = n
+}
+
+// effectiveMaxChunkChars returns the configured max chunk chars, falling back
+// to embed.DefaultMaxChunkChars when no override is set.
+func (vs *VaultStore) effectiveMaxChunkChars() int {
+	if vs.maxChunkChars > 0 {
+		return vs.maxChunkChars
+	}
+	return embed.DefaultMaxChunkChars
 }
 
 // PersistPage writes a single page and its blocks/links to the store.
@@ -447,7 +464,7 @@ func (vs *VaultStore) generateEmbeddings(pageName string, blocks []types.BlockEn
 	if vs.store == nil {
 		return
 	}
-	GenerateEmbeddings(vs.store, vs.embedder, pageName, blocks, headingPath)
+	GenerateEmbeddings(vs.store, vs.embedder, pageName, blocks, headingPath, vs.effectiveMaxChunkChars())
 }
 
 // LoadExternalPages loads all non-local pages from the persistent store into

--- a/vault/vault_store_test.go
+++ b/vault/vault_store_test.go
@@ -10,6 +10,7 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/unbound-force/dewey/v3/embed"
 	"github.com/unbound-force/dewey/v3/store"
 	"github.com/unbound-force/dewey/v3/types"
 )
@@ -1098,7 +1099,7 @@ func TestGenerateEmbeddings_RetryOnContextOverflow(t *testing.T) {
 
 	insertTestPageAndBlocks(t, s, "overflow-page", blocks)
 
-	count := GenerateEmbeddings(s, me, "overflow-page", blocks, nil)
+	count := GenerateEmbeddings(s, me, "overflow-page", blocks, nil, embed.DefaultMaxChunkChars)
 	if count != 1 {
 		t.Errorf("GenerateEmbeddings count = %d, want 1 (retry should succeed)", count)
 	}
@@ -1136,7 +1137,7 @@ func TestGenerateEmbeddings_RetryFailsBoth(t *testing.T) {
 
 	insertTestPageAndBlocks(t, s, "double-fail-page", blocks)
 
-	count := GenerateEmbeddings(s, me, "double-fail-page", blocks, nil)
+	count := GenerateEmbeddings(s, me, "double-fail-page", blocks, nil, embed.DefaultMaxChunkChars)
 	if count != 0 {
 		t.Errorf("GenerateEmbeddings count = %d, want 0 (both attempts failed)", count)
 	}


### PR DESCRIPTION
## Summary

Implements [#53](https://github.com/unbound-force/dewey/issues/53) — configurable embedding chunk limit with preparation for Granite Embedding R2 model upgrade.

### New Capability

- **Configurable chunk limit**: `DEWEY_CHUNK_MAX_CHARS` env var and `embedding.max_chunk_chars` config field control the maximum chunk character limit sent to the embedding model. Default increased from 768 to 12288 (~8192 tokens).

### Changes

- `PrepareChunk` now accepts a `maxChars int` parameter instead of using a package-level constant (eliminates global state)
- Configured chunk limit threaded through `GenerateEmbeddings` → all 11 production call sites via tool structs and server options
- `dewey doctor` displays an informational advisory when the legacy `granite-embedding:30m` model is configured
- `dewey init` template includes the new `max_chunk_chars` config option
- Defensive guard for negative/zero `maxChars` in `PrepareChunk`
- Extracted `resolveMaxChunkChars()` helper (DRY env var parsing)

### Guard Clause

Default model stays `granite-embedding:30m` — R2 is not yet on Ollama. TODO comment tracks the pending update.

### Tests

- 6 new config resolution tests (env var, config file, default, invalid, zero, negative)
- 4 new chunker boundary tests (small/large limit, exact boundary, no-truncation)
- 2 new doctor advisory tests (helper function + INFO marker)

### Documentation

- `AGENTS.md`: chunk size limit resolution precedence, config example
- `README.md`: `DEWEY_CHUNK_MAX_CHARS` in env var tables, config examples
- Website sync: unbound-force/website#166

### OpenSpec Artifacts

- `openspec/changes/upgrade-embedding-model-r2/` — proposal, design, specs, tasks